### PR TITLE
🐛 Fix the SPANK plugin's plugstack.conf example to a single line

### DIFF
--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -156,13 +156,11 @@ overridden by users at submission time.
 
 **`/etc/slurm/plugstack.conf.d/iqm-qdmi.conf`**
 
+The whole directive must be a single line; plugstack.conf does not support line
+continuation.
+
 ```text
-required /usr/lib/slurm/iqm-spank-plugin.so \
-    iqm_base_url=https://resonance.iqm.tech \
-    iqm_tokens_file=/etc/iqm/tokens.json \
-    partitions=quantum,debug \
-    iqm_license_prefix=iqm_qc_ \
-    iqm_require_license=1
+required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech iqm_tokens_file=/etc/iqm/tokens.json partitions=quantum,debug iqm_license_prefix=iqm_qc_ iqm_require_license=1
 ```
 
 - `iqm_base_url`: Default API endpoint.

--- a/spank/iqm-qdmi.conf.in
+++ b/spank/iqm-qdmi.conf.in
@@ -19,14 +19,8 @@
 # IQM QDMI SPANK Plugin — plugstack.conf.d drop-in configuration.
 #
 # This file is installed by CMake into the plugstack.conf.d directory.
-# To activate, uncomment the plugin line below and fill in site-specific values.
-# See the plugin README for details.
+# To activate, uncomment the plugin line below and fill in site-specific
+# values. The whole directive must stay on a single line; plugstack.conf does
+# not support line continuation. See the plugin README for details.
 
-# required @IQM_QDMI_SPANK_INSTALL_DIR@/iqm-spank-plugin.so \
-#     partitions= \
-#     iqm_base_url= \
-#     iqm_tokens_file= \
-#     iqm_qc_id= \
-#     iqm_qc_alias= \
-#     iqm_license_prefix= \
-#     iqm_require_license=
+# required @IQM_QDMI_SPANK_INSTALL_DIR@/iqm-spank-plugin.so partitions= iqm_base_url= iqm_tokens_file= iqm_qc_id= iqm_qc_alias= iqm_license_prefix= iqm_require_license=

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -18,6 +18,7 @@
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+// clang-format off
 /** @file
  * @brief Slurm SPANK plugin for IQM QDMI integration.
  *
@@ -35,13 +36,10 @@
  *   2. User-set environment variables
  *   3. plugstack.conf defaults
  *
- * Example plugstack.conf entry:
+ * Example plugstack.conf entry (the whole directive must be a single line;
+ * plugstack.conf does not support line continuation):
  * @code
- * required /usr/lib/slurm/iqm-spank-plugin.so \
- *     partitions=quantum                           \
- *     iqm_base_url=https://resonance.iqm.tech      \
- *     iqm_tokens_file=/etc/iqm/tokens.json         \
- *     iqm_qc_alias=emerald
+ * required /usr/lib/slurm/iqm-spank-plugin.so partitions=quantum iqm_base_url=https://resonance.iqm.tech iqm_tokens_file=/etc/iqm/tokens.json iqm_qc_alias=emerald
  * @endcode
  *
  * Supported plugstack arguments, srun options, and mapped env variables:
@@ -80,6 +78,7 @@
  * plugstack.conf). This check requires Slurm >= 23.02 (`SLURM_JOB_LICENSES`);
  * on older Slurm, or when the job has no alias, it is a silent no-op.
  */
+// clang-format on
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
Slurm's plugstack.conf parser doesn't support line continuation, so the multi-line, backslash-continued example shown in the SPANK plugin's doc comment, its installed plugstack.conf.d template, and docs/spank_plugin.md all produce `Invalid line. Ignoring.` errors when loaded — reproduced on a from-source Slurm 26.05.1 build, and consistent with SchedMD's own SPANK docs, which only ever show single-line directives. `spank/test/entrypoint.sh` already renders the directive correctly as a single line, so this brings the three doc/template locations in line with what the project's own test infrastructure was already doing. Also wraps the affected doc comment in `spank/iqm_spank_plugin.cpp` with `clang-format off`/`on`, since `clang-format`'s default comment reflow would otherwise wrap the single-line example back across multiple lines and reintroduce the exact bug being fixed here.

Fixes #131