### PR TITLE
🩹 Time out cleanly and fail clearly on empty results in the offloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
-  `estimate` functions for Slurm job submissions ([#104]) ([**@marcelwa**])
+  `estimate` functions for Slurm job submissions ([#104], [#130])
+  ([**@marcelwa**])
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114]) ([**@marcelwa**])
@@ -112,6 +113,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#130]: https://github.com/iqm-finland/QDMI-on-IQM/pull/130
 [#122]: https://github.com/iqm-finland/QDMI-on-IQM/pull/122
 [#120]: https://github.com/iqm-finland/QDMI-on-IQM/pull/120
 [#117]: https://github.com/iqm-finland/QDMI-on-IQM/pull/117

--- a/python/iqm/qdmi/estimator.py
+++ b/python/iqm/qdmi/estimator.py
@@ -50,7 +50,6 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("circuit", type=str, help="Path to the QPY circuit file.")
     parser.add_argument("observable", type=str, help="Path to the serialized observable file.")
     parser.add_argument("--maxiter", type=int, required=True, help="Maximum number of iterations.")
-    parser.add_argument("--timeout", type=int, help="Timeout passed to the IQM Backend in seconds.", default=300)
     parser.add_argument("--simulator", action="store_true", help="Use the simulator instead of the actual backend.")
     parser.add_argument("--base-url", type=str, dest="base_url", help="IQM server base URL.", default=None)
     parser.add_argument("--tokens-file", type=str, help="IQM tokens file for authentication.", default=None)

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -101,6 +101,22 @@ def extract_counts(pub_result: PubResult) -> dict[str, int]:
     raise RuntimeError(msg)
 
 
+def _first_pub(primitive_result: Iterable[PubResult]) -> PubResult:
+    """Return the first pub result from a primitive result.
+
+    Returns:
+        The first pub result.
+
+    Raises:
+        RuntimeError: If the primitive result contains no pubs.
+    """
+    first_pub = next(iter(primitive_result), None)
+    if first_pub is None:
+        msg = "Primitive result contained no pubs."
+        raise RuntimeError(msg)
+    return first_pub
+
+
 def _get_jobs_dir() -> Path:
     """Get the jobs directory path.
 
@@ -227,7 +243,7 @@ def sample(
         backend, sampler = build_sampler(simulator=simulator)
         qc_for_execution = transpile(qc, backend, optimization_level=TRANSPILE_OPTIMIZATION_LEVEL)
         job = sampler.run([(qc_for_execution,)], shots=shots)
-        first_pub = next(iter(job.result()))
+        first_pub = _first_pub(cast("Iterable[PubResult]", job.result()))
         return extract_counts(first_pub)
 
     # Make sure the `jobs` directory exists on the shared filesystem
@@ -265,7 +281,7 @@ def sample(
 
     payload = _decode_payload(process)
     primitive_result = cast("Iterable[PubResult]", _load_pickled_result(payload))
-    first_pub = next(iter(primitive_result))
+    first_pub = _first_pub(primitive_result)
     return extract_counts(first_pub)
 
 

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -147,7 +147,12 @@ def _new_job_dir() -> Path:
     return job_dir
 
 
-def _run_srun(command: list[str], job_dir: Path) -> subprocess.CompletedProcess[bytes]:
+def _run_srun(
+    command: list[str],
+    job_dir: Path,
+    *,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[bytes]:
     """Run *command* via `srun` and return the completed process.
 
     On failure, *job_dir* (containing the serialized inputs) is intentionally
@@ -158,9 +163,14 @@ def _run_srun(command: list[str], job_dir: Path) -> subprocess.CompletedProcess[
         The completed process, with captured stdout/stderr.
 
     Raises:
-        RuntimeError: If the Slurm job returns a non-zero exit code.
+        RuntimeError: If the Slurm job times out or returns a non-zero exit
+            code.
     """
-    process = subprocess.run(command, capture_output=True, check=False)
+    try:
+        process = subprocess.run(command, capture_output=True, check=False, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        msg = f"Slurm job timed out after {timeout}s (job inputs kept at {job_dir} for debugging)"
+        raise RuntimeError(msg) from e
     if process.returncode != 0:
         stderr = process.stderr.decode().strip()
         msg = f"Error while submitting job to Slurm: {stderr} (job inputs kept at {job_dir} for debugging)"
@@ -223,8 +233,8 @@ def sample(
             If False (default), offload to Slurm.
         simulator: If True, run the job on the simulator instead of the quantum computer.
             Only used when `local=False`.
-        timeout: The timeout passed to the IQM Backend in seconds.
-            Only used when `local=False`.
+        timeout: How long to wait for the Slurm job to complete, in seconds,
+            before giving up. Only used when `local=False`.
 
     Returns:
         A dictionary of measurement counts.
@@ -269,10 +279,8 @@ def sample(
     ]
     if simulator:
         command.append("--simulator")
-    if timeout:
-        command.extend(["--timeout", str(timeout)])
 
-    process = _run_srun(command, job_dir)
+    process = _run_srun(command, job_dir, timeout=timeout)
 
     # Cleanup artifacts after successful completion.
     qc_path.unlink(missing_ok=True)
@@ -316,8 +324,8 @@ def estimate(
             If False (default), offload to Slurm.
         simulator: If True, run the job on the simulator instead of the quantum computer.
             Only used when `local=False`.
-        timeout: The timeout passed to the IQM Backend in seconds.
-            Only used when `local=False`.
+        timeout: How long to wait for the Slurm job to complete, in seconds,
+            before giving up. Only used when `local=False`.
 
     Returns:
         The VQE result, including the optimal parameters and eigenvalue.
@@ -365,10 +373,8 @@ def estimate(
     ]
     if simulator:
         command.append("--simulator")
-    if timeout:
-        command.extend(["--timeout", str(timeout)])
 
-    process = _run_srun(command, job_dir)
+    process = _run_srun(command, job_dir, timeout=timeout)
 
     # Cleanup artifacts after successful completion.
     qc_path.unlink(missing_ok=True)

--- a/python/iqm/qdmi/sampler.py
+++ b/python/iqm/qdmi/sampler.py
@@ -45,7 +45,6 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Sample a serialized QPY circuit.")
     parser.add_argument("circuit", type=str, help="Path to the QPY circuit file.")
     parser.add_argument("--shots", type=int, required=True, help="Number of shots to run the circuit.")
-    parser.add_argument("--timeout", type=int, help="Timeout passed to the IQM Backend in seconds.", default=300)
     parser.add_argument("--simulator", action="store_true", help="Use the simulator instead of the actual backend.")
     parser.add_argument("--base-url", type=str, dest="base_url", help="IQM server base URL.", default=None)
     parser.add_argument("--tokens-file", type=str, help="IQM tokens file for authentication.", default=None)

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -103,9 +103,12 @@ def test_sample_slurm_mock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
         stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
         stderr = b""
 
-    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
         assert capture_output is True
         assert check is False
+        assert timeout is None
         captured_command[:] = command
         return FakeCompletedProcess()
 
@@ -136,9 +139,12 @@ def test_estimate_slurm_mock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
         stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
         stderr = b""
 
-    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
         assert capture_output is True
         assert check is False
+        assert timeout is None
         captured_command[:] = command
         return FakeCompletedProcess()
 
@@ -168,9 +174,12 @@ def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.Mo
         stdout = b""
         stderr = b"srun: error: something went wrong"
 
-    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
         assert capture_output is True
         assert check is False
+        assert timeout is None
         assert command
         return FakeCompletedProcess()
 
@@ -187,6 +196,27 @@ def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.Mo
     job_dirs = list(tmp_path.iterdir())
     assert len(job_dirs) == 1
     assert (job_dirs[0] / "qc.qpy").exists()
+
+
+def test_sample_slurm_timeout_raises_runtime_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A Slurm job that exceeds the given timeout raises a clear RuntimeError, not a bare subprocess error."""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert capture_output is True
+        assert check is False
+        assert timeout == 5
+        raise subprocess.TimeoutExpired(cmd=command, timeout=timeout)
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        offloader.sample(circuit, shots=7, local=False, simulator=True, timeout=5)
 
 
 def test_first_pub_raises_on_empty_result() -> None:

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -187,3 +187,9 @@ def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.Mo
     job_dirs = list(tmp_path.iterdir())
     assert len(job_dirs) == 1
     assert (job_dirs[0] / "qc.qpy").exists()
+
+
+def test_first_pub_raises_on_empty_result() -> None:
+    """An empty primitive result raises a clear RuntimeError instead of a bare StopIteration."""
+    with pytest.raises(RuntimeError, match="no pubs"):
+        offloader._first_pub([])  # noqa: SLF001


### PR DESCRIPTION
🤖 *AI text below* 🤖

Now that #104 has merged, this branch has been rebased onto `main` (base already updated by GitHub); the diff is just the two commits below.

These two issues were found during adversarial review of #104's fix commits, but neither is actually related to what that PR's review comments were about, so they're split out here rather than padding out an already-large review:

- `_run_srun()` parsed and passed through a `--timeout` argument that never did anything: `IQMBackend` (and the `add_dynamic_device_library()` call it wraps) has no timeout parameter, so the value could never reach anything that used it. Repurposed it to bound the `srun` subprocess call itself, so a hung Slurm job now fails with a clear `RuntimeError` instead of blocking forever. Dropped the now-pointless `--timeout` flag from the `iqm-sampler`/`iqm-estimator` worker CLIs, since it never had any effect there.
- `sample()` extracted the first pub result via a bare `next(iter(...))`, which raises an unhelpful `StopIteration` if a job unexpectedly returns no pubs. Added a small helper that raises a `RuntimeError` explaining what happened instead.
