### PR TITLE
🐛 Fix test compilation

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -18,7 +18,7 @@
 add_executable(integration_tests test_iqm_device_integration.cpp)
 target_compile_features(integration_tests PRIVATE cxx_std_20)
 target_link_libraries(
-  integration_tests PRIVATE gtest_main qdmi::qdmi_project_warnings
+  integration_tests PRIVATE GTest::gtest_main qdmi::qdmi_project_warnings
                             qdmi::iqm_fomac)
 add_dependencies(integration_tests qdmi_test_iqm_device_defs)
 gtest_discover_tests(

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -24,5 +24,5 @@ target_sources(
   mocks INTERFACE FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} FILES
                   ${MOCK_HEADERS})
 
-target_link_libraries(mocks INTERFACE gmock gtest)
+target_link_libraries(mocks INTERFACE GTest::gmock GTest::gtest)
 target_compile_features(mocks INTERFACE cxx_std_20)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,12 +20,6 @@ add_executable(unit_tests test_iqm_api_config.cpp test_iqm_auth.cpp
 target_compile_features(unit_tests PRIVATE cxx_std_20)
 target_link_libraries(
   unit_tests
-  PRIVATE gtest_main
-          gmock_main
-          gtest
-          gmock
-          qdmi::qdmi_project_warnings
-          ${QDMI_TARGET_NAME}
-          iqm::qdmi_device_internals
-          mocks)
+  PRIVATE GTest::gtest_main GTest::gmock_main qdmi::qdmi_project_warnings
+          ${QDMI_TARGET_NAME} iqm::qdmi_device_internals mocks)
 gtest_discover_tests(unit_tests)


### PR DESCRIPTION
After merging #8, the project didn't compile locally for me anymore with the error
```
/usr/bin/ld: CMakeFiles/integration_tests.dir/test_iqm_device_integration.cpp.o: undefined reference to symbol '_ZN7testing7MessageC1Ev'
```
indicating issues with name resolution.

This PR consistently uses the guarded `GTest::gtest_main` and `GTest::gtest_mock` link targets, which resolves the issue.