### PR TITLE
🚸 Improve retry logic with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ## Added
 
 - ✨ Add end-to-end examples and documentation for running experiments on IQM hardware ([#53]) ([**@marcelwa**], [**@burgholzer**])
-- 🚸 Add explicit retry logic to avoid hitting API rate limits ([#52]) ([**@marcelwa**], [**@burgholzer**])
+- 🚸 Add explicit retry logic to avoid hitting API rate limits ([#52], [#73]) ([**@marcelwa**], [**@burgholzer**])
 - ✨ Add Qiskit-compatible `IQMBackend` wrapper including Sampler and Estimator primitives ([#37]) ([**@marcelwa**], [**@burgholzer**])
 
 ## Changed
@@ -48,6 +48,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#73]: https://github.com/iqm-finland/QDMI-on_IQM/pull/73
 [#67]: https://github.com/iqm-finland/QDMI-on-IQM/pull/67
 [#56]: https://github.com/iqm-finland/QDMI-on_IQM/pull/56
 [#53]: https://github.com/iqm-finland/QDMI-on_IQM/pull/53

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ myst_heading_anchors = 3
 
 nb_execution_mode = "cache"
 nb_execution_raise_on_error = True
-nb_execution_timeout = 60
+nb_execution_timeout = 300
 nb_mime_priority_overrides = [("latex", "image/svg+xml", 15)]
 
 copybutton_prompt_text = r"(?:\(\.?venv\) )?(?:\[.*\] )?\$ "

--- a/include/curl_http_client_internal.hpp
+++ b/include/curl_http_client_internal.hpp
@@ -55,10 +55,7 @@ enum class ERROR_LOG_POLICY : uint8_t {
 };
 
 /// Number of retries to attempt after receiving HTTP 429.
-constexpr uint8_t RATE_LIMIT_RETRY_COUNT = 3;
-
-/// Delay in seconds between consecutive HTTP 429 retry attempts.
-constexpr uint8_t RATE_LIMIT_RETRY_DELAY_SECONDS = 2;
+constexpr uint8_t RATE_LIMIT_RETRY_COUNT = 5;
 
 /**
  * @brief Result of a single CURL request attempt.
@@ -134,13 +131,13 @@ int Perform_request_with_retries(const std::string &url, std::string &response,
                                   error_log_policy);
     }
 
+    const int delay_seconds = 2 << attempt;
     LOG_DEBUG("Request to URL '" + url +
               "' hit HTTP 429 rate limiting; retrying in " +
-              std::to_string(RATE_LIMIT_RETRY_DELAY_SECONDS) +
-              " second(s) (attempt " + std::to_string(attempt + 1) + "/" +
+              std::to_string(delay_seconds) + " second(s) (attempt " +
+              std::to_string(attempt + 1) + "/" +
               std::to_string(RATE_LIMIT_RETRY_COUNT) + ")");
-    std::this_thread::sleep_for(
-        std::chrono::seconds(RATE_LIMIT_RETRY_DELAY_SECONDS));
+    std::this_thread::sleep_for(std::chrono::seconds(delay_seconds));
   }
 
   return QDMI_ERROR_FATAL;

--- a/test/unit/test_curl_http_client.cpp
+++ b/test/unit/test_curl_http_client.cpp
@@ -231,10 +231,10 @@ TEST(CurlHttpClientTest, RetriesHttp429UntilSuccess) {
 TEST(CurlHttpClientTest, RetriesExhaustedForHttp429ReturnInvalidArgument) {
   const LoggerCapture logger_capture;
   const auto result = iqm::test_support::Retry_response_codes_for_testing(
-      {429, 429, 429, 429}, "https://example.test/jobs", false);
+      {429, 429, 429, 429, 429, 429}, "https://example.test/jobs", false);
 
   EXPECT_EQ(result.status_code, QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(result.sleep_call_count, 3U);
+  EXPECT_EQ(result.sleep_call_count, 5U);
 
   const auto logs = logger_capture.str();
   EXPECT_NE(logs.find("failed with HTTP 429 (Client Error)"),


### PR DESCRIPTION
For some reason we are hitting more and more rate limits despite the initial retry logic.
Adding an exponential backoff and increasing the retries to 5.