### PR TITLE
🐛 Enforce required SPANK licenses when none were requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Reject missing Slurm license requests when the SPANK plugin has
-  `iqm_require_license=1` enabled
+  `iqm_require_license=1` enabled ([#134]) ([**@burgholzer**])
 - 🩹 Fix rate limit handling and retry logic for API requests ([#122])
   ([**@burgholzer**])
 
@@ -114,6 +114,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#122]: https://github.com/iqm-finland/QDMI-on-IQM/pull/122
 [#120]: https://github.com/iqm-finland/QDMI-on-IQM/pull/120
 [#117]: https://github.com/iqm-finland/QDMI-on-IQM/pull/117

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   `estimate` functions for Slurm job submissions ([#104]) ([**@marcelwa**])
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
-  on-premise QCs ([#114]) ([**@marcelwa**])
+  on-premise QCs ([#114], [#134]) ([**@marcelwa**], [**@burgholzer**])
 
 ### Changed
 
@@ -25,8 +25,6 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🐛 Reject missing Slurm license requests when the SPANK plugin has
-  `iqm_require_license=1` enabled ([#134]) ([**@burgholzer**])
 - 🩹 Fix rate limit handling and retry logic for API requests ([#122])
   ([**@burgholzer**])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Reject missing Slurm license requests when the SPANK plugin has
+  `iqm_require_license=1` enabled
 - 🩹 Fix rate limit handling and retry logic for API requests ([#122])
   ([**@burgholzer**])
 

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -230,12 +230,13 @@ that pressure itself, ahead of the QC's own queue.
    separator, the plugin replaces `:` and `,` in the alias with `_` when
    deriving the name (e.g. alias `emerald:mock` → license
    `iqm_qc_emerald_mock`).
-4. By default, a mismatch (or a missing `--licenses` request) only logs a
-   warning. Setting `iqm_require_license=1` instead fails the job step at launch
-   — after the job has already been allocated, not at submission time — and only
-   takes effect if the plugin is declared `required` (not `optional`) in
-   `plugstack.conf`. The hard requirement fails closed when `SLURM_JOB_LICENSES`
-   is unavailable and therefore requires Slurm 23.02 or newer.
+4. By default, a mismatched request logs a warning, while a missing `--licenses`
+   request is a silent no-op. Setting `iqm_require_license=1` instead fails
+   either case at job-step launch — after the job has already been allocated,
+   not at submission time — and only takes effect if the plugin is declared
+   `required` (not `optional`) in `plugstack.conf`. The hard requirement fails
+   closed when `SLURM_JOB_LICENSES` is unavailable and therefore requires Slurm
+   23.02 or newer.
 5. Optionally, add the license name to `AccountingStorageTRES` in `slurm.conf`
    to track its usage in Slurm accounting.
 

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -173,7 +173,8 @@ required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.t
 - `iqm_require_license`: When set to a truthy value
   (`1`/`true`/`yes`/`on`/`enabled`, case-insensitive), fails at launch jobs
   whose Slurm license request does not match the derived name, instead of only
-  logging a warning (default: off). See
+  logging a warning (default: off). This fails closed when `SLURM_JOB_LICENSES`
+  is unavailable, so only enable it on Slurm 23.02 or newer. See
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses)
   for the exact semantics. An unrecognized value logs a warning and is treated
   as off.
@@ -233,7 +234,8 @@ that pressure itself, ahead of the QC's own queue.
    warning. Setting `iqm_require_license=1` instead fails the job step at launch
    — after the job has already been allocated, not at submission time — and only
    takes effect if the plugin is declared `required` (not `optional`) in
-   `plugstack.conf`.
+   `plugstack.conf`. The hard requirement fails closed when `SLURM_JOB_LICENSES`
+   is unavailable and therefore requires Slurm 23.02 or newer.
 5. Optionally, add the license name to `AccountingStorageTRES` in `slurm.conf`
    to track its usage in Slurm accounting.
 

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -91,10 +91,10 @@ This matters most for **on-premise QCs**: like Resonance, an on-premise setup
 still runs its own internal queue, but it typically fronts single-tenant
 hardware, so uncontrolled Slurm-side concurrency puts unnecessary pressure on
 that queue. Requesting the license lets Slurm regulate that pressure itself,
-ahead of the QC's own queue. If you omit `--licenses` on a cluster where it's
-expected, the plugin logs a warning (or, if the administrator has set
-`iqm_require_license=1`, fails your job step at launch instead — after it has
-already been allocated, not at submission time).
+ahead of the QC's own queue. If you omit `--licenses`, the default policy is a
+silent no-op. If the administrator has set `iqm_require_license=1`, the plugin
+instead fails your job step at launch — after it has already been allocated, not
+at submission time.
 
 ### Executing via CLI Scripts
 
@@ -125,8 +125,8 @@ policy or handle backend-side queue management.
   check (see
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses))
   additionally requires Slurm 23.02 or newer, since it relies on the
-  `SLURM_JOB_LICENSES` job environment variable; on older Slurm versions it is a
-  silent no-op.
+  `SLURM_JOB_LICENSES` job environment variable; on older Slurm versions the
+  default policy is a silent no-op, while `iqm_require_license=1` fails closed.
 - **C++ Compiler**: C++20 standard library support (GCC 13+ or Clang 16+).
 - **Compilation Constraint**: SPANK plugins are tied to the Slurm daemon ABI.
   You must compile the plugin against the target cluster's Slurm header files

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -172,9 +172,10 @@ required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.t
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses).
 - `iqm_require_license`: When set to a truthy value
   (`1`/`true`/`yes`/`on`/`enabled`, case-insensitive), fails at launch jobs
-  whose Slurm license request does not match the derived name, instead of only
-  logging a warning (default: off). This fails closed when `SLURM_JOB_LICENSES`
-  is unavailable, so only enable it on Slurm 23.02 or newer. See
+  whose Slurm license request is missing or does not match the derived name. By
+  default, mismatches log a warning and an absent request is ignored. This fails
+  closed when `SLURM_JOB_LICENSES` is unavailable, so only enable it on Slurm
+  23.02 or newer. See
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses)
   for the exact semantics. An unrecognized value logs a warning and is treated
   as off.

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -400,11 +400,20 @@ public:
                      static_cast<int>(licenses_buf.size()));
 
     if (licenses_rc != ESPANK_SUCCESS && licenses_rc != ESPANK_NOSPACE) {
-      slurm_debug(
-          "[iqm_spank_plugin] SLURM_JOB_LICENSES not present in job "
-          "environment (requires Slurm >=23.02, or no --licenses requested); "
-          "skipping Slurm license alignment check");
-      return ESPANK_SUCCESS;
+      if (!require_license_) {
+        slurm_debug(
+            "[iqm_spank_plugin] SLURM_JOB_LICENSES not present in job "
+            "environment (requires Slurm >=23.02, or no --licenses requested); "
+            "skipping Slurm license alignment check");
+        return ESPANK_SUCCESS;
+      }
+
+      slurm_spank_log(
+          "[iqm_spank_plugin] error: missing required Slurm license '%s' for "
+          "QC alias '%s' — resubmit with --licenses=%s:<n> "
+          "(iqm_require_license is enabled)",
+          expected_license.c_str(), alias->c_str(), expected_license.c_str());
+      return ESPANK_ERROR;
     }
 
     bool aligned = false;

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -361,12 +361,12 @@ public:
    * check is skipped (returns `ESPANK_SUCCESS`, debug log only) when:
    *   - No `IQM_QC_ALIAS` is resolved (`IQM_QC_ID`-only jobs are not
    *     checked; raw IDs are not reliably convertible into license names).
-   *   - `SLURM_JOB_LICENSES` is absent — true both on Slurm < 23.02 (the
-   *     variable does not exist there) and when the user requested no
-   *     `--licenses` at all. These two cases cannot be distinguished from
-   *     inside the plugin, so absence is always treated as a no-op. A
-   *     value too long to fit the lookup buffer is treated as a mismatch
-   *     instead (fail closed, not skipped).
+   *   - `SLURM_JOB_LICENSES` is absent and `iqm_require_license` is disabled.
+   *     Absence means either Slurm < 23.02 (where the variable does not exist)
+   *     or that the user requested no `--licenses`; these cases cannot be
+   *     distinguished. With `iqm_require_license` enabled, either case is
+   *     rejected. A value too long to fit the lookup buffer is treated as a
+   *     mismatch instead (fail closed, not skipped).
    *
    * Note on enforcement: returning `ESPANK_ERROR` here fails the task at
    * launch in `slurm_spank_task_init` (remote context) — i.e. *after* the

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -76,7 +76,8 @@
  * already been allocated — it is not a submission-time rejection — and only
  * takes effect if the plugin is declared `required`, not `optional`, in
  * plugstack.conf). This check requires Slurm >= 23.02 (`SLURM_JOB_LICENSES`);
- * on older Slurm, or when the job has no alias, it is a silent no-op.
+ * on older Slurm it is a silent no-op unless `iqm_require_license=1`, which
+ * fails closed. Jobs without an alias are always skipped.
  */
 // clang-format on
 

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -52,8 +52,9 @@
  *   - partitions=quantum,quantum-dev (comma-separated, restricts activation)
  *   - iqm_license_prefix=iqm_qc_ (prefix used to derive the expected Slurm
  *     license name from IQM_QC_ALIAS; default: "iqm_qc_")
- *   - iqm_require_license=1 (reject jobs whose Slurm license request does
- *     not match the derived name; default: off, warn only)
+ *   - iqm_require_license=1 (reject jobs whose Slurm license request is
+ *     missing or does not match the derived name; by default, mismatches
+ *     warn and an absent request is ignored)
  *
  * Partition detection uses the `SLURM_JOB_PARTITION` environment variable
  * (set by Slurm in every job), which is portable across all Slurm versions.
@@ -799,9 +800,9 @@ private:
   /// argument (default: "iqm_qc_").
   std::optional<std::string> license_prefix_;
 
-  /// When true, jobs that resolve an IQM_QC_ALIAS but do not request the
-  /// corresponding Slurm license via --licenses are rejected outright
-  /// instead of only receiving a warning. Configurable via
+  /// When true, jobs that resolve an IQM_QC_ALIAS but have no Slurm license
+  /// request or request a different license are rejected. By default,
+  /// mismatches warn and an absent request is ignored. Configurable via
   /// `iqm_require_license` (default: false/off).
   bool require_license_ = false;
 };

--- a/spank/test/test_license_alignment.sh
+++ b/spank/test/test_license_alignment.sh
@@ -33,7 +33,7 @@
 #   3. Aliases containing ':' (e.g. "emerald:mock") are sanitized to '_' when
 #      deriving the expected license name.
 #   4. No --licenses request at all is a silent no-op.
-#   5. With iqm_require_license=1, a mismatched request is rejected outright.
+#   5. With iqm_require_license=1, mismatched and absent requests are rejected.
 
 set -euo pipefail
 
@@ -270,6 +270,15 @@ else
     pass "Mismatched Slurm license rejected with iqm_require_license=1 (rc=$rc)"
   else
     fail "srun failed (rc=$rc) but not with the expected 'missing required Slurm license' message"
+  fi
+
+  run_srun_capture --iqm-qc-alias="$test_qc_alias" env
+  if [[ $rc -eq 0 ]]; then
+    fail "srun succeeded (rc=0) despite iqm_require_license=1 and no license request"
+  elif echo "$output" | grep -Fq "missing required Slurm license"; then
+    pass "Absent Slurm license rejected with iqm_require_license=1 (rc=$rc)"
+  else
+    fail "srun without --licenses failed (rc=$rc) but not with the expected 'missing required Slurm license' message"
   fi
 
   restore_conf


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary
- fail closed when `iqm_require_license` is enabled but the job has no Slurm license request
- preserve the default silent behavior for absent requests and the existing mismatch warning behavior
- add regression coverage and document the exact policy consistently

## Validation
- `uvx nox -s lint`
- isolated Slurm 25.11 fixture: default absence succeeds silently; required absence fails with task-init return `-1`; existing mismatch scenarios pass
- fresh independent read-only verification of the final branch