### PR TITLE
🚚 Replace meetiqm.com with the new domain

### DIFF
--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Test
         env:
-          IQM_BASE_URL: "https://resonance.meetiqm.com"
+          IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           RESONANCE_API_KEY: ${{ secrets.RESONANCE_API_KEY }}
           IQM_CPP_API_LOG_LEVEL: "DEBUG"

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -53,7 +53,7 @@ jobs:
       # run the tests (for retry for transient AWS connectivity failures)
       - name: Test
         env:
-          IQM_BASE_URL: "https://resonance.meetiqm.com"
+          IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           RESONANCE_API_KEY: ${{ secrets.RESONANCE_API_KEY }}
           IQM_CPP_API_LOG_LEVEL: "DEBUG"

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -58,7 +58,7 @@ jobs:
         run: cmake --build build
       - name: Test
         env:
-          IQM_BASE_URL: "https://resonance.meetiqm.com"
+          IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           RESONANCE_API_KEY: ${{ secrets.RESONANCE_API_KEY }}
           IQM_CPP_API_LOG_LEVEL: "DEBUG"

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Test
         env:
           CONFIG: ${{ inputs.config }}
-          IQM_BASE_URL: "https://resonance.meetiqm.com"
+          IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           RESONANCE_API_KEY: ${{ secrets.RESONANCE_API_KEY }}
           IQM_CPP_API_LOG_LEVEL: "DEBUG"

--- a/.github/workflows/python-packaging-cibuildwheel.yml
+++ b/.github/workflows/python-packaging-cibuildwheel.yml
@@ -38,7 +38,7 @@ jobs:
       # run cibuildwheel to build wheels for the specified Python version
       - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
-          IQM_BASE_URL: "https://resonance.meetiqm.com"
+          IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: "emerald:mock"
           IQM_TOKEN: ${{ secrets.RESONANCE_API_KEY }}
           IQM_CPP_API_LOG_LEVEL: "DEBUG"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.meetiqm.com">
+  <a href="https://www.iqm.tech">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/iqm-finland/QDMI-on-IQM/raw/refs/heads/main/docs/_static/iqm_logo_dark.svg">
      <img src="https://github.com/iqm-finland/QDMI-on-IQM/raw/refs/heads/main/docs/_static/iqm_logo.svg" alt="IQM Logo" width="40%">
@@ -18,7 +18,7 @@
 By providing this officially supported implementation, we empower HPC centers and middleware developers to embed IQM processors via a stable, vendor-agnostic standard.
 This avoids the need for fragile, bespoke adapter chains and allows users to keep their familiar tools while operators maintain manageable workflows.
 
-The library seamlessly wraps backend orchestration—spanning persistent session control, calibration queries, and job semantics via the [IQM Server API](https://resonance.meetiqm.com/docs/api-reference)—to connect higher-level software and schedulers to both our cloud-hosted endpoints through [IQM Resonance](https://resonance.meetiqm.com) and our on-premise device deployments.
+The library seamlessly wraps backend orchestration—spanning persistent session control, calibration queries, and job semantics via the [IQM Server API](https://resonance.iqm.tech/docs/api-reference)—to connect higher-level software and schedulers to both our cloud-hosted endpoints through [IQM Resonance](https://resonance.iqm.tech) and our on-premise device deployments.
 
 The underlying library is written in C++20, providing a reliable foundation for long-lived integration code.
 Pre-compiled binaries for major OS and architecture configurations are provided alongside an official Python wrapper for straightforward installation via `uv` and direct use in Python workflows.
@@ -80,7 +80,7 @@ int main() {
     IQM_QDMI_device_session_alloc(&session);
 
     // Configure server and auth
-    const char* url = "https://resonance.meetiqm.com";
+    const char* url = "https://resonance.iqm.tech";
     const char* token = "your-api-token";
     IQM_QDMI_device_session_set_parameter(session,
         QDMI_DEVICE_SESSION_PARAMETER_BASEURL, strlen(url) + 1, url);
@@ -135,7 +135,7 @@ For complete examples, see the [Usage Guide](https://iqm-finland.github.io/QDMI-
 4. **Result Retrieval**: Poll for job completion and retrieve measurement results
 5. **Calibration Control**: Optionally trigger calibrations and update to new calibration sets
 
-The library interfaces with the [IQM Server API](https://resonance.meetiqm.com/docs/api-reference) to provide complete device
+The library interfaces with the [IQM Server API](https://resonance.iqm.tech/docs/api-reference) to provide complete device
 management through the standardized QDMI interface.
 
 ## Testing

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 By providing this officially supported implementation, we empower HPC centers and middleware developers to embed IQM processors via a stable, vendor-agnostic standard.
 This avoids the need for fragile, bespoke adapter chains and allows users to keep their familiar tools while operators maintain manageable workflows.
 
-The library seamlessly wraps backend orchestration—spanning persistent session control, calibration queries, and job semantics via the [IQM Server API](https://resonance.meetiqm.com/docs/api-reference)—to connect higher-level software and schedulers to both our cloud-hosted endpoints through [IQM Resonance](https://resonance.meetiqm.com) and our on-premise device deployments.
+The library seamlessly wraps backend orchestration—spanning persistent session control, calibration queries, and job semantics via the [IQM Server API](https://resonance.iqm.tech/docs/api-reference)—to connect higher-level software and schedulers to both our cloud-hosted endpoints through [IQM Resonance](https://resonance.iqm.tech) and our on-premise device deployments.
 
 The underlying library is written in C++20, providing a reliable foundation for long-lived integration code.
 Pre-compiled binaries for major OS and architecture configurations are provided alongside an official Python wrapper for straightforward installation via `uv` and direct use in Python workflows.

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -80,7 +80,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile
 
 backend = IQMBackend(
-  base_url="https://resonance.meetiqm.com",
+  base_url="https://resonance.iqm.tech",
   qc_alias="emerald:mock",
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.10"
 description = "Implementation of a QDMI device for IQM Quantum Computers"
 readme = "README.md"
 authors = [
-  { name = "IQM Finland Oy", email = "developers@meetiqm.com" },
+  { name = "IQM Finland Oy", email = "developers@iqm.tech" },
 ]
 
 license = "Apache-2.0 WITH LLVM-exception"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ addopts = [
 ]
 filterwarnings = [
   "error",
+  "ignore:.*Device operation 'prx_12' cannot be mapped to a Qiskit gate and will be skipped.*:UserWarning:",
 ]
 log_level = "INFO"
 testpaths = ["test/python"]

--- a/python/iqm/qdmi/qiskit.py
+++ b/python/iqm/qdmi/qiskit.py
@@ -71,7 +71,7 @@ class IQMBackend(QDMIBackend):
         device = add_dynamic_device_library(
             library_path=str(IQM_QDMI_LIBRARY_PATH),
             prefix="IQM",
-            base_url=base_url or os.getenv("IQM_BASE_URL") or "https://resonance.meetiqm.com",
+            base_url=base_url or os.getenv("IQM_BASE_URL") or "https://resonance.iqm.tech",
             token=token or os.getenv("IQM_TOKEN") or os.getenv("RESONANCE_API_KEY"),
             auth_file=tokens_file or os.getenv("IQM_TOKENS_FILE"),
             custom1=qc_id or os.getenv("IQM_QC_ID"),

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -58,9 +58,8 @@ protected:
     const std::string api_key{(api_key_env != nullptr) ? api_key_env : ""};
 
     const auto *base_url_env = std::getenv("IQM_BASE_URL");
-    const std::string base_url = (base_url_env != nullptr)
-                                     ? base_url_env
-                                     : "https://resonance.iqm.tech";
+    const std::string base_url =
+        (base_url_env != nullptr) ? base_url_env : "https://resonance.iqm.tech";
 
     const auto *qc_id_env = std::getenv("IQM_QC_ID");
     const std::optional<std::string> qc_id =

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -60,7 +60,7 @@ protected:
     const auto *base_url_env = std::getenv("IQM_BASE_URL");
     const std::string base_url = (base_url_env != nullptr)
                                      ? base_url_env
-                                     : "https://resonance.meetiqm.com";
+                                     : "https://resonance.iqm.tech";
 
     const auto *qc_id_env = std::getenv("IQM_QC_ID");
     const std::optional<std::string> qc_id =

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -42,6 +42,7 @@
 // time for real job execution on the quantum computer.
 constexpr size_t DEFAULT_JOB_WAIT_TIMEOUT = 300; // seconds
 
+namespace {
 class QDMIIntegrationTest : public testing::Test {
 protected:
   IQM_QDMI_Device_Session session = nullptr;
@@ -219,6 +220,7 @@ protected:
       "graph_definition": null,
     })";
 };
+} // namespace
 
 TEST_F(QDMIIntegrationTest, QueryDeviceProperties) {
   const auto device_name = fomac.get_name();


### PR DESCRIPTION
IQM is changing the domain name from `meetiqm.com` to `iqm.tech` so the code and documents are updated accordingly

The update is starting 4.5.2026 and will rolled out over time so some domains might still re-direct to the old meetiqm.com for some time