### PR TITLE
🐛 Avoid heralding setting in `OptionalJobParameter` test

### DIFF
--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -731,7 +731,7 @@ TEST_F(QDMIIntegrationTest, JobCycleCornerCases) {
 
 TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
   constexpr size_t shots_num = 64;
-  const std::string heralding_mode = "zeros";
+  const std::string heralding_mode = "none";
   const std::string move_validation_mode = "allow_prx";
   const std::string move_gate_frame_tracking_mode = "no_detuning_correction";
   const std::string dd_mode = "enabled";


### PR DESCRIPTION
On mocks that return random measurement results this may lead to no actual shots being returned, which makes the server fail.

@iqmtjm FYI. This "fixes" (circumvents) the problems I was reporting. From the definition of the `zeros` heralding mode I gathered that it only proceeds if all initial measurements return 0.
When running on a mock, it can happen that none of the 64 shots we run here satisfy that criterion; hence no actual shots are produced which makes some validation fail after post-processing. This only seems to happen on mocks as the actual devices are more reliable in the state preparation.
