### PR TITLE
🚸 Demote warnings from missing calibration enpoints to debug level

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ myst_heading_anchors = 3
 
 nb_execution_mode = "cache"
 nb_execution_raise_on_error = True
+nb_execution_timeout = 60
 nb_mime_priority_overrides = [("latex", "image/svg+xml", 15)]
 
 copybutton_prompt_text = r"(?:\(\.?venv\) )?(?:\[.*\] )?\$ "

--- a/include/curl_http_client.hpp
+++ b/include/curl_http_client.hpp
@@ -62,6 +62,20 @@ public:
           std::string &response) override;
 
   /**
+   * @brief Perform an optional HTTP GET request using cURL.
+   *
+   * Behaves like get(), but downgrades non-success logging for capability
+   * probes where missing endpoints are expected.
+   *
+   * @param url The target URL for the GET request.
+   * @param bearer_token The bearer token for authentication (can be empty).
+   * @param response Reference to string that will contain the response body.
+   * @return QDMI_SUCCESS on success, otherwise the mapped QDMI error code.
+   */
+  int get_optional(const std::string &url, const std::string &bearer_token,
+                   std::string &response) override;
+
+  /**
    * @brief Perform an HTTP POST request using cURL.
    *
    * Sends an HTTP POST request to the specified URL with optional data payload.

--- a/include/http_client.hpp
+++ b/include/http_client.hpp
@@ -58,6 +58,24 @@ public:
                   std::string &response) = 0;
 
   /**
+   * @brief Perform an optional HTTP GET request.
+   *
+   * Uses the same request semantics as get(), but callers may use this for
+   * capability probes where a non-success response is expected and should not
+   * be surfaced as an error log.
+   *
+   * @param url The target URL for the GET request.
+   * @param bearer_token The bearer token for authentication (can be empty).
+   * @param response Reference to string that will contain the response body.
+   * @return HTTP status code or error code from qdmi/constants.h.
+   */
+  virtual int get_optional(const std::string &url,
+                           const std::string &bearer_token,
+                           std::string &response) {
+    return get(url, bearer_token, response);
+  }
+
+  /**
    * @brief Perform an HTTP POST request.
    *
    * Sends an HTTP POST request to the specified URL with optional data payload,

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -52,16 +52,26 @@ enum class ERROR_LOG_POLICY : uint8_t {
   LOG_AS_DEBUG,
 };
 
+/**
+ * @brief Function hooks used to override selected libcurl entry points.
+ *
+ * Tests use these hooks to force specific failure paths without requiring a
+ * live network interaction.
+ */
 struct Curl_api_hooks {
+  /// Hook for curl_easy_init.
   CURL *(*easy_init)() = curl_easy_init;
+  /// Hook for curl_easy_perform.
   CURLcode (*easy_perform)(CURL *) = curl_easy_perform;
 };
 
+// Helper for access to the mutable curl hook set
 Curl_api_hooks &Get_curl_api_hooks() {
   static Curl_api_hooks curl_api_hooks{};
   return curl_api_hooks;
 }
 
+// Helper to simulate curl_easy_init failure in tests
 CURL *Fail_curl_easy_init() { return nullptr; }
 
 // Helper for policy-aware error logging
@@ -295,6 +305,19 @@ int CurlHttpClient::get_optional(const std::string &url,
                              ERROR_LOG_POLICY::LOG_AS_DEBUG);
 }
 
+/**
+ * @brief Perform an HTTP POST request using cURL.
+ *
+ * Sends an authenticated POST request, attaches a JSON content type header,
+ * and appends an optional extra header when provided.
+ *
+ * @param url The target URL for the POST request.
+ * @param bearer_token The bearer token for authentication.
+ * @param response Reference to the response body buffer.
+ * @param data The request payload to send.
+ * @param extra_header An optional extra HTTP header.
+ * @return The mapped QDMI status code for the request outcome.
+ */
 int CurlHttpClient::post(const std::string &url,
                          const std::string &bearer_token, std::string &response,
                          const std::string &data,

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -61,6 +61,8 @@ Curl_api_hooks &Get_curl_api_hooks() {
   return curl_api_hooks;
 }
 
+CURL *Fail_curl_easy_init() { return nullptr; }
+
 // Helper for policy-aware error logging
 void Log_error(const ERROR_LOG_POLICY policy, const std::string &message) {
   if (policy == ERROR_LOG_POLICY::LOG_AS_DEBUG) {
@@ -357,6 +359,11 @@ void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
   curl_api_hooks.easy_init = easy_init != nullptr ? easy_init : curl_easy_init;
   curl_api_hooks.easy_perform =
       easy_perform != nullptr ? easy_perform : curl_easy_perform;
+}
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+void Enable_curl_easy_init_failure_for_testing() {
+  Set_curl_api_hooks_for_testing(Fail_curl_easy_init, nullptr);
 }
 
 // NOLINTNEXTLINE(misc-use-anonymous-namespace)

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -38,12 +38,12 @@ namespace iqm {
 
 namespace {
 enum class ERROR_LOG_POLICY : uint8_t {
-  ERROR,
-  DEBUG,
+  LOG_AS_ERROR,
+  LOG_AS_DEBUG,
 };
 
 void Log_error(const ERROR_LOG_POLICY policy, const std::string &message) {
-  if (policy == ERROR_LOG_POLICY::DEBUG) {
+  if (policy == ERROR_LOG_POLICY::LOG_AS_DEBUG) {
     LOG_DEBUG(message);
     return;
   }
@@ -254,14 +254,14 @@ int Perform_get_request(const std::string &url, const std::string &bearer_token,
 int CurlHttpClient::get(const std::string &url, const std::string &bearer_token,
                         std::string &response) {
   return Perform_get_request(url, bearer_token, response,
-                             ERROR_LOG_POLICY::ERROR);
+                             ERROR_LOG_POLICY::LOG_AS_ERROR);
 }
 
 int CurlHttpClient::get_optional(const std::string &url,
                                  const std::string &bearer_token,
                                  std::string &response) {
   return Perform_get_request(url, bearer_token, response,
-                             ERROR_LOG_POLICY::DEBUG);
+                             ERROR_LOG_POLICY::LOG_AS_DEBUG);
 }
 
 int CurlHttpClient::post(const std::string &url,
@@ -302,7 +302,7 @@ int CurlHttpClient::post(const std::string &url,
     return QDMI_ERROR_FATAL;
   }
   const auto ret =
-      Handle_response_code(curl, url, response, ERROR_LOG_POLICY::ERROR);
+      Handle_response_code(curl, url, response, ERROR_LOG_POLICY::LOG_AS_ERROR);
   curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
   curl_slist_free_all(headers);
   return ret;

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <curl/curl.h>
+#include <curl/easy.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 #include <string>
@@ -341,7 +342,7 @@ int CurlHttpClient::post(const std::string &url,
 
 namespace test_support {
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 int Handle_response_code_for_testing(const int64_t response_code,
                                      const std::string &url,
                                      const std::string &response,
@@ -352,7 +353,7 @@ int Handle_response_code_for_testing(const int64_t response_code,
                                   : ERROR_LOG_POLICY::LOG_AS_ERROR);
 }
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
                                     CURLcode (*easy_perform)(CURL *)) {
   auto &curl_api_hooks = Get_curl_api_hooks();
@@ -361,12 +362,12 @@ void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
       easy_perform != nullptr ? easy_perform : curl_easy_perform;
 }
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void Enable_curl_easy_init_failure_for_testing() {
   Set_curl_api_hooks_for_testing(Fail_curl_easy_init, nullptr);
 }
 
-// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void Reset_curl_api_hooks_for_testing() {
   Set_curl_api_hooks_for_testing(nullptr, nullptr);
 }

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -37,6 +37,19 @@
 namespace iqm {
 
 namespace {
+enum class ERROR_LOG_POLICY : uint8_t {
+  ERROR,
+  DEBUG,
+};
+
+void Log_error(const ERROR_LOG_POLICY policy, const std::string &message) {
+  if (policy == ERROR_LOG_POLICY::DEBUG) {
+    LOG_DEBUG(message);
+    return;
+  }
+  LOG_ERROR(message);
+}
+
 // Helper for CURL responses
 size_t Curl_write_callback(void *contents, const size_t size,
                            const size_t nmemb, std::string *response) {
@@ -57,7 +70,8 @@ curl_slist *Default_headers(const std::string &bearer_token) {
 }
 
 int Handle_response_code(CURL *curl, const std::string &url,
-                         const std::string &response) {
+                         const std::string &response,
+                         const ERROR_LOG_POLICY error_log_policy) {
   int64_t response_code{};
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
@@ -117,7 +131,7 @@ int Handle_response_code(CURL *curl, const std::string &url,
     error_context += " (Unexpected Response Code)";
   }
 
-  LOG_ERROR(error_context);
+  Log_error(error_log_policy, error_context);
 
   // Log IQM-specific errors if present
   bool logged_structured_error = false;
@@ -126,8 +140,10 @@ int Handle_response_code(CURL *curl, const std::string &url,
   if (has_json && json_response.contains("errors") &&
       !json_response["errors"].is_null() &&
       json_response["errors"].is_array() && !json_response["errors"].empty()) {
-    LOG_ERROR("Response contains " +
-              std::to_string(json_response["errors"].size()) + " error(s):");
+    Log_error(error_log_policy,
+              "Response contains " +
+                  std::to_string(json_response["errors"].size()) +
+                  " error(s):");
     for (const auto &error : json_response["errors"]) {
       std::string error_msg;
       if (error.contains("error_code") && error["error_code"].is_string()) {
@@ -137,7 +153,7 @@ int Handle_response_code(CURL *curl, const std::string &url,
         error_msg += error["message"].get<std::string>();
       }
       if (!error_msg.empty()) {
-        LOG_ERROR("  - " + error_msg);
+        Log_error(error_log_policy, "  - " + error_msg);
       }
     }
     logged_structured_error = true;
@@ -157,14 +173,14 @@ int Handle_response_code(CURL *curl, const std::string &url,
       error_msg += json_response["message"].get<std::string>();
     }
     if (!error_msg.empty()) {
-      LOG_ERROR("Error: " + error_msg);
+      Log_error(error_log_policy, "Error: " + error_msg);
       logged_structured_error = true;
     }
   }
 
   // Fall back to raw response if no structured errors are available
   if (!logged_structured_error && !response.empty()) {
-    LOG_ERROR("Response: " + response);
+    Log_error(error_log_policy, "Response: " + response);
   }
 
   // Log IQM messages if present (might contain additional context)
@@ -201,10 +217,10 @@ int Handle_response_code(CURL *curl, const std::string &url,
 
   return QDMI_ERROR_FATAL;
 }
-} // namespace
 
-int CurlHttpClient::get(const std::string &url, const std::string &bearer_token,
-                        std::string &response) {
+int Perform_get_request(const std::string &url, const std::string &bearer_token,
+                        std::string &response,
+                        const ERROR_LOG_POLICY error_log_policy) {
   LOG_INFO("Performing GET request to " + url);
   CURL *curl = curl_easy_init(); // NOLINT(misc-include-cleaner)
   if (curl == nullptr) {
@@ -220,19 +236,32 @@ int CurlHttpClient::get(const std::string &url, const std::string &bearer_token,
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
   auto *headers = Default_headers(bearer_token);
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  // Perform the request
   if (const auto res = curl_easy_perform(curl); // NOLINT(misc-include-cleaner)
       res != CURLE_OK) {
-    LOG_ERROR("curl_easy_perform() failed: " +
-              std::string(curl_easy_strerror(res)));
+    Log_error(error_log_policy, "curl_easy_perform() failed: " +
+                                    std::string(curl_easy_strerror(res)));
     curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
     curl_slist_free_all(headers);
     return QDMI_ERROR_FATAL;
   }
-  const auto ret = Handle_response_code(curl, url, response);
+  const auto ret = Handle_response_code(curl, url, response, error_log_policy);
   curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
   curl_slist_free_all(headers);
   return ret;
+}
+} // namespace
+
+int CurlHttpClient::get(const std::string &url, const std::string &bearer_token,
+                        std::string &response) {
+  return Perform_get_request(url, bearer_token, response,
+                             ERROR_LOG_POLICY::ERROR);
+}
+
+int CurlHttpClient::get_optional(const std::string &url,
+                                 const std::string &bearer_token,
+                                 std::string &response) {
+  return Perform_get_request(url, bearer_token, response,
+                             ERROR_LOG_POLICY::DEBUG);
 }
 
 int CurlHttpClient::post(const std::string &url,
@@ -272,7 +301,8 @@ int CurlHttpClient::post(const std::string &url,
     curl_slist_free_all(headers);
     return QDMI_ERROR_FATAL;
   }
-  const auto ret = Handle_response_code(curl, url, response);
+  const auto ret =
+      Handle_response_code(curl, url, response, ERROR_LOG_POLICY::ERROR);
   curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
   curl_slist_free_all(headers);
   return ret;

--- a/src/internal/curl_http_client.cpp
+++ b/src/internal/curl_http_client.cpp
@@ -37,11 +37,31 @@
 namespace iqm {
 
 namespace {
+/**
+ * @brief Logging policy used for non-success HTTP response handling.
+ *
+ * This enum controls whether response failures are surfaced at ERROR level for
+ * required requests or downgraded to DEBUG for optional capability probes.
+ */
 enum class ERROR_LOG_POLICY : uint8_t {
+  /// Log all errors at ERROR level (default for required requests)
   LOG_AS_ERROR,
+  /// Log errors at DEBUG level (use for optional capability checks to avoid
+  /// alarming users with expected failures)
   LOG_AS_DEBUG,
 };
 
+struct Curl_api_hooks {
+  CURL *(*easy_init)() = curl_easy_init;
+  CURLcode (*easy_perform)(CURL *) = curl_easy_perform;
+};
+
+Curl_api_hooks &Get_curl_api_hooks() {
+  static Curl_api_hooks curl_api_hooks{};
+  return curl_api_hooks;
+}
+
+// Helper for policy-aware error logging
 void Log_error(const ERROR_LOG_POLICY policy, const std::string &message) {
   if (policy == ERROR_LOG_POLICY::LOG_AS_DEBUG) {
     LOG_DEBUG(message);
@@ -58,6 +78,7 @@ size_t Curl_write_callback(void *contents, const size_t size,
   return real_size;
 }
 
+// Helper for default HTTP request headers
 curl_slist *Default_headers(const std::string &bearer_token) {
   curl_slist *headers = nullptr;
   headers = curl_slist_append(headers, "User-Agent: IQM QDMI C++ API");
@@ -69,12 +90,10 @@ curl_slist *Default_headers(const std::string &bearer_token) {
   return headers;
 }
 
-int Handle_response_code(CURL *curl, const std::string &url,
+// Helper for HTTP response code handling and logging
+int Handle_response_code(const int64_t response_code, const std::string &url,
                          const std::string &response,
                          const ERROR_LOG_POLICY error_log_policy) {
-  int64_t response_code{};
-  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-
   // Parse JSON response for IQM-specific errors and messages
   nlohmann::json json_response;
   bool has_json = false;
@@ -218,11 +237,21 @@ int Handle_response_code(CURL *curl, const std::string &url,
   return QDMI_ERROR_FATAL;
 }
 
+// Helper overload to allow passing CURL* for response code extraction
+int Handle_response_code(CURL *curl, const std::string &url,
+                         const std::string &response,
+                         const ERROR_LOG_POLICY error_log_policy) {
+  int64_t response_code{};
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+  return Handle_response_code(response_code, url, response, error_log_policy);
+}
+
 int Perform_get_request(const std::string &url, const std::string &bearer_token,
                         std::string &response,
                         const ERROR_LOG_POLICY error_log_policy) {
   LOG_INFO("Performing GET request to " + url);
-  CURL *curl = curl_easy_init(); // NOLINT(misc-include-cleaner)
+  auto &curl_api_hooks = Get_curl_api_hooks();
+  CURL *curl = curl_api_hooks.easy_init();
   if (curl == nullptr) {
     LOG_ERROR("curl_easy_init() failed");
     return QDMI_ERROR_FATAL;
@@ -236,8 +265,7 @@ int Perform_get_request(const std::string &url, const std::string &bearer_token,
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
   auto *headers = Default_headers(bearer_token);
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  if (const auto res = curl_easy_perform(curl); // NOLINT(misc-include-cleaner)
-      res != CURLE_OK) {
+  if (const auto res = curl_api_hooks.easy_perform(curl); res != CURLE_OK) {
     Log_error(error_log_policy, "curl_easy_perform() failed: " +
                                     std::string(curl_easy_strerror(res)));
     curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
@@ -269,7 +297,8 @@ int CurlHttpClient::post(const std::string &url,
                          const std::string &data,
                          const std::string &extra_header) {
   LOG_INFO("Performing POST request to " + url);
-  CURL *curl = curl_easy_init();
+  auto &curl_api_hooks = Get_curl_api_hooks();
+  CURL *curl = curl_api_hooks.easy_init();
   if (curl == nullptr) {
     LOG_ERROR("curl_easy_init() failed");
     return QDMI_ERROR_FATAL;
@@ -294,7 +323,7 @@ int CurlHttpClient::post(const std::string &url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
   }
   // Perform the request
-  if (const auto res = curl_easy_perform(curl); res != CURLE_OK) {
+  if (const auto res = curl_api_hooks.easy_perform(curl); res != CURLE_OK) {
     LOG_ERROR("curl_easy_perform() failed: " +
               std::string(curl_easy_strerror(res)));
     curl_easy_cleanup(curl); // NOLINT(misc-include-cleaner)
@@ -307,5 +336,34 @@ int CurlHttpClient::post(const std::string &url,
   curl_slist_free_all(headers);
   return ret;
 }
+
+namespace test_support {
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+int Handle_response_code_for_testing(const int64_t response_code,
+                                     const std::string &url,
+                                     const std::string &response,
+                                     const bool use_debug_logging) {
+  return Handle_response_code(response_code, url, response,
+                              use_debug_logging
+                                  ? ERROR_LOG_POLICY::LOG_AS_DEBUG
+                                  : ERROR_LOG_POLICY::LOG_AS_ERROR);
+}
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
+                                    CURLcode (*easy_perform)(CURL *)) {
+  auto &curl_api_hooks = Get_curl_api_hooks();
+  curl_api_hooks.easy_init = easy_init != nullptr ? easy_init : curl_easy_init;
+  curl_api_hooks.easy_perform =
+      easy_perform != nullptr ? easy_perform : curl_easy_perform;
+}
+
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
+void Reset_curl_api_hooks_for_testing() {
+  Set_curl_api_hooks_for_testing(nullptr, nullptr);
+}
+
+} // namespace test_support
 
 } // namespace iqm

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -58,7 +58,9 @@
 struct IQM_QDMI_Operation_impl_d;
 struct IQM_QDMI_Site_impl_d;
 
+namespace {
 enum class IQM_QDMI_DEVICE_SESSION_STATUS : uint8_t { ALLOCATED, INITIALIZED };
+}
 
 /**
  * @brief Implementation of the IQM_QDMI_Device_Session structure.
@@ -632,10 +634,14 @@ IQM_QDMI_EXPORT int IQM_QDMI_device_session_init_with_http_client(
   const auto cocos_health_url =
       session->api_config_->url(iqm::API_ENDPOINT::COCOS_HEALTH);
   std::string cocos_health_response;
-  const auto status = session->http_client_->get(
+  const auto status = session->http_client_->get_optional(
       cocos_health_url, session->token_manager_->get_bearer_token(),
       cocos_health_response);
   session->supports_calibration_jobs_ = (status == QDMI_SUCCESS);
+  if (!session->supports_calibration_jobs_) {
+    LOG_DEBUG("Calibration jobs are unavailable on this backend; "
+              "optional COCOS health check failed");
+  }
 
   LOG_INFO("Device session initialized successfully");
   return QDMI_SUCCESS;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,8 +15,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_executable(unit_tests test_iqm_api_config.cpp test_iqm_auth.cpp
-                          test_iqm_device.cpp test_logging.cpp)
+add_executable(
+  unit_tests test_curl_http_client.cpp test_iqm_api_config.cpp
+             test_iqm_auth.cpp test_iqm_device.cpp test_logging.cpp)
 target_compile_features(unit_tests PRIVATE cxx_std_20)
 target_link_libraries(
   unit_tests PRIVATE GTest::gmock_main GTest::gtest qdmi::qdmi_project_warnings

--- a/test/unit/curl_http_client_test_support.hpp
+++ b/test/unit/curl_http_client_test_support.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include <cstdint>
-#include <curl/curl.h>
 #include <string>
 
 namespace iqm::test_support {
@@ -44,15 +43,12 @@ int Handle_response_code_for_testing(int64_t response_code,
                                      bool use_debug_logging);
 
 /**
- * @brief Override the CURL entry points used by CurlHttpClient in tests.
+ * @brief Make CurlHttpClient behave as if curl_easy_init failed.
  *
- * Passing nullptr for a hook restores the default libcurl function.
- *
- * @param easy_init Replacement for curl_easy_init.
- * @param easy_perform Replacement for curl_easy_perform.
+ * This helper is used to cover the GET and POST error paths that return
+ * QDMI_ERROR_FATAL when no CURL handle can be created.
  */
-void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
-                                    CURLcode (*easy_perform)(CURL *));
+void Enable_curl_easy_init_failure_for_testing();
 
 /**
  * @brief Restore the default libcurl hooks after a test override.

--- a/test/unit/curl_http_client_test_support.hpp
+++ b/test/unit/curl_http_client_test_support.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
+ * All rights reserved.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <curl/curl.h>
+#include <string>
+
+namespace iqm::test_support {
+
+/**
+ * @brief Exercise CurlHttpClient response handling with a synthetic status.
+ *
+ * This helper bypasses a live CURL handle and directly invokes the internal
+ * response classification logic used by CurlHttpClient.
+ *
+ * @param response_code The HTTP status code to classify.
+ * @param url The request URL used in generated log messages.
+ * @param response The raw response body to parse and inspect.
+ * @param use_debug_logging Whether non-success logs should be emitted at DEBUG
+ * level instead of ERROR.
+ * @return The mapped QDMI status code.
+ */
+int Handle_response_code_for_testing(int64_t response_code,
+                                     const std::string &url,
+                                     const std::string &response,
+                                     bool use_debug_logging);
+
+/**
+ * @brief Override the CURL entry points used by CurlHttpClient in tests.
+ *
+ * Passing nullptr for a hook restores the default libcurl function.
+ *
+ * @param easy_init Replacement for curl_easy_init.
+ * @param easy_perform Replacement for curl_easy_perform.
+ */
+void Set_curl_api_hooks_for_testing(CURL *(*easy_init)(),
+                                    CURLcode (*easy_perform)(CURL *));
+
+/**
+ * @brief Restore the default libcurl hooks after a test override.
+ */
+void Reset_curl_api_hooks_for_testing();
+
+} // namespace iqm::test_support

--- a/test/unit/test_curl_http_client.cpp
+++ b/test/unit/test_curl_http_client.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2025 - 2026 IQM Finland Oy
+ * All rights reserved.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE.md
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include "curl_http_client.hpp"
+#include "curl_http_client_test_support.hpp"
+#include "iqm_qdmi/constants.h"
+#include "logging.hpp"
+
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+/**
+ * @brief Captures logger output for assertions within a single test scope.
+ */
+class LoggerCapture {
+public:
+  /**
+   * @brief Redirect logger output to an internal string stream.
+   */
+  LoggerCapture()
+      : logger_(&iqm::Logger::get_instance()),
+        original_level_(logger_->get_level()) {
+    logger_->set_level(iqm::LOG_LEVEL::DEBUG);
+    logger_->set_output(log_stream_);
+  }
+
+  LoggerCapture(const LoggerCapture &) = delete;
+  LoggerCapture &operator=(const LoggerCapture &) = delete;
+  LoggerCapture(LoggerCapture &&) = delete;
+  LoggerCapture &operator=(LoggerCapture &&) = delete;
+
+  /**
+   * @brief Restore the original logger output stream and level.
+   */
+  ~LoggerCapture() {
+    logger_->set_output(std::cerr);
+    logger_->set_level(original_level_);
+  }
+
+  /**
+   * @brief Return the captured log output.
+   * @return The current contents of the capture stream.
+   */
+  [[nodiscard]] std::string str() const { return log_stream_.str(); }
+
+private:
+  /// Logger singleton used for temporary output redirection.
+  iqm::Logger *logger_;
+  /// Original log level restored when the guard goes out of scope.
+  iqm::LOG_LEVEL original_level_;
+  /// Buffer that captures log output for test assertions.
+  std::stringstream log_stream_;
+};
+
+/**
+ * @brief Restores CurlHttpClient test hooks when leaving scope.
+ */
+class CurlApiHookGuard {
+public:
+  /**
+   * @brief Install temporary curl hook overrides.
+   * @param easy_init Replacement function for curl_easy_init.
+   * @param easy_perform Replacement function for curl_easy_perform.
+   */
+  CurlApiHookGuard(CURL *(*easy_init)(), CURLcode (*easy_perform)(CURL *)) {
+    iqm::test_support::Set_curl_api_hooks_for_testing(easy_init, easy_perform);
+  }
+
+  CurlApiHookGuard(const CurlApiHookGuard &) = delete;
+  CurlApiHookGuard &operator=(const CurlApiHookGuard &) = delete;
+  CurlApiHookGuard(CurlApiHookGuard &&) = delete;
+  CurlApiHookGuard &operator=(CurlApiHookGuard &&) = delete;
+
+  /**
+   * @brief Restore the default curl hooks.
+   */
+  ~CurlApiHookGuard() { iqm::test_support::Reset_curl_api_hooks_for_testing(); }
+};
+
+/**
+ * @brief Test helper that simulates curl_easy_init failure.
+ * @return nullptr to emulate a failed CURL handle allocation.
+ */
+CURL *Failing_curl_easy_init() { return nullptr; }
+
+TEST(CurlHttpClientTest, SuccessMessagesAreLogged) {
+  LoggerCapture logger_capture;
+
+  const auto ret = iqm::test_support::Handle_response_code_for_testing(
+      200, "https://example.test/jobs",
+      R"({"messages":[{"message":"alpha"},{"message":7},{"ignored":true}]})",
+      false);
+
+  EXPECT_EQ(ret, QDMI_SUCCESS);
+
+  const auto logs = logger_capture.str();
+  EXPECT_NE(logs.find("Response contains 3 message(s):"), std::string::npos);
+  EXPECT_NE(logs.find("  - alpha"), std::string::npos);
+  EXPECT_NE(logs.find("Request successful (HTTP 200)"), std::string::npos);
+}
+
+TEST(CurlHttpClientTest, InvalidJsonServerErrorFallsBackToRawResponse) {
+  LoggerCapture logger_capture;
+
+  const auto ret = iqm::test_support::Handle_response_code_for_testing(
+      503, "https://example.test/jobs", "not-json", false);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+
+  const auto logs = logger_capture.str();
+  EXPECT_NE(logs.find("Response is not valid JSON"), std::string::npos);
+  EXPECT_NE(logs.find("failed with HTTP 503 (Server Error)"),
+            std::string::npos);
+  EXPECT_NE(logs.find("Response: not-json"), std::string::npos);
+}
+
+TEST(CurlHttpClientTest, RedirectResponseLogsAdditionalMessages) {
+  LoggerCapture logger_capture;
+
+  const auto ret = iqm::test_support::Handle_response_code_for_testing(
+      302, "https://example.test/jobs",
+      R"({"messages":[{"message":"follow redirect"}]})", false);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+
+  const auto logs = logger_capture.str();
+  EXPECT_NE(logs.find("failed with HTTP 302 (Unexpected Redirect)"),
+            std::string::npos);
+  EXPECT_NE(logs.find("Response contains 1 additional message(s):"),
+            std::string::npos);
+  EXPECT_NE(logs.find("  - follow redirect"), std::string::npos);
+  EXPECT_NE(
+      logs.find("Response: {\"messages\":[{\"message\":\"follow redirect\"}]}"),
+      std::string::npos);
+}
+
+TEST(CurlHttpClientTest, StructuredErrorsSuppressRawFallback) {
+  LoggerCapture logger_capture;
+
+  const auto ret = iqm::test_support::Handle_response_code_for_testing(
+      600, "https://example.test/jobs",
+      R"({"errors":[{"error_code":"E1","message":"boom"},{"message":"detail"},{"error_code":7},{"ignored":true}]})",
+      false);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+
+  const auto logs = logger_capture.str();
+  EXPECT_NE(logs.find("failed with HTTP 600 (Unexpected Response Code)"),
+            std::string::npos);
+  EXPECT_NE(logs.find("Response contains 4 error(s):"), std::string::npos);
+  EXPECT_NE(logs.find("  - [E1] boom"), std::string::npos);
+  EXPECT_NE(logs.find("  - detail"), std::string::npos);
+  EXPECT_EQ(logs.find("Response: {\"errors\":"), std::string::npos);
+}
+
+TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlInitFails) {
+  LoggerCapture logger_capture;
+  CurlApiHookGuard curl_api_hook_guard(Failing_curl_easy_init, nullptr);
+  iqm::CurlHttpClient http_client;
+  std::string response;
+
+  EXPECT_EQ(http_client.get("https://example.test/jobs", "", response),
+            QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("curl_easy_init() failed"),
+            std::string::npos);
+}
+
+TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlInitFails) {
+  LoggerCapture logger_capture;
+  CurlApiHookGuard curl_api_hook_guard(Failing_curl_easy_init, nullptr);
+  iqm::CurlHttpClient http_client;
+  std::string response;
+
+  EXPECT_EQ(
+      http_client.post("https://example.test/jobs", "", response, "{}", ""),
+      QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("curl_easy_init() failed"),
+            std::string::npos);
+}
+
+TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlPerformFails) {
+  LoggerCapture logger_capture;
+  iqm::CurlHttpClient http_client;
+  std::string response;
+
+  EXPECT_EQ(
+      http_client.get("unsupported-protocol://example.test/jobs", "", response),
+      QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("curl_easy_perform() failed:"),
+            std::string::npos);
+}
+
+TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlPerformFails) {
+  LoggerCapture logger_capture;
+  iqm::CurlHttpClient http_client;
+  std::string response;
+
+  EXPECT_EQ(http_client.post("unsupported-protocol://example.test/jobs", "",
+                             response, "{}", ""),
+            QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("curl_easy_perform() failed:"),
+            std::string::npos);
+}
+
+} // namespace

--- a/test/unit/test_curl_http_client.cpp
+++ b/test/unit/test_curl_http_client.cpp
@@ -22,7 +22,6 @@
 #include "iqm_qdmi/constants.h"
 #include "logging.hpp"
 
-#include <curl/curl.h>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <sstream>
@@ -79,12 +78,10 @@ private:
 class CurlApiHookGuard {
 public:
   /**
-   * @brief Install temporary curl hook overrides.
-   * @param easy_init Replacement function for curl_easy_init.
-   * @param easy_perform Replacement function for curl_easy_perform.
+   * @brief Install a temporary curl_easy_init failure hook.
    */
-  CurlApiHookGuard(CURL *(*easy_init)(), CURLcode (*easy_perform)(CURL *)) {
-    iqm::test_support::Set_curl_api_hooks_for_testing(easy_init, easy_perform);
+  CurlApiHookGuard() {
+    iqm::test_support::Enable_curl_easy_init_failure_for_testing();
   }
 
   CurlApiHookGuard(const CurlApiHookGuard &) = delete;
@@ -97,12 +94,6 @@ public:
    */
   ~CurlApiHookGuard() { iqm::test_support::Reset_curl_api_hooks_for_testing(); }
 };
-
-/**
- * @brief Test helper that simulates curl_easy_init failure.
- * @return nullptr to emulate a failed CURL handle allocation.
- */
-CURL *Failing_curl_easy_init() { return nullptr; }
 
 TEST(CurlHttpClientTest, SuccessMessagesAreLogged) {
   LoggerCapture logger_capture;
@@ -176,7 +167,7 @@ TEST(CurlHttpClientTest, StructuredErrorsSuppressRawFallback) {
 
 TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlInitFails) {
   LoggerCapture logger_capture;
-  CurlApiHookGuard curl_api_hook_guard(Failing_curl_easy_init, nullptr);
+  CurlApiHookGuard curl_api_hook_guard;
   iqm::CurlHttpClient http_client;
   std::string response;
 
@@ -188,7 +179,7 @@ TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlInitFails) {
 
 TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlInitFails) {
   LoggerCapture logger_capture;
-  CurlApiHookGuard curl_api_hook_guard(Failing_curl_easy_init, nullptr);
+  CurlApiHookGuard curl_api_hook_guard;
   iqm::CurlHttpClient http_client;
   std::string response;
 

--- a/test/unit/test_curl_http_client.cpp
+++ b/test/unit/test_curl_http_client.cpp
@@ -96,7 +96,7 @@ public:
 };
 
 TEST(CurlHttpClientTest, SuccessMessagesAreLogged) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
 
   const auto ret = iqm::test_support::Handle_response_code_for_testing(
       200, "https://example.test/jobs",
@@ -112,7 +112,7 @@ TEST(CurlHttpClientTest, SuccessMessagesAreLogged) {
 }
 
 TEST(CurlHttpClientTest, InvalidJsonServerErrorFallsBackToRawResponse) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
 
   const auto ret = iqm::test_support::Handle_response_code_for_testing(
       503, "https://example.test/jobs", "not-json", false);
@@ -127,7 +127,7 @@ TEST(CurlHttpClientTest, InvalidJsonServerErrorFallsBackToRawResponse) {
 }
 
 TEST(CurlHttpClientTest, RedirectResponseLogsAdditionalMessages) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
 
   const auto ret = iqm::test_support::Handle_response_code_for_testing(
       302, "https://example.test/jobs",
@@ -147,7 +147,7 @@ TEST(CurlHttpClientTest, RedirectResponseLogsAdditionalMessages) {
 }
 
 TEST(CurlHttpClientTest, StructuredErrorsSuppressRawFallback) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
 
   const auto ret = iqm::test_support::Handle_response_code_for_testing(
       600, "https://example.test/jobs",
@@ -166,8 +166,8 @@ TEST(CurlHttpClientTest, StructuredErrorsSuppressRawFallback) {
 }
 
 TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlInitFails) {
-  LoggerCapture logger_capture;
-  CurlApiHookGuard curl_api_hook_guard;
+  const LoggerCapture logger_capture;
+  const CurlApiHookGuard curl_api_hook_guard;
   iqm::CurlHttpClient http_client;
   std::string response;
 
@@ -178,8 +178,8 @@ TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlInitFails) {
 }
 
 TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlInitFails) {
-  LoggerCapture logger_capture;
-  CurlApiHookGuard curl_api_hook_guard;
+  const LoggerCapture logger_capture;
+  const CurlApiHookGuard curl_api_hook_guard;
   iqm::CurlHttpClient http_client;
   std::string response;
 
@@ -191,7 +191,7 @@ TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlInitFails) {
 }
 
 TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlPerformFails) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
   iqm::CurlHttpClient http_client;
   std::string response;
 
@@ -203,7 +203,7 @@ TEST(CurlHttpClientTest, GetReturnsFatalWhenCurlPerformFails) {
 }
 
 TEST(CurlHttpClientTest, PostReturnsFatalWhenCurlPerformFails) {
-  LoggerCapture logger_capture;
+  const LoggerCapture logger_capture;
   iqm::CurlHttpClient http_client;
   std::string response;
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -28,7 +28,9 @@
 #include <exception>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,6 +44,8 @@ using testing::SetArgReferee;
 int IQM_QDMI_device_session_init_with_http_client(
     IQM_QDMI_Device_Session session,
     std::unique_ptr<iqm::IHttpClient> http_client);
+
+namespace {
 
 // ============================================================================
 // TEST FIXTURES
@@ -71,67 +75,6 @@ protected:
   std::unique_ptr<iqm::MockHttpClient> mock_http_client_;
   iqm::MockHttpClient *mock_handle_{};
 
-  void SetUp() override {
-    EXPECT_EQ(IQM_QDMI_device_initialize(), QDMI_SUCCESS);
-    mock_http_client_ = std::make_unique<iqm::MockHttpClient>();
-    mock_handle_ = mock_http_client_.get();
-    EXPECT_EQ(IQM_QDMI_device_session_alloc(&session), QDMI_SUCCESS);
-    const std::string base_url = "https://localhost";
-    EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
-                  session, QDMI_DEVICE_SESSION_PARAMETER_BASEURL,
-                  base_url.size() + 1, base_url.c_str()),
-              QDMI_SUCCESS);
-  }
-
-  void TearDown() override {
-    if (session != nullptr) {
-      IQM_QDMI_device_session_free(session);
-    }
-    EXPECT_EQ(IQM_QDMI_device_finalize(), QDMI_SUCCESS);
-  }
-
-  static constexpr auto TEST_CIRCUIT_IQM_JSON = R"(
-    {
-      "name": "test_circuit",
-      "instructions": [
-        {
-          "name": "prx",
-          "locus": [
-            "QB1"
-          ],
-          "args": {
-            "angle_t": 0.25,
-            "phase_t": 0.75
-          }
-        },
-        {
-          "name": "cz",
-          "locus": [
-            "QB1",
-            "QB2"
-          ],
-          "args": {}
-        },
-        {
-          "name": "measure",
-          "locus": [
-            "QB1"
-          ],
-          "args": {
-            "key": "meas_2_0_0"
-          }
-        }
-      ],
-      "metadata": {}
-    }
-  )";
-};
-
-class DeviceJobMockTest : public DeviceIntegrationMockTest {
-protected:
-  IQM_QDMI_Device_Job job = nullptr;
-
-  // Mock initialization responses for unified API
   const std::string list_quantum_computers_response = R"({
       "quantum_computers": [
         {
@@ -426,6 +369,66 @@ protected:
       ],
       "warnings": []
     })";
+
+  void SetUp() override {
+    EXPECT_EQ(IQM_QDMI_device_initialize(), QDMI_SUCCESS);
+    mock_http_client_ = std::make_unique<iqm::MockHttpClient>();
+    mock_handle_ = mock_http_client_.get();
+    EXPECT_EQ(IQM_QDMI_device_session_alloc(&session), QDMI_SUCCESS);
+    const std::string base_url = "https://localhost";
+    EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                  session, QDMI_DEVICE_SESSION_PARAMETER_BASEURL,
+                  base_url.size() + 1, base_url.c_str()),
+              QDMI_SUCCESS);
+  }
+
+  void TearDown() override {
+    if (session != nullptr) {
+      IQM_QDMI_device_session_free(session);
+    }
+    EXPECT_EQ(IQM_QDMI_device_finalize(), QDMI_SUCCESS);
+  }
+
+  static constexpr auto TEST_CIRCUIT_IQM_JSON = R"(
+    {
+      "name": "test_circuit",
+      "instructions": [
+        {
+          "name": "prx",
+          "locus": [
+            "QB1"
+          ],
+          "args": {
+            "angle_t": 0.25,
+            "phase_t": 0.75
+          }
+        },
+        {
+          "name": "cz",
+          "locus": [
+            "QB1",
+            "QB2"
+          ],
+          "args": {}
+        },
+        {
+          "name": "measure",
+          "locus": [
+            "QB1"
+          ],
+          "args": {
+            "key": "meas_2_0_0"
+          }
+        }
+      ],
+      "metadata": {}
+    }
+  )";
+};
+
+class DeviceJobMockTest : public DeviceIntegrationMockTest {
+protected:
+  IQM_QDMI_Device_Job job = nullptr;
 
   void SetUp() override {
     DeviceIntegrationMockTest::SetUp();
@@ -862,7 +865,7 @@ TEST_F(DeviceJobMockTest, EmptyShotsReturnsNullTerminator) {
   EXPECT_TRUE(result.empty());
 }
 
-static constexpr auto TEST_CALIBRATION_CONFIG = R"(
+constexpr auto TEST_CALIBRATION_CONFIG = R"(
     {
       "procedure_config": {
         "excluded_qubits": [],
@@ -965,6 +968,66 @@ TEST_F(DeviceIntegrationMockTest, HTTPAuthenticationFailure) {
             QDMI_ERROR_PERMISSIONDENIED);
 }
 
+TEST_F(DeviceIntegrationMockTest,
+       MissingCocosHealthEndpointDisablesCalibrationJobs) {
+  struct Logger_guard {
+    iqm::Logger *logger;
+    iqm::LOG_LEVEL original_level;
+
+    Logger_guard(iqm::Logger *logger_in, const iqm::LOG_LEVEL level)
+        : logger(logger_in), original_level(level) {}
+
+    Logger_guard(const Logger_guard &) = delete;
+    Logger_guard &operator=(const Logger_guard &) = delete;
+    Logger_guard(Logger_guard &&) = delete;
+    Logger_guard &operator=(Logger_guard &&) = delete;
+
+    ~Logger_guard() {
+      logger->set_output(std::cerr);
+      logger->set_level(original_level);
+    }
+  };
+
+  std::stringstream log_stream{};
+  auto &logger = iqm::Logger::get_instance();
+  const Logger_guard logger_guard{&logger, logger.get_level()};
+  logger.set_level(iqm::LOG_LEVEL::DEBUG);
+  logger.set_output(log_stream);
+
+  EXPECT_CALL(*mock_http_client_, get(_, _, _))
+      .WillOnce(DoAll(SetArgReferee<2>(list_quantum_computers_response),
+                      Return(QDMI_SUCCESS)))
+      .WillOnce(
+          DoAll(SetArgReferee<2>(get_static_quantum_architectures_response),
+                Return(QDMI_SUCCESS)))
+      .WillOnce(
+          DoAll(SetArgReferee<2>(get_dynamic_quantum_architectures_response),
+                Return(QDMI_SUCCESS)))
+      .WillOnce(
+          DoAll(SetArgReferee<2>(get_calibration_set_quality_metrics_response),
+                Return(QDMI_SUCCESS)))
+      .WillOnce(Return(QDMI_ERROR_NOTFOUND));
+
+  ASSERT_EQ(IQM_QDMI_device_session_init_with_http_client(
+                session, std::move(mock_http_client_)),
+            QDMI_SUCCESS);
+
+  IQM_QDMI_Device_Job job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_create_device_job(session, &job),
+            QDMI_SUCCESS);
+
+  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  EXPECT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT,
+                sizeof(QDMI_Program_Format), &format),
+            QDMI_ERROR_NOTSUPPORTED);
+
+  const auto logs = log_stream.str();
+  EXPECT_EQ(logs.find("ERROR"), std::string::npos);
+
+  IQM_QDMI_device_job_free(job);
+}
+
 TEST_F(DeviceIntegrationMockTest, MalformedJSONResponse) {
 
   // Test malformed JSON responses
@@ -1005,6 +1068,8 @@ TEST_F(DeviceJobMockTest, JobSubmissionFailure) {
 // ============================================================================
 // JOB HANDLING TESTS
 // ============================================================================
+
+} // namespace
 
 TEST_F(DeviceJobMockTest, JobParameterValidation) {
   // Test null job parameter


### PR DESCRIPTION
Since the integration tests go through Resonance, every call that initiates a QDMI session logs a warning about the failed attempt to access the calibration endpoint. This was annoying and confusing for users, as it did not represent a real failure case. This PR demotes such warnings to debug level.