### PR TITLE
:page_facing_up: Update License with LLVM Exception

### DIFF
--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -1,10 +1,11 @@
 {
   "author": {
-    "name": "IQM QDMI developers",
+    "name": "IQM Finland Oy",
     "years": [2025, 2026]
   },
   "force_author": true,
-  "license": "Apache-2.0",
+  "custom_license": "Licensed under the Apache License v2.0 with LLVM Exceptions (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttps://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the\nLicense for the specific language governing permissions and limitations under the License.\n\nSPDX-License-Identifier: Apache-2.0 WITH LLVM-exception",
+  "force_license": true,
   "title": false,
   "include": ["**/*"],
   "style_override_for_suffix": {
@@ -14,7 +15,9 @@
     ".td": "SLASH_STYLE",
     ".yaml": "POUND_STYLE",
     ".toml": "POUND_STYLE",
-    ".proto": "SLASH_STYLE"
+    ".proto": "SLASH_STYLE",
+    ".ts": "C_STYLE",
+    ".ps1": "POUND_STYLE"
   },
   "exclude": [
     "^\\.[^/]+",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.24...4.2)
 project(

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -162,7 +162,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
     other commercial damages or losses), even if such Contributor
     has been advised of the possibility of such damages.
 
-9.  Accepting Warranty or Additional Support. While redistributing
+9.  Accepting Warranty or Additional Liability. While redistributing
     the Work or Derivative Works thereof, You may choose to offer,
     and charge a fee for, acceptance of support, warranty, indemnity,
     or other liability obligations and/or rights consistent with this
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2025 Munich Quantum Software GmbH
+Copyright [yyyy] [name of copyright owner]
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -199,3 +199,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ Please see our [Contributing Guide](docs/contributing.md) for:
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the Apache License 2.0 with LLVM exceptions. See the [LICENSE.md](LICENSE.md) file for details.

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 include(FetchContent)
 include(CMakeDependentOption)

--- a/cmake/iqm-qdmi-device-config.cmake.in
+++ b/cmake/iqm-qdmi-device-config.cmake.in
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # A CMake config file for the library, to be used by external projects
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Set the Doxygen configuration file. In the Doxyfile.in file, there are some
 # placeholders that are replaced by CMake. That is also the reason for the

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Doxyfile 1.12.0
 

--- a/docs/_static/iqm_logo.svg
+++ b/docs/_static/iqm_logo.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
- Copyright (c) 2025 - 2026 IQM QDMI developers
+ Copyright (c) 2025 - 2026 IQM Finland Oy
  All rights reserved.
 
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 (the "License");
+ Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 
  Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/docs/_static/iqm_logo_dark.svg
+++ b/docs/_static/iqm_logo_dark.svg
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
- Copyright (c) 2025 - 2026 IQM QDMI developers
+ Copyright (c) 2025 - 2026 IQM Finland Oy
  All rights reserved.
 
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 (the "License");
+ Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 
  Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/docs/layout.xml
+++ b/docs/layout.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2025 - 2026 IQM QDMI developers
+ Copyright (c) 2025 - 2026 IQM Finland Oy
  All rights reserved.
 
- SPDX-License-Identifier: Apache-2.0
-
- Licensed under the Apache License, Version 2.0 (the "License");
+ Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 
  Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <doxygenlayout version="1.0">

--- a/include/curl_http_client.hpp
+++ b/include/curl_http_client.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/include/http_client.hpp
+++ b/include/http_client.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/include/iqm_api_config.hpp
+++ b/include/iqm_api_config.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/include/iqm_auth.hpp
+++ b/include/iqm_auth.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 [build-system]
 requires = ["scikit-build-core>=0.11.6"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ authors = [
   { name = "Marcel Walter", email = "marcel@munichquantum.software" }
 ]
 
-license = "Apache-2.0"
+license = "Apache-2.0 WITH LLVM-exception"
 license-files = ["LICENSE.md"]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ requires-python = ">=3.10"
 description = "Implementation of a QDMI device for IQM Quantum Computers"
 readme = "README.md"
 authors = [
-  { name = "Lukas Burgholzer", email = "lukas@munichquantum.software" },
-  { name = "Marcel Walter", email = "marcel@munichquantum.software" }
+  { name = "IQM Finland Oy", email = "developers@meetiqm.com" },
 ]
 
 license = "Apache-2.0 WITH LLVM-exception"

--- a/python/iqm/qdmi/__init__.py
+++ b/python/iqm/qdmi/__init__.py
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Python wrapper for exposing the IQM QDMI device library."""
 

--- a/python/iqm/qdmi/__main__.py
+++ b/python/iqm/qdmi/__main__.py
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Command line interface for the IQM QDMI device library."""
 

--- a/python/iqm/qdmi/_version.pyi
+++ b/python/iqm/qdmi/_version.pyi
@@ -1,18 +1,18 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 version: str

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,9 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: MIT
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Licensed under the MIT License
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Site customization shim to enable multiprocess coverage collection in tests.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 include(GNUInstallDirs)
 

--- a/src/curl_http_client.cpp
+++ b/src/curl_http_client.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/src/iqm_api_config.cpp
+++ b/src/iqm_api_config.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/src/iqm_auth.cpp
+++ b/src/iqm_auth.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "logging.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_subdirectory(fomac)
 add_subdirectory(mock)

--- a/test/fomac/CMakeLists.txt
+++ b/test/fomac/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_library(qdmi_iqm_fomac fomac.cpp fomac.hpp)
 target_link_libraries(

--- a/test/fomac/fomac.cpp
+++ b/test/fomac/fomac.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/test/fomac/fomac.hpp
+++ b/test/fomac/fomac.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_executable(integration_tests test_iqm_device_integration.cpp)
 target_compile_features(integration_tests PRIVATE cxx_std_20)

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "fomac.hpp"

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_library(mocks INTERFACE)
 

--- a/test/mock/mock_http_client.hpp
+++ b/test/mock/mock_http_client.hpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 /** @file

--- a/test/python/test_init.py
+++ b/test/python/test_init.py
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Tests for the Python distribution of the IQM QDMI device library."""
 

--- a/test/python/test_main.py
+++ b/test/python/test_main.py
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Tests for the Python distribution of the IQM QDMI device library."""
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright (c) 2025 - 2026 IQM QDMI developers
+# Copyright (c) 2025 - 2026 IQM Finland Oy
 # All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_executable(unit_tests test_iqm_api_config.cpp test_iqm_auth.cpp
                           test_iqm_device.cpp test_logging.cpp)

--- a/test/unit/test_iqm_api_config.cpp
+++ b/test/unit/test_iqm_api_config.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "iqm_api_config.hpp"

--- a/test/unit/test_iqm_auth.cpp
+++ b/test/unit/test_iqm_auth.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "iqm_auth.hpp"

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "http_client.hpp"

--- a/test/unit/test_logging.cpp
+++ b/test/unit/test_logging.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2025 - 2026 IQM QDMI developers
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
  * All rights reserved.
  *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include "logging.hpp"


### PR DESCRIPTION
The code was previously distributed under the Apache License 2.0. This PR adds the LLVM exception to this license stating:

```
As an exception, if, as a result of your compiling your source code, portions
of this Software are embedded into an Object form of such source code, you
may redistribute such embedded portions in such Object form without complying
with the conditions of Sections 4(a), 4(b) and 4(d) of the License.

In addition, if you combine or link compiled forms of this Software with
software that is licensed under the GPLv2 ("Combined Software") and if a
court of competent jurisdiction determines that the patent provision (Section
3), the indemnity provision (Section 9) or other Section of the License
conflicts with the conditions of the GPLv2, you may retroactively and
prospectively choose to deem waived or otherwise exclude such Section(s) of
the License, but only in their entirety and only with respect to the Combined
Software.
```

This change has been propagated through the `license-tools` configuration and the license headers across all files.