### PR TITLE
:memo: Adjust Repo Link Throughout the Documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,8 @@ body:
         **Thanks for taking the time to report an issue!**
 
         ⚠ Before submitting:
-        1. Search [existing issues](https://github.com/iqm-finland/QDMI/search?q=is%3Aissue&type=issues) to avoid duplicates
-        2. For questions or discussions, please use our [discussions forum](https://github.com/iqm-finland/QDMI/discussions)
+        1. Search [existing issues](https://github.com/iqm-finland/QDMI-on-IQM/search?q=is%3Aissue&type=issues) to avoid duplicates
+        2. For questions or discussions, please use our [discussions forum](https://github.com/iqm-finland/QDMI-on-IQM/discussions)
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -8,7 +8,7 @@ body:
         **Thanks for helping improve this project by suggesting a feature!**
 
         ⚠ Before submitting:
-        - Search [existing feature requests](https://github.com/iqm-finland/QDMI/search?q=is%3Aissue&type=issues) to avoid duplicates
+        - Search [existing feature requests](https://github.com/iqm-finland/QDMI-on-IQM/search?q=is%3Aissue&type=issues) to avoid duplicates
         - One feature per issue helps us track and implement ideas effectively
 
   - type: textarea

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,7 +11,7 @@ Security updates are applied only to the most recent releases.
 To report vulnerabilities, you can privately report a potential security issue
 via the GitHub security vulnerabilities feature. This can be done here:
 
-https://github.com/iqm-finland/QDMI/security/advisories
+https://github.com/iqm-finland/QDMI-on-IQM/security/advisories
 
 Please do **not** open a public issue about a potential security vulnerability.
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -13,7 +13,7 @@ You can save time by following this procedure when reporting a problem:
   It is much easier to identify the cause for the problem if a handful of lines suffice to show that something is not
   working.
 
-[Issues]: https://github.com/iqm-finland/QDMI/issues
-[Discussions]: https://github.com/iqm-finland/QDMI/discussions
+[Issues]: https://github.com/iqm-finland/QDMI-on-IQM/issues
+[Discussions]: https://github.com/iqm-finland/QDMI-on-IQM/discussions
 
 <!-- [DOXYGEN] -->

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Please see our [Contributing Guide](docs/contributing.md) for:
 ## Getting Help
 
 - **Documentation**: Check the [docs/](docs/) directory
-- **Discussions**: Ask questions in [GitHub Discussions](https://github.com/iqm-finland/QDMI/discussions)
-- **Bug Reports**: Open an issue in [GitHub Issues](https://github.com/iqm-finland/QDMI/issues)
+- **Discussions**: Ask questions in [GitHub Discussions](https://github.com/iqm-finland/QDMI-on-IQM/discussions)
+- **Bug Reports**: Open an issue in [GitHub Issues](https://github.com/iqm-finland/QDMI-on-IQM/issues)
 - **Security**: Report vulnerabilities via our [Security Policy](.github/SECURITY.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ unified interface.
 $ sudo apt-get install cmake g++ libcurl4-openssl-dev
 
 # Clone the repository
-$ git clone https://github.com/iqm-finland/QDMI.git
-$ cd QDMI
+$ git clone https://github.com/iqm-finland/QDMI-on-IQM.git
+$ cd QDMI-on-IQM
 
 # Build the library
 $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,22 +2,22 @@
 
 Thank you for your interest in contributing to the IQM QDMI Device implementation! This document outlines how to contribute and the development guidelines.
 
-We use GitHub to [host code](https://github.com/iqm-finland/QDMI), to [track issues and feature requests](https://github.com/iqm-finland/QDMI/issues), as well as accept [pull requests](https://github.com/iqm-finland/QDMI/pulls). See <https://docs.github.com/en/get-started/quickstart> for a general introduction to working with GitHub and contributing to projects.
+We use GitHub to [host code](https://github.com/iqm-finland/QDMI-on-IQM), to [track issues and feature requests](https://github.com/iqm-finland/QDMI-on-IQM/issues), as well as accept [pull requests](https://github.com/iqm-finland/QDMI-on-IQM/pulls). See <https://docs.github.com/en/get-started/quickstart> for a general introduction to working with GitHub and contributing to projects.
 
 ## Types of Contributions
 
 Pick the path that fits your time and interests:
 
 - 🐛 **Report bugs**:
-  Use the _🐛 Bug report_ template at <https://github.com/iqm-finland/QDMI/issues>.
+  Use the _🐛 Bug report_ template at <https://github.com/iqm-finland/QDMI-on-IQM/issues>.
   Include steps to reproduce, expected vs. actual behavior, environment details, and a minimal example.
 
 - 🛠️ **Fix bugs**:
-  Browse [issues](https://github.com/iqm-finland/QDMI/issues), especially those labeled "bug", "help wanted", or "good first issue".
+  Browse [issues](https://github.com/iqm-finland/QDMI-on-IQM/issues), especially those labeled "bug", "help wanted", or "good first issue".
   Open a draft PR early to get feedback.
 
 - 💡 **Propose features**:
-  Use the _✨ Feature request_ template at <https://github.com/iqm-finland/QDMI/issues>.
+  Use the _✨ Feature request_ template at <https://github.com/iqm-finland/QDMI-on-IQM/issues>.
   Describe the motivation, alternatives considered, and (optionally) a small API sketch.
 
 - ✨ **Implement features**:
@@ -36,7 +36,7 @@ Pick the path that fits your time and interests:
   Incremental tooling fixes have a big impact.
 
 - 🙌 **Community support**:
-  Triage issues, reproduce reports, and answer questions in [Discussions](https://github.com/iqm-finland/QDMI/discussions).
+  Triage issues, reproduce reports, and answer questions in [Discussions](https://github.com/iqm-finland/QDMI-on-IQM/discussions).
 
 ## Guidelines
 
@@ -89,24 +89,24 @@ Ready to contribute? We value contributions from people with all levels of exper
 
    **External Contribution**
 
-   If you do not have write access to the [iqm-finland/QDMI](https://github.com/iqm-finland/QDMI) repository, fork the repository on GitHub (see <https://docs.github.com/en/get-started/quickstart/fork-a-repo>) and clone your fork locally.
+   If you do not have write access to the [iqm-finland/QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) repository, fork the repository on GitHub (see <https://docs.github.com/en/get-started/quickstart/fork-a-repo>) and clone your fork locally.
 
    ```console
-   $ git clone git@github.com:your_name_here/QDMI.git
+   $ git clone git@github.com:your_name_here/QDMI-on-IQM.git
    ```
 
    **Internal Contribution**
 
-   If you do have write access to the [iqm-finland/QDMI](https://github.com/iqm-finland/QDMI) repository, clone the repository locally.
+   If you do have write access to the [iqm-finland/QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) repository, clone the repository locally.
 
    ```console
-   $ git clone git@github.com:iqm-finland/QDMI.git
+   $ git clone git@github.com:iqm-finland/QDMI-on-IQM.git
    ```
 
 2. **Change into the project directory**
 
    ```console
-   $ cd QDMI
+   $ cd QDMI-on-IQM
    ```
 
 3. **Create a branch for local development**
@@ -311,7 +311,7 @@ If you discover a security vulnerability, please follow the guidelines in our [S
 If you have any questions about contributing, feel free to:
 
 - Open an issue with the "question" label
-- Start a discussion in [GitHub Discussions](https://github.com/iqm-finland/QDMI/discussions)
+- Start a discussion in [GitHub Discussions](https://github.com/iqm-finland/QDMI-on-IQM/discussions)
 - Reach out to the maintainers directly
 
 Thank you for contributing to the IQM QDMI Device implementation! 🎉

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -8,25 +8,25 @@ Ready to contribute to the project? This guide will get you started.
 
    **External Contribution**
 
-   If you do not have write access to the [iqm-finland/QDMI](https://github.com/iqm-finland/QDMI) repository, fork the repository on GitHub (see <https://docs.github.com/en/get-started/quickstart/fork-a-repo>) and clone your
+   If you do not have write access to the [iqm-finland/QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) repository, fork the repository on GitHub (see <https://docs.github.com/en/get-started/quickstart/fork-a-repo>) and clone your
    fork locally.
 
    ```bash
-   $ git clone git@github.com:your_name_here/QDMI.git
+   $ git clone git@github.com:your_name_here/QDMI-on-IQM.git
    ```
 
    **Internal Contribution**
 
-   If you do have write access to the [iqm-finland/QDMI](https://github.com/iqm-finland/QDMI) repository, clone the repository locally.
+   If you do have write access to the [iqm-finland/QDMI-on-IQM](https://github.com/iqm-finland/QDMI-on-IQM) repository, clone the repository locally.
 
    ```bash
-   $ git clone git@github.com/iqm-finland/QDMI.git
+   $ git clone git@github.com/iqm-finland/QDMI-on-IQM.git
    ```
 
 2. Change into the project directory
 
    ```bash
-   $ cd QDMI
+   $ cd QDMI-on-IQM
    ```
 
 3. Create a branch for local development

--- a/docs/header.html
+++ b/docs/header.html
@@ -63,7 +63,7 @@
   <body>
     <!-- https://tholman.com/github-corners/ -->
     <a
-      href="https://github.com/iqm-finland/QDMI"
+      href="https://github.com/iqm-finland/QDMI-on-IQM"
       class="github-corner"
       title="View source on GitHub"
       target="_blank"

--- a/docs/spack_guide.md
+++ b/docs/spack_guide.md
@@ -21,8 +21,8 @@ from spack.package import *
 class IqmQdmi(CMakePackage):
     """IQM QDMI Device."""
 
-    homepage = "https://github.com/iqm-finland/QDMI"
-    git = "git@github.com:iqm-finland/QDMI.git"
+    homepage = "https://github.com/iqm-finland/QDMI-on-IQM"
+    git = "git@github.com:iqm-finland/QDMI-on-IQM.git"
 
     maintainers("@burgholzer", "@marcelwa")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/iqm-finland/QDMI"
-Issues = "https://github.com/iqm-finland/QDMI/issues"
-Discussions = "https://github.com/iqm-finland/QDMI/discussions"
+Homepage = "https://github.com/iqm-finland/QDMI-on-IQM"
+Issues = "https://github.com/iqm-finland/QDMI-on-IQM/issues"
+Discussions = "https://github.com/iqm-finland/QDMI-on-IQM/discussions"
 
 [project.scripts]
 iqm-qdmi = "iqm.qdmi.__main__:main"


### PR DESCRIPTION
The repo title changed from `QDMI` to `QDMI-on-IQM`. This PR reflects this change throughout the documentation.