### PR TITLE
⬆️ Update QDMI to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
-Compatible with QDMI `v1.2`.
+Compatible with QDMI `v1.3.0`.
 
 - 🎉 Initial release ([**@burgholzer**], [**@marcelwa**])
 

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -23,13 +23,13 @@ if(TARGET qdmi::qdmi)
 else()
   message(STATUS "QDMI will be included via FetchContent")
   # cmake-format: off
-  set(QDMI_VERSION 1.2.2
+  set(QDMI_VERSION 1.3.0
       CACHE STRING "QDMI version")
-  set(QDMI_REV "1843a1a8a9c828d39fe01704675be5634153c969" # v1.2.x
+  set(QDMI_REV "0f7e08c58b72800d1022a01cfb618af67b9a9c30" # v1.3.0
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")
-  set(QDMI_INSTALL
+  set(INSTALL_QDMI
       OFF
       CACHE BOOL "Generate installation instructions for QDMI")
   # cmake-format: on

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,11 +6,11 @@ This project relies on several third-party libraries and tools. Below is a compr
 
 These dependencies are linked into the shared library and **shipped with every built wheel or binary**.
 
-| Dependency      | Version          | License                        | Purpose                                       |
-| :-------------- | :--------------- | :----------------------------- | :-------------------------------------------- |
-| [QDMI]          | 1.2.x (@1843a1a) | Apache-2.0 with LLVM-exception | QDMI specification and interface headers      |
-| [nlohmann/json] | 3.12.0           | MIT License                    | JSON parsing and serialization                |
-| [cURL]          | system-provided  | MIT/X derivative               | HTTP client library for backend communication |
+| Dependency      | Version         | License                        | Purpose                                       |
+| :-------------- | :-------------- | :----------------------------- | :-------------------------------------------- |
+| [QDMI]          | 1.3.0           | Apache-2.0 with LLVM-exception | QDMI specification and interface headers      |
+| [nlohmann/json] | 3.12.0          | MIT License                    | JSON parsing and serialization                |
+| [cURL]          | system-provided | MIT/X derivative               | HTTP client library for backend communication |
 
 [QDMI]: https://github.com/Munich-Quantum-Software-Stack/qdmi
 [nlohmann/json]: https://github.com/nlohmann/json


### PR DESCRIPTION
This PR updates QDMI to its latest stable version (`v1.3.0`).
After this PR, we should be able to prepare and tag the `v1.0.0` release of QDMI on IQM.