### PR TITLE
🐛 Fix CD workflow and bump to 1.0.1

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'
     name: 🚀 Deploy to PyPI
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/iqm-qdmi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,27 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-27
+
+### Fixed
+
+- 🐛 Fix CD workflow runner ([#49]) ([**@burgholzer**])
+
+## [1.0.0] - 2026-04-27
+
 Compatible with QDMI `v1.3.0`.
 
 - 🎉 Initial release ([**@burgholzer**], [**@marcelwa**])
 
 <!-- Version links -->
 
-[Unreleased]: https://github.com/iqm-finland/QDMI-on_IQM/compare/...HEAD
+[Unreleased]: https://github.com/iqm-finland/QDMI-on_IQM/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/iqm-finland/QDMI-on_IQM/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/iqm-finland/QDMI-on_IQM/compare/...v1.0.0
+
+<!-- PR links -->
+
+[#49]: https://github.com/iqm-finland/QDMI-on_IQM/pull/49
 
 <!-- Contributor -->
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.24...4.2)
 project(
   iqm-qdmi-device
   LANGUAGES C CXX
-  VERSION 1.0.0
+  VERSION 1.0.1
   DESCRIPTION "Implementation of a QDMI device for IQM Quantum Computers")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "iqm-qdmi"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.10"
 
 description = "Implementation of a QDMI device for IQM Quantum Computers"

--- a/uv.lock
+++ b/uv.lock
@@ -812,7 +812,7 @@ wheels = [
 
 [[package]]
 name = "iqm-qdmi"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This fixes the CD workflow, which was using `ubuntu-slim` as a runner; but those do not have docker installed, which is a requirement for the publishing action.
This also directly prepares the release of 1.0.1, which should hopefully run through smoothly.