### PR TITLE
✨ Expose the current calibration set ID as a device property via `QDMI_DEVICE_PROPERTY_CUSTOM1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Added
 
+- ✨ Expose the current calibration set ID as a device property via `QDMI_DEVICE_PROPERTY_CUSTOM1` ([#108]) ([**@burgholzer**])
 - ✨ Add `iqm-sampler` and `iqm-estimator` CLI entrypoints leveraging `IQMBackend`'s primitives ([#92]) ([**@marcelwa**])
 - ✨ Implement Slurm SPANK plugin for injecting IQM environment variables and session parameters into Slurm jobs ([#74]) ([**@marcelwa**])
 - ✨ Support environment variable fallbacks (`IQM_BASE_URL`, `IQM_QC_ID`, and `IQM_QC_ALIAS`) for session initialization ([#74]) ([**@marcelwa**])
@@ -65,6 +66,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#108]: https://github.com/iqm-finland/QDMI-on-IQM/pull/108
 [#107]: https://github.com/iqm-finland/QDMI-on-IQM/pull/107
 [#92]: https://github.com/iqm-finland/QDMI-on-IQM/pull/92
 [#78]: https://github.com/iqm-finland/QDMI-on-IQM/pull/78

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,6 +189,7 @@ The following properties about the device can be queried via the {cpp:func}`IQM_
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_SITES`: The list of available qubit sites on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_OPERATIONS`: The list of available calibrated operations on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_COUPLINGMAP`: The coupling map between qubits on the device.
+- {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_CUSTOM1`: The current calibration set ID used by the session.
 
 The following properties about every site (qubit) can be queried via the {cpp:func}`IQM_QDMI_device_session_query_site_property` function:
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1730,6 +1730,10 @@ int IQM_QDMI_device_session_query_device_property(
                       QDMI_Program_Format, SUPPORTED_PROGRAM_FORMATS, prop,
                       size, value, size_ret)
   }
+  // Custom device property 1 exposes the current calibration set ID.
+  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_CUSTOM1,
+                      session->calibration_set_id_.c_str(), prop, size, value,
+                      size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 }
 

--- a/test/fomac/fomac.cpp
+++ b/test/fomac/fomac.cpp
@@ -272,6 +272,19 @@ auto FoMaC::get_duration_scale_factor() const -> double {
   return scale_factor;
 }
 
+auto FoMaC::get_calibration_set_id() const -> std::string {
+  size_t size = 0;
+  const int ret = IQM_QDMI_device_session_query_device_property(
+      session_, QDMI_DEVICE_PROPERTY_CUSTOM1, 0, nullptr, &size);
+  throw_if_error(ret, "Failed to query the calibration set ID size");
+  std::string calibration_set_id(size - 1, '\0');
+  const int ret2 = IQM_QDMI_device_session_query_device_property(
+      session_, QDMI_DEVICE_PROPERTY_CUSTOM1, size, calibration_set_id.data(),
+      nullptr);
+  throw_if_error(ret2, "Failed to query the calibration set ID");
+  return calibration_set_id;
+}
+
 auto FoMaC::get_site_index(IQM_QDMI_Site site) const -> uint64_t {
   uint64_t site_id = 0;
   const int ret = IQM_QDMI_device_session_query_site_property(
@@ -562,7 +575,6 @@ auto FoMaC::get_histogram(IQM_QDMI_Device_Job job)
   }
   return results;
 }
-
 auto FoMaC::get_calibration_set_id(IQM_QDMI_Device_Job job) -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_CUSTOM1,

--- a/test/fomac/fomac.hpp
+++ b/test/fomac/fomac.hpp
@@ -72,6 +72,8 @@ public:
 
   [[nodiscard]] auto get_duration_scale_factor() const -> double;
 
+  [[nodiscard]] auto get_calibration_set_id() const -> std::string;
+
   [[nodiscard]] auto get_site_index(IQM_QDMI_Site site) const -> uint64_t;
 
   [[nodiscard]] auto get_site_t1(IQM_QDMI_Site site) const -> uint64_t;

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -378,15 +378,20 @@ TEST_F(QDMIIntegrationTest, QueryDeviceProperties) {
   const auto duration_scale_factor = fomac.get_duration_scale_factor();
   ASSERT_GT(duration_scale_factor, 0.0);
 
+  const auto calibration_set_id = fomac.get_calibration_set_id();
+  ASSERT_FALSE(calibration_set_id.empty())
+      << "Device must provide a calibration set ID";
+
   // The MAX property is not a valid value for any device.
   EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
                 session, QDMI_DEVICE_PROPERTY_MAX, 0, nullptr, nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
 
-  // The IQM device does not support custom properties for sites.
+  // Custom property 1 exposes the calibration set ID.
   EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
                 session, QDMI_DEVICE_PROPERTY_CUSTOM1, 0, nullptr, nullptr),
-            QDMI_ERROR_NOTSUPPORTED);
+            QDMI_SUCCESS);
+  // The IQM device does not support the remaining custom device properties.
   EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
                 session, QDMI_DEVICE_PROPERTY_CUSTOM2, 0, nullptr, nullptr),
             QDMI_ERROR_NOTSUPPORTED);


### PR DESCRIPTION
This PR exposes the currently tracked calibration set id as a QDMI device property.
This may be helpful for bookkeeping reasons.