### PR TITLE
♻️ Return device alias as `QDMI_DEVICE_PROPERTY_NAME` instead of static `"IQM QDMI Device"`

### DIFF
--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1585,8 +1585,14 @@ int IQM_QDMI_device_session_query_device_property(
   if (session->session_status_ != IQM_QDMI_DEVICE_SESSION_STATUS::INITIALIZED) {
     return QDMI_ERROR_BADSTATE;
   }
-  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_NAME, "IQM QDMI Device", prop, size,
-                      value, size_ret)
+  if (prop == QDMI_DEVICE_PROPERTY_NAME) {
+    if (!session->quantum_computer_alias_.has_value()) {
+      return QDMI_ERROR_BADSTATE;
+    }
+    ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_NAME,
+                        session->quantum_computer_alias_->c_str(), prop, size,
+                        value, size_ret)
+  }
   // NOLINTNEXTLINE(misc-include-cleaner)
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_VERSION, IQM_QDMI_DEVICE_VERSION,
                       prop, size, value, size_ret)

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -46,6 +46,7 @@ class QDMIIntegrationTest : public testing::Test {
 protected:
   IQM_QDMI_Device_Session session = nullptr;
   FoMaC fomac{};
+  std::optional<std::string> requested_qc_alias = std::nullopt;
 
   void SetUp() override {
     EXPECT_EQ(IQM_QDMI_device_initialize(), QDMI_SUCCESS);
@@ -71,6 +72,7 @@ protected:
         (qc_alias_env != nullptr)
             ? std::make_optional<std::string>(qc_alias_env)
             : std::nullopt;
+    requested_qc_alias = qc_alias;
 
     session = FoMaC::get_iqm_session(base_url, api_key, std::nullopt, qc_id,
                                      qc_alias);
@@ -222,6 +224,10 @@ protected:
 TEST_F(QDMIIntegrationTest, QueryDeviceProperties) {
   const auto device_name = fomac.get_name();
   ASSERT_FALSE(device_name.empty()) << "Device must provide a name";
+  if (requested_qc_alias.has_value()) {
+    EXPECT_EQ(device_name, *requested_qc_alias)
+        << "Device name must match the selected QC alias";
+  }
 
   const auto version = fomac.get_version();
   ASSERT_FALSE(version.empty()) << "Device must provide a version";


### PR DESCRIPTION
This PR refactors the behavior of `QDMI_DEVICE_PROPERTY_NAME`. It now returns the quantum computer alias of the current session instead of the static `"IQM QDMI Device"` string.