### PR TITLE
🐛 Fix inverted allowed-skips condition for python-linter/examples in CI Check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -217,11 +217,11 @@ jobs:
               && 'cpp-linter,' || ''
             }}
             ${{
-              fromJSON(needs.change-detection.outputs.run-python-tests)
+              !fromJSON(needs.change-detection.outputs.run-python-tests)
               && 'examples,' || ''
             }}
             ${{
-              fromJSON(needs.change-detection.outputs.run-python-linter)
+              !fromJSON(needs.change-detection.outputs.run-python-linter)
               && 'python-linter,' || ''
             }}
             ${{


### PR DESCRIPTION
## Summary

The `required-checks-pass` ("🚦 Check") job's `allowed-skips` computation is missing a `!` negation on the `run-python-tests`/`run-python-linter` conditions:

```yaml
${{
  fromJSON(needs.change-detection.outputs.run-python-tests)
  && 'examples,' || ''
}}
${{
  fromJSON(needs.change-detection.outputs.run-python-linter)
  && 'python-linter,' || ''
}}
```

Every sibling condition in the same block (`cpp-tests`, `cpp-linter`, `build-sdist`/`build-wheel`, `spank-tests`) correctly negates the change-detection output before deciding what's allowed to skip. These two don't, so when a PR doesn't touch Python files, `python-linter` and `examples` are (correctly) skipped by change-detection, but never added to `allowed-skips` — and the required "Check" job fails even though every actual job passed.

This is currently blocking #116 and #117, and will block any future PR that doesn't touch Python.