### PR TITLE
🐛 Actually block job launch on validation failure in SPANK plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Fix the SPANK plugin silently launching jobs despite failed validation
+  (missing `IQM_BASE_URL` or conflicting auth), since `ESPANK_ERROR` is a
+  positive value and Slurm's task launcher only aborts on a negative hook return
+  ([#117]) ([**@marcelwa**])
 - 🩹 Ensure the QDMI device can handle devices with computational resonators
   ([#107]) ([**@burgholzer**])
 
@@ -89,6 +93,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#117]: https://github.com/iqm-finland/QDMI-on-IQM/pull/117
 [#108]: https://github.com/iqm-finland/QDMI-on-IQM/pull/108
 [#107]: https://github.com/iqm-finland/QDMI-on-IQM/pull/107
 [#105]: https://github.com/iqm-finland/QDMI-on-IQM/pull/105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,12 @@ releases may include breaking changes.
 - ✨ Add `iqm-sampler` and `iqm-estimator` CLI entrypoints leveraging
   `IQMBackend`'s primitives ([#92]) ([**@marcelwa**])
 - ✨ Implement Slurm SPANK plugin for injecting IQM environment variables and
-  session parameters into Slurm jobs ([#74]) ([**@marcelwa**])
+  session parameters into Slurm jobs ([#74], [#117]) ([**@marcelwa**])
 - ✨ Support environment variable fallbacks (`IQM_BASE_URL`, `IQM_QC_ID`, and
   `IQM_QC_ALIAS`) for session initialization ([#74]) ([**@marcelwa**])
 
 ### Fixed
 
-- 🐛 Fix the SPANK plugin silently launching jobs despite failed validation
-  (missing `IQM_BASE_URL` or conflicting auth), since `ESPANK_ERROR` is a
-  positive value and Slurm's task launcher only aborts on a negative hook return
-  ([#117]) ([**@marcelwa**])
 - 🩹 Ensure the QDMI device can handle devices with computational resonators
   ([#107]) ([**@burgholzer**])
 

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -597,7 +597,15 @@ int slurm_spank_init_post_opt(spank_t /* spank */, const int /* ac */,
  * Injects IQM environment variables into the job environment and performs
  * validation of the resulting configuration.
  *
- * @return `ESPANK_SUCCESS` on success, otherwise `ESPANK_ERROR`.
+ * Slurm-ABI note: slurmstepd (`task.c`, `spank_user_task(...) < 0`) only
+ * treats a *negative* return from this specific hook as fatal — it does
+ * NOT check for nonzero. `ESPANK_ERROR` is `+3000` (see
+ * `slurm/slurm_errno.h`), so returning it directly here would only log
+ * "task_init() failed with rc=3000" and let the task launch anyway. This
+ * wrapper therefore translates any internal validation failure to a plain
+ * `-1` before returning, so a `required` plugin actually blocks the task.
+ *
+ * @return `ESPANK_SUCCESS` on success, `-1` if validation failed.
  */
 int slurm_spank_task_init(spank_t spank, const int /* ac */, char ** /* av */) {
   Emit_hook_log("slurm_spank_task_init");
@@ -609,7 +617,7 @@ int slurm_spank_task_init(spank_t spank, const int /* ac */, char ** /* av */) {
 
   if (const auto rc = g_config.inject_environment(spank);
       rc != ESPANK_SUCCESS) {
-    return rc;
+    return -1;
   }
 
   const auto validation_rc = IQMSpankConfigManager::validate_environment(spank);
@@ -620,7 +628,10 @@ int slurm_spank_task_init(spank_t spank, const int /* ac */, char ** /* av */) {
   // Structured diagnostic summary.
   IQMSpankConfigManager::emit_diagnostics(spank);
 
-  return validation_rc;
+  if (validation_rc != ESPANK_SUCCESS) {
+    return -1;
+  }
+  return ESPANK_SUCCESS;
 }
 
 /**


### PR DESCRIPTION
## Summary

Split out of #114 at [@burgholzer's request](https://github.com/iqm-finland/QDMI-on-IQM/pull/114#issuecomment-3346103524), so this pre-existing bugfix can land independently of the Slurm license capacity-limiting feature.

`slurm_spank_task_init()` returned `ESPANK_ERROR` directly on validation failure, but `ESPANK_ERROR` is `+3000` and slurmstepd's task-init hook (`task.c`, `spank_user_task(...) < 0`) only treats a *negative* return as fatal. As a result, jobs with invalid IQM configuration (missing `IQM_BASE_URL` or conflicting `IQM_TOKEN`/`IQM_TOKENS_FILE`) were logged as errors but launched anyway instead of being blocked.

This PR translates any internal validation failure to a plain `-1` before returning from the hook, so a `required` plugin actually blocks the task launch as intended.