### PR TITLE
⬆️ Update `mqt-core` to version 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⬆️ Update `mqt-core` to version 3.7.0 ([#120]) ([**@denialhaag**])
+- ⬆️ Update QDMI to version 1.3.2 ([#120]) ([**@denialhaag**])
 - ♻️ Rewrite the C++ HTTP client to use [cpr] instead of direct `libcurl` calls
   ([#105]) ([**@marcelwa**])
 - ♻️ Considerably simplify the internal HTTP client implementation ([#105])
@@ -89,6 +91,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#120]: https://github.com/iqm-finland/QDMI-on-IQM/pull/120
 [#117]: https://github.com/iqm-finland/QDMI-on-IQM/pull/117
 [#108]: https://github.com/iqm-finland/QDMI-on-IQM/pull/108
 [#107]: https://github.com/iqm-finland/QDMI-on-IQM/pull/107

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -23,9 +23,11 @@ if(TARGET qdmi::qdmi)
 else()
   message(STATUS "QDMI will be included via FetchContent")
   # cmake-format: off
-  set(QDMI_VERSION 1.3.0
+  set(QDMI_MINIMUM_VERSION 1.3.0
+      CACHE STRING "Minimum QDMI version")
+  set(QDMI_VERSION 1.3.2
       CACHE STRING "QDMI version")
-  set(QDMI_REV "0f7e08c58b72800d1022a01cfb618af67b9a9c30" # v1.3.0
+  set(QDMI_REV "d05a0b418f42e54e9585d2e00af8ce23e745fd83" # v1.3.2
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")
@@ -37,7 +39,7 @@ else()
     qdmi
     GIT_REPOSITORY https://github.com/${QDMI_REPO_OWNER}/qdmi.git
     GIT_TAG ${QDMI_REV}
-    FIND_PACKAGE_ARGS ${QDMI_VERSION})
+    FIND_PACKAGE_ARGS ${QDMI_MINIMUM_VERSION})
   list(APPEND FETCH_PACKAGES qdmi)
 endif()
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,7 +11,7 @@ These dependencies are linked into the shared library and
 
 | Dependency      | Version | License                        | Purpose                                                    |
 | :-------------- | :------ | :----------------------------- | :--------------------------------------------------------- |
-| [QDMI]          | 1.3.0   | Apache-2.0 with LLVM-exception | QDMI specification and interface headers                   |
+| [QDMI]          | 1.3.2   | Apache-2.0 with LLVM-exception | QDMI specification and interface headers                   |
 | [nlohmann/json] | 3.12.0  | MIT License                    | JSON parsing and serialization                             |
 | [CPR]           | 1.14.2  | MIT License                    | C++ Requests HTTP client library for backend communication |
 
@@ -110,7 +110,6 @@ Used for local development workflows, **not shipped** in any binary or wheel.
 | Dependency | Version    | License     | Purpose                                                          |
 | :--------- | :--------- | :---------- | :--------------------------------------------------------------- |
 | [nox]      | ≥2026.4.10 | Apache-2.0  | Session runner for tests, linting, docs, packaging, and examples |
-| [ty]       | ==0.0.35   | MIT License | Static type checking                                             |
 
 [Breathe]: https://github.com/breathe-doc/breathe
 [CPR]: https://github.com/libcpr/cpr
@@ -135,4 +134,3 @@ Used for local development workflows, **not shipped** in any binary or wheel.
 [Sphinx AutoAPI]: https://github.com/readthedocs/sphinx-autoapi
 [Sphinx Copybutton]: https://github.com/executablebooks/sphinx-copybutton
 [Sphinx Design]: https://github.com/executablebooks/sphinx-design
-[ty]: https://github.com/astral-sh/ty

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,7 +43,7 @@ These are installed when users request the `qiskit` extra via
 
 | Dependency | Version | License     | Purpose                                                                  |
 | :--------- | :------ | :---------- | :----------------------------------------------------------------------- |
-| [MQT Core] | ~=3.6.1 | MIT License | QDMI-aware Qiskit provider, backend, sampler, and estimator integrations |
+| [MQT Core] | ~=3.7.0 | MIT License | QDMI-aware Qiskit provider, backend, sampler, and estimator integrations |
 | [Qiskit]   | ≥1.1    | Apache-2.0  | Quantum circuit construction, transpilation, and primitive interfaces    |
 
 ## End-to-End Example Dependencies

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -107,9 +107,9 @@ under the project's own license terms.
 
 Used for local development workflows, **not shipped** in any binary or wheel.
 
-| Dependency | Version    | License     | Purpose                                                          |
-| :--------- | :--------- | :---------- | :--------------------------------------------------------------- |
-| [nox]      | ≥2026.4.10 | Apache-2.0  | Session runner for tests, linting, docs, packaging, and examples |
+| Dependency | Version    | License    | Purpose                                                          |
+| :--------- | :--------- | :--------- | :--------------------------------------------------------------- |
+| [nox]      | ≥2026.4.10 | Apache-2.0 | Session runner for tests, linting, docs, packaging, and examples |
 
 [Breathe]: https://github.com/breathe-doc/breathe
 [CPR]: https://github.com/libcpr/cpr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 
 [project.optional-dependencies]
 qiskit = [
-  "mqt-core~=3.6.1",
+  "mqt-core~=3.7.0",
   "qiskit[qasm3-import]>=1.1",
   "qiskit-algorithms>=0.4.0"
 ]
@@ -62,7 +62,7 @@ iqm-estimator = "iqm.qdmi.estimator:main"
 
 [dependency-groups]
 qiskit = [
-  "mqt-core~=3.6.1",
+  "mqt-core~=3.7.0",
   "qiskit[qasm3-import]>=1.1",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -892,7 +892,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.6.1" },
+    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.7.0" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1" },
     { name = "qiskit-algorithms", marker = "extra == 'qiskit'", specifier = ">=0.4.0" },
 ]
@@ -900,7 +900,7 @@ provides-extras = ["qiskit"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mqt-core", specifier = "~=3.6.1" },
+    { name = "mqt-core", specifier = "~=3.7.0" },
     { name = "nox", specifier = ">=2026.4.10" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
@@ -922,14 +922,14 @@ docs = [
     { name = "sphinx-design", specifier = ">=0.6.1" },
 ]
 qiskit = [
-    { name = "mqt-core", specifier = "~=3.6.1" },
+    { name = "mqt-core", specifier = "~=3.7.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "mqt-core", specifier = "~=3.6.1" },
+    { name = "mqt-core", specifier = "~=3.7.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
@@ -1196,34 +1196,34 @@ wheels = [
 
 [[package]]
 name = "mqt-core"
-version = "3.6.1"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/95/e1429f163a477845785a71d6dea92dfa1675d5228c1a01135f38340436ed/mqt_core-3.6.1.tar.gz", hash = "sha256:ce26f34bc0a363a795c8f95a2aa19341104b2961f3a2a4e2a19e2229e9e7dcd5", size = 655317, upload-time = "2026-05-20T00:34:36.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/e9/a9bde84ad0b9e4f3d142bf5d211859101348cc96c18f9cec5e45e1069ad0/mqt_core-3.7.0.tar.gz", hash = "sha256:b6dad03018624bbe44f0eeaf5bc8f4a8f9ccc241f08a70be6983f2f51fd8ea59", size = 680151, upload-time = "2026-07-08T23:23:54.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/e0/3e362a11e4103dd4c456f381daad92c5f18a6c467426999f58c480ba2cd6/mqt_core-3.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:79de9549084ca6b107153b9fbab5987354a50c5ce692930b40679a4416f74c6c", size = 5180469, upload-time = "2026-05-20T00:33:52.936Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ea/2d5529b1d6983f5f20ba5e095a4a2476348c5faee92cbba847a69a8a48e9/mqt_core-3.6.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:a5e1c7f5f2522471700e908c8e2dc1963c1458e952a6814f021e0ed13724035d", size = 5671256, upload-time = "2026-05-20T00:33:55.019Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ac/1cb831f10d1be99114c8df214ff96bab3ffdc9913f4494984ce3398e5f5a/mqt_core-3.6.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87d93dd7a1f2a45083facc5e376b40e5c4306703eb5af56f9381678244226061", size = 6693517, upload-time = "2026-05-20T00:33:57.005Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/66/971c7c7e5f570899fbaed56b43523698faa0b46c575e9be114fd6a7c7eca/mqt_core-3.6.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:181b62397c04f30f4b482bfb588b1e08ea21d8ca6a78a94d45c8170d3dd0ade4", size = 7128865, upload-time = "2026-05-20T00:33:58.732Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/66776318b8399d3ee0e995cc5415b17e3b86d0debcc8f2b94054a35fd550/mqt_core-3.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:1275e6be9f4198ffa16df06443df081ffa0d9016edd5bc22f2e5fb6866d692d1", size = 4046804, upload-time = "2026-05-20T00:34:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/67/fdc2331352e35d938b276416008be7ffc0178eb66276b1445bc3a3767897/mqt_core-3.6.1-cp310-cp310-win_arm64.whl", hash = "sha256:74d03c9782cd2be1a7dc9f35a06815faf924caf9cf6572da815bfb59425f2c56", size = 7936592, upload-time = "2026-05-20T00:34:02.329Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b0/a5a7450a9ffaff0ae8de49f65cd24c63901e3fee3dc740584c09b046165c/mqt_core-3.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27b80e793f27a963417cc06da908a31f51fae07722a20cdb5b32edd8e0276be1", size = 5181464, upload-time = "2026-05-20T00:34:04.102Z" },
-    { url = "https://files.pythonhosted.org/packages/75/3d/9409c8f111c119722a8909bbfc92a7a3d8e4377e058ccfe62a46bf61ac09/mqt_core-3.6.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:2eae0ed0d4233749a8831bbeb32948da4031566acb742212b3681ed208289159", size = 5672582, upload-time = "2026-05-20T00:34:05.8Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/dc/ba457c6db680a6e9aa84895bb25da826f03fb6454cfbd496a6c0ece3a9da/mqt_core-3.6.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bb184b52c318b3b9d5db97fa006120cbe683a8fa9cd80790bf24b67489cd204", size = 6694132, upload-time = "2026-05-20T00:34:07.64Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f9/3cc61de4fab97611c89d5977156ead60eb48c2721b8d4126d0ff1704e73c/mqt_core-3.6.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5c1b9750fa3e8447fd1bfd92b599688d3dc8574d3e70d1264c9a40b1b7be94", size = 7129376, upload-time = "2026-05-20T00:34:09.454Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b5/80713df591091312e3801a5ecb84bf93c2996dfb0dbd9a912973ed3adc9c/mqt_core-3.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:9d607b34f571500dbf0fb1ecb5f5ef95139dc32d57461a1cd0614387af778e75", size = 4047971, upload-time = "2026-05-20T00:34:11.097Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7e/e9ace3e69c3613f5e1b73e5497cc94c451c259ab66fc3fda077f908ffc32/mqt_core-3.6.1-cp311-cp311-win_arm64.whl", hash = "sha256:8520f7cfa3b5e7465555fe06c3c1c17c194cfca92a06ac3f1bdf3c7660c1ef88", size = 7937030, upload-time = "2026-05-20T00:34:12.761Z" },
-    { url = "https://files.pythonhosted.org/packages/77/c1/423abe9632f79a8174d87b0b3f60d08d8e033e5c947c1a35e8cf7f4b4b33/mqt_core-3.6.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:8136975d84f3ad721a01e4461dbd15e8ae00630e8cf8ca000e247c68d44b32cc", size = 5177324, upload-time = "2026-05-20T00:34:14.518Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/45/c2af228132100238121b256c84172acaaba3c4f68b45b0fcfab2a7684910/mqt_core-3.6.1-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ee0433a5f4a22e6542e86558e29665219415aad730f699c555743d8fbd38a110", size = 5668253, upload-time = "2026-05-20T00:34:16.491Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c1/1e4596f76d52e56b96849575795be5132320c7fa39df1dd83e1eff9f7d4a/mqt_core-3.6.1-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7ff7726627bfe4e779fa74397b89d9e686543a99ea2132d588aee7da6ecc89d", size = 6679218, upload-time = "2026-05-20T00:34:18.481Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/df/de19e1e6f9f2b0cfdca08af28ff033a883a1995185724de8812728d45f3f/mqt_core-3.6.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cf804ce909a7f9301759cfbc83b0d7dd6234752504f24185a39f616078bfb", size = 7112143, upload-time = "2026-05-20T00:34:19.967Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e4/8d18330770afe008a5f26598e5b8025404d3adab04d8fe3e590576fd31aa/mqt_core-3.6.1-cp312-abi3-win_amd64.whl", hash = "sha256:ef594511df7596c23c61d96adf8d3f805ee81aa1afb52fc589d19b2b036d88fc", size = 4040427, upload-time = "2026-05-20T00:34:22.237Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1c/5f054d1c0a1f3be73135bcb324ff5c1ef1312fa2d94c78a88b7e264dec0d/mqt_core-3.6.1-cp312-abi3-win_arm64.whl", hash = "sha256:9ed5a594426937520bc2b3c8f92a5a52cb37df8a9d55661e1a6d8ec37d169b39", size = 7929919, upload-time = "2026-05-20T00:34:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/12/f50cadbb52bda38a4d727a90d5542c64078da8b5f0f18f36938e41877bd1/mqt_core-3.6.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c103a008405f4b554ee7bf092cd26a7d46cf7425c5ca8fa9b0a2e0004c4d8fa9", size = 5190293, upload-time = "2026-05-20T00:34:25.703Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0f/53b37b867d077124e30907bc520a80ceab0ca045f7687ea3aac301eebbab/mqt_core-3.6.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:0ef1c62495ed4b110f3bce89dcf0a21a1353f64010cccc1ec71a50ce0cdea26e", size = 5682141, upload-time = "2026-05-20T00:34:27.394Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/ce/3bb8f5f64897fc1d70d637097098c1ada7abf579a93f8d66e392a3eb5e18/mqt_core-3.6.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7459aae9b2d80be7b32e3317d3fb86f5f5977b27c149de1e6d68c67d4c80b71", size = 6699266, upload-time = "2026-05-20T00:34:29.069Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9f/87088625f8d5426caf4a66bcc288e1833999c5dd3e9718604117821b25ec/mqt_core-3.6.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e4183e8ec739087e5f94319bfb054318b184d6fdaab2bca5207745ff89dae09", size = 7129965, upload-time = "2026-05-20T00:34:31.213Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/b7/4b9b70f914add8961fb736008618ea28f93b5acdba19878fde7d9fd4f30a/mqt_core-3.6.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c7a2bdc0ff010672501cfc5735a547d9b15cab4f1604a78c687b69924ab25f", size = 4133733, upload-time = "2026-05-20T00:34:32.79Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/5d/4e1e3e2ea7cab9d093a865c0e2b3de0729257e4eaff8abcd654503e43aa7/mqt_core-3.6.1-cp314-cp314t-win_arm64.whl", hash = "sha256:31df5b87f5afc09bbe3f815df434f0306a56b952b4f5dc2599e4d53625031b09", size = 8008654, upload-time = "2026-05-20T00:34:34.446Z" },
+    { url = "https://files.pythonhosted.org/packages/63/28/b564c030d05327be870105de61e1d5c053351fc48ca1a758514708026819/mqt_core-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5c214906f6c44501f44d68735600dcaf9bef03ab82e8c28a1ec3598341a77a7d", size = 5219987, upload-time = "2026-07-08T23:23:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/20/6ce443751548b82d9c0bd46d28fed0ceba8760c0fffa8339a56756057b56/mqt_core-3.7.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:f035ebe4aaa5cd157299deb931346685fda7155ed766f34f549a4e29968f889b", size = 5691688, upload-time = "2026-07-08T23:23:11.986Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/07/9da691977f7c4f3dcbfe2acb66c6f71049c39c4eae676dbac76fba8668ba/mqt_core-3.7.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2de1a664b41eb59df7e422b491150e916a75e6bc8d74b1bfafeb2878d980af7", size = 6715927, upload-time = "2026-07-08T23:23:13.648Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/36/f9121569c19709478e66bfd7b76ae6d01cbd959a4cfec0e6e32b6983bdec/mqt_core-3.7.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd537702e9ae4f0dbfa519808baec049230523c364adbb84b57e432800b60dad", size = 7152081, upload-time = "2026-07-08T23:23:15.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/da4deeb4137c751eab7e304bb97b37610098ff72f6de5046c82ee9ac3b82/mqt_core-3.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:f30c4cb95555e20fea57d9ea96cc96279e44d3f7a4490cb62d20c9e375c72cad", size = 8066357, upload-time = "2026-07-08T23:23:17.153Z" },
+    { url = "https://files.pythonhosted.org/packages/55/52/166a3f17ae01e3767405a064dbbf21a4b70f1b668787ba7abdb17ca8fd7f/mqt_core-3.7.0-cp310-cp310-win_arm64.whl", hash = "sha256:99a546f8f653b23f1a16fc202f3cad588f70eb3c2ce581923e4da48ed3caa367", size = 7951308, upload-time = "2026-07-08T23:23:19.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7c/b3f8595a59011951c63891dc7930fd70dd64dc438da99b5c054937c429f7/mqt_core-3.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d101ddac7e704c1f2a18591be0ba05fd148df4de3be03327cc2e78e2f9be8fed", size = 5219815, upload-time = "2026-07-08T23:23:21.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7a/c1a5c5e4581442d34169b3318e85232682414af130f0b7c9a6a96be9895e/mqt_core-3.7.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:2cc1cb0cdc83cc352fec6fee71df9ed3c30c2cbdf163e0af59a3835f53eb11c4", size = 5691518, upload-time = "2026-07-08T23:23:23.678Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/97/dfa55943fd05d1c4b2a061db17b297d64a473d319b5abc0c38dd6eea9a87/mqt_core-3.7.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9058762975f8fd09b33453d56e2e81dcaf9f27635f15e97fb429b6780d206c6", size = 6715504, upload-time = "2026-07-08T23:23:25.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fa/2252535dae7358324fac83267619017583011f000944b99fb3b35fbc78a4/mqt_core-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3335998c93a601ef17672df239ff3e59ad4f0ba646f0576007c9e64483937b8a", size = 7151936, upload-time = "2026-07-08T23:23:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c6/60e2b6d3336e7b9d530864a82a401cde4c79e1863894603dba706cefa43a/mqt_core-3.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7aff40d8043fb009ea7f36d160651891dc163c5813eca19cbfd6bba0333301b2", size = 8066529, upload-time = "2026-07-08T23:23:29.04Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5d/9404802663938bea4564ca4e69e88b18e6988f1c4f11d117658922535255/mqt_core-3.7.0-cp311-cp311-win_arm64.whl", hash = "sha256:e331f150cd435858c51d72891e25e3e920c910d09dde08fd0f8341382a3bbf6a", size = 7951129, upload-time = "2026-07-08T23:23:30.856Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/6f/e5a9c767ea006416a309644a461130ca662d9e826e33e1e35da1d2fd4d3b/mqt_core-3.7.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e0af92724e3cb331d88db7e1c4c4fce6296520603be694f86c8f74adb6620f2", size = 5211763, upload-time = "2026-07-08T23:23:32.605Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e3/d5ac6f0db322fadf8ed2b1af9e726d748d1840750c3460f61e6d1948d3e3/mqt_core-3.7.0-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:42a09e718ff9e801cd29422ec4e6bb5a39a923e9159b995647b9745f74fc5194", size = 5685492, upload-time = "2026-07-08T23:23:34.261Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3c/ebf28553eb37b86368c4046963e8e2e4a2f0612a63072689579700236215/mqt_core-3.7.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc27f85c8c8d700b7d53c1b2c6cb52ab12d8ae61f37a0b2c3999791af564b8b9", size = 6699042, upload-time = "2026-07-08T23:23:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/43/23/599c8192073b6891ec829ac44237d39843a9d6007da10e51a00a607a3aa5/mqt_core-3.7.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:baeda0bc20303948dfb27ae4f815fc66577f2c615c3f46ea9f4aca14e53619ff", size = 7133398, upload-time = "2026-07-08T23:23:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/30/08/f737a9aa6b795e095e8ad6621b352b12c83d5a6543c35fc57969222f029e/mqt_core-3.7.0-cp312-abi3-win_amd64.whl", hash = "sha256:eaaf3e4ec1bdb6df7325fd305cd47eb3607f4619d0702a56519fb4be93fd1459", size = 8057646, upload-time = "2026-07-08T23:23:39.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a1/2571eb9fc0fa9eff770d32435fbe95cb23b9505ff225ac27e8b1a5a1bed3/mqt_core-3.7.0-cp312-abi3-win_arm64.whl", hash = "sha256:70bdf26447fe42f033383646afdf98bbebfd319f917102dbc4a6b7d9809ba3d1", size = 7939316, upload-time = "2026-07-08T23:23:41.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f0/e0584f77b3474c1cb616adae56f4afd0552145812dd31dab48054e575ab4/mqt_core-3.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db344b721a6e8c3bedfe398b6a561fe8cb63d21ec7cf9142e58f3608b211deb8", size = 5226079, upload-time = "2026-07-08T23:23:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ca9c24007c5b62475e1c50a5061215037e129fa70aa51fe2e73623760559/mqt_core-3.7.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:94b3ba6177ed0d7d3c012c9b590ad41a74386ab267fd6fe307769d6572943387", size = 5701134, upload-time = "2026-07-08T23:23:44.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/7a/eb8dd41c3783bd7072abb59db0077bfe7bd385e320e9c1035aa6ac218752/mqt_core-3.7.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b7352f1fe76cbd3150586a30ed9e3aa5257cc96596a4bd602b40cbe797340eb", size = 6718109, upload-time = "2026-07-08T23:23:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1b/c800230ba42b7e658e65e359bf18fd2a51532da14e89331256a466c2e9cf/mqt_core-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eab167445b041b258120b2a8b9a776334f185cb6108dce1c49985530b78aba19", size = 7152032, upload-time = "2026-07-08T23:23:48.943Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fd/673c808e77eb808c3f980af928f1db42a3cc189f32bb83286c56bfe77792/mqt_core-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3c6734d51a54490d16de9f45a5bdd05bcbdc1ebf83f08cbca042add9e43c5594", size = 8127355, upload-time = "2026-07-08T23:23:50.793Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1e/ef910579560991fa0a69c0c7d6d17d1e3e2e3ba66f7cf17bc96cb25ad0dd/mqt_core-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e95d30b2aa9afb3ea03f8c4ce31058f11f0b8c3069df4ea7082b84e15a363edd", size = 8019397, upload-time = "2026-07-08T23:23:52.713Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates `mqt-core` to version 3.7.0 and QDMI to version 1.3.2.