### PR TITLE
:sparkles: Support selecting a specific QC via SPANK from the offloader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,10 @@ explicit intent, valid credentials, and an appropriate target.
 - MUST follow existing patterns in neighboring source and test files.
 - MUST document new user-facing behavior and update `CHANGELOG.md` for
   noteworthy user-facing changes.
+- MUST fold additions, enhancements, or bug fixes for features that are still in
+  `[Unreleased]` into the existing `[Unreleased]` `CHANGELOG.md` entry for that
+  feature (appending the PR number) rather than creating separate bullet points
+  for every minor addition to an unreleased feature.
 - MUST update `docs/examples.md` when changing an example.
 - MUST preserve the existing license header and SPDX identifier appropriate to
   the file's component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ releases may include breaking changes.
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114]) ([**@marcelwa**])
+- ✨ Add `qc_id`/`qc_alias` SPANK device-selection parameters to
+  `iqm.qdmi.offloader.sample`/`estimate` ([#133]) ([**@marcelwa**])
 
 ### Changed
 
@@ -112,6 +114,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133
 [#122]: https://github.com/iqm-finland/QDMI-on-IQM/pull/122
 [#120]: https://github.com/iqm-finland/QDMI-on-IQM/pull/120
 [#117]: https://github.com/iqm-finland/QDMI-on-IQM/pull/117

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,11 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
-  `estimate` functions for Slurm job submissions ([#104]) ([**@marcelwa**])
+  `estimate` functions (including `qc_id`/`qc_alias` SPANK device-selection
+  parameters) for Slurm job submissions ([#104], [#133]) ([**@marcelwa**])
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114]) ([**@marcelwa**])
-- ✨ Add `qc_id`/`qc_alias` SPANK device-selection parameters to
-  `iqm.qdmi.offloader.sample`/`estimate` ([#133]) ([**@marcelwa**])
 
 ### Changed
 

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -138,6 +138,15 @@ directory path is resolved as follows:
 Ensure that the jobs directory is located on a shared cluster filesystem
 accessible by both the login node and all Slurm compute nodes.
 
+### Selecting a Quantum Computer per Job
+
+Both functions accept optional `qc_id` and `qc_alias` keyword arguments to pin a
+specific quantum computer for a single job, without changing the process's
+default backend configuration. When set, they are passed as `--iqm-qc-id` and
+`--iqm-qc-alias` options on the `srun` command itself, which the QDMI-on-IQM
+[SPANK plugin](spank_plugin.md) resolves into the job's `IQM_QC_ID` and
+`IQM_QC_ALIAS` environment variables. Only used when `local=False`.
+
 ### Programmatic Sampling Example
 
 ```python

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -131,6 +131,28 @@ def _new_job_dir() -> Path:
     return job_dir
 
 
+def _spank_qc_selection_args(qc_id: str | None, qc_alias: str | None) -> list[str]:
+    """Build `srun` options for an explicit per-job quantum computer selection.
+
+    Unlike backend credentials (`IQM_BASE_URL`/`IQM_TOKENS_FILE`), which reach
+    the job purely through the environment -- either plain Slurm propagation
+    from the submitting shell, or the QDMI-on-IQM SPANK plugin's own
+    plugstack.conf.d defaults on the `quantum` partition -- QC selection is a
+    per-call choice. It is passed as a `--iqm-qc-id`/`--iqm-qc-alias` option on
+    `srun` itself, which the SPANK plugin resolves into the job's
+    `IQM_QC_ID`/`IQM_QC_ALIAS` environment variable.
+
+    Returns:
+        List of `srun` options for the requested quantum computer selection.
+    """
+    args = []
+    if qc_id:
+        args.append(f"--iqm-qc-id={qc_id}")
+    if qc_alias:
+        args.append(f"--iqm-qc-alias={qc_alias}")
+    return args
+
+
 def _run_srun(command: list[str], job_dir: Path) -> subprocess.CompletedProcess[bytes]:
     """Run *command* via `srun` and return the completed process.
 
@@ -191,6 +213,8 @@ def sample(
     local: bool = False,
     simulator: bool = False,
     timeout: float | None = None,
+    qc_id: str | None = None,
+    qc_alias: str | None = None,
 ) -> dict[str, int]:
     """Sample from a quantum circuit.
 
@@ -209,6 +233,12 @@ def sample(
             Only used when `local=False`.
         timeout: The timeout passed to the IQM Backend in seconds.
             Only used when `local=False`.
+        qc_id: If given, passed as `--iqm-qc-id` to `srun`, which the QDMI-on-IQM
+            SPANK plugin resolves into the `IQM_QC_ID` job environment variable.
+            Only used when `local=False`.
+        qc_alias: If given, passed as `--iqm-qc-alias` to `srun`, which the
+            QDMI-on-IQM SPANK plugin resolves into the `IQM_QC_ALIAS` job
+            environment variable. Only used when `local=False`.
 
     Returns:
         A dictionary of measurement counts.
@@ -246,6 +276,7 @@ def sample(
         f"--job-name={job_name}",
         "--nodes=1",
         "--partition=quantum",
+        *_spank_qc_selection_args(qc_id, qc_alias),
         "iqm-sampler",
         str(qc_path.absolute()),
         "--shots",
@@ -277,6 +308,8 @@ def estimate(
     local: bool = False,
     simulator: bool = False,
     timeout: float | None = None,
+    qc_id: str | None = None,
+    qc_alias: str | None = None,
 ) -> VQEResult:
     """Estimate the optimal parameters for a given ansatz circuit and operator.
 
@@ -302,6 +335,12 @@ def estimate(
             Only used when `local=False`.
         timeout: The timeout passed to the IQM Backend in seconds.
             Only used when `local=False`.
+        qc_id: If given, passed as `--iqm-qc-id` to `srun`, which the QDMI-on-IQM
+            SPANK plugin resolves into the `IQM_QC_ID` job environment variable.
+            Only used when `local=False`.
+        qc_alias: If given, passed as `--iqm-qc-alias` to `srun`, which the
+            QDMI-on-IQM SPANK plugin resolves into the `IQM_QC_ALIAS` job
+            environment variable. Only used when `local=False`.
 
     Returns:
         The VQE result, including the optimal parameters and eigenvalue.
@@ -341,6 +380,7 @@ def estimate(
         f"--job-name={job_name}",
         "--nodes=1",
         "--partition=quantum",
+        *_spank_qc_selection_args(qc_id, qc_alias),
         "iqm-estimator",
         str(qc_path.absolute()),
         str(operator_path.absolute()),

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -24,7 +24,7 @@ import math
 import pickle  # noqa: S403
 import re
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from qiskit import QuantumCircuit
@@ -32,9 +32,6 @@ from qiskit.circuit import Parameter
 from qiskit.quantum_info import SparsePauliOp
 
 from iqm.qdmi import offloader
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class FakeBitArray:
@@ -158,6 +155,99 @@ def test_estimate_slurm_mock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     # Backend configuration (base URL, tokens, etc.) is not passed explicitly:
     # it is inherited by the job's environment (e.g. via the Slurm SPANK plugin).
     assert "--base-url" not in captured_command
+
+
+def test_sample_slurm_uses_spank_qc_alias_and_no_cli_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The Slurm path must never put credentials on the `srun` command line.
+
+    Backend credentials (`IQM_BASE_URL`/`IQM_TOKENS_FILE`) reach the job
+    purely through the environment -- either plain Slurm propagation or the
+    QDMI-on-IQM SPANK plugin's own injection -- never as CLI arguments. Only
+    the explicit `qc_alias` selection is forwarded, as a SPANK `--iqm-*`
+    option on `srun` itself (not a worker CLI flag).
+    """
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
+        stderr = b""
+
+    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setenv("IQM_BASE_URL", "https://resonance.example")
+    monkeypatch.setenv("IQM_TOKENS_FILE", "tokens_path")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    counts = offloader.sample(circuit, shots=7, local=False, simulator=True, qc_alias="emerald:mock")
+
+    worker_index = captured_command.index("iqm-sampler")
+    worker_command = captured_command[worker_index : worker_index + 4]
+    assert counts == {"0": 1}
+    assert "https://resonance.example" not in captured_command
+    assert "tokens_path" not in captured_command
+    for flag in ("--base-url", "--tokens-file", "--token", "--qc-alias"):
+        assert flag not in captured_command
+    assert "--iqm-qc-alias=emerald:mock" in captured_command
+    assert captured_command.index("--iqm-qc-alias=emerald:mock") < worker_index
+    assert worker_command[0] == "iqm-sampler"
+    assert Path(worker_command[1]).name == "qc.qpy"
+    assert worker_command[2] == "--shots"
+    assert worker_command[3] == "7"
+
+
+def test_estimate_slurm_uses_spank_qc_id_and_no_cli_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mirrors `test_sample_slurm_uses_spank_qc_alias_and_no_cli_credentials` for `estimate()`."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
+        stderr = b""
+
+    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setenv("IQM_BASE_URL", "https://resonance.example")
+    monkeypatch.setenv("IQM_TOKENS_FILE", "tokens_path")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    qc_id = "12345678-1234-1234-1234-123456789abc"
+    result = offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True, qc_id=qc_id)
+
+    worker_index = captured_command.index("iqm-estimator")
+    worker_command = captured_command[worker_index : worker_index + 5]
+    assert result.optimal_parameters == {"theta": 0.125}
+    assert "https://resonance.example" not in captured_command
+    assert "tokens_path" not in captured_command
+    for flag in ("--base-url", "--tokens-file", "--token", "--qc-id", "--qc-alias"):
+        assert flag not in captured_command
+    assert f"--iqm-qc-id={qc_id}" in captured_command
+    assert captured_command.index(f"--iqm-qc-id={qc_id}") < worker_index
+    assert worker_command[0] == "iqm-estimator"
+    assert Path(worker_command[1]).name == "ansatz.qpy"
+    assert Path(worker_command[2]).name == "operator.pkl"
+    assert worker_command[3] == "--maxiter"
+    assert worker_command[4] == "3"
 
 
 def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -181,9 +181,12 @@ def test_sample_slurm_uses_spank_qc_alias_and_no_cli_credentials(
         stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
         stderr = b""
 
-    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
         assert capture_output is True
         assert check is False
+        assert timeout is None
         captured_command[:] = command
         return FakeCompletedProcess()
 
@@ -223,9 +226,12 @@ def test_estimate_slurm_uses_spank_qc_id_and_no_cli_credentials(
         stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
         stderr = b""
 
-    def fake_run(command: list[str], *, capture_output: bool, check: bool) -> FakeCompletedProcess:
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
         assert capture_output is True
         assert check is False
+        assert timeout is None
         captured_command[:] = command
         return FakeCompletedProcess()
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

Lets a caller pin a specific quantum computer for a single offloaded job. The `offloader` module added in #104 can already sample and estimate on Slurm, but had no way to target one QC among several — `sample()` and `estimate()` now accept `qc_id`/`qc_alias`, forwarded as `--iqm-qc-id`/`--iqm-qc-alias` on the `srun` command line, which the SPANK plugin resolves into the job's `IQM_QC_ID`/`IQM_QC_ALIAS` environment variables.

Both flags are only meaningful on the non-local (Slurm) path and default to unset, so existing callers see no behavior change.
