### PR TITLE
✨ Validate IQM backends before SPANK task launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Validate IQM backend and target-QC availability once per node for each
+  Slurm job step before launching tasks ([#136]) ([**@burgholzer**])
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
   `estimate` functions (including `qc_id`/`qc_alias` SPANK device-selection
   parameters) for Slurm job submissions ([#104], [#130], [#133])
@@ -22,6 +24,10 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⚡️ Cache SPANK validation per node and job step, isolate it from daemon-only
+  environment variables, bound each launch-time request to 30 seconds by
+  default, emit task diagnostics once per node and step, and require Slurm 20.02
+  or newer ([#136]) ([**@burgholzer**])
 - ♻️ Further align C++ HTTP and authentication handling with [cpr] abstractions
   ([#122]) ([**@burgholzer**])
 
@@ -114,6 +120,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133
 [#130]: https://github.com/iqm-finland/QDMI-on-IQM/pull/130

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -119,9 +119,18 @@ The SPANK plugin is a lightweight C++ module that intercepts job launches to
 parse options and inject environment variables. It does not implement scheduler
 policy or handle backend-side queue management.
 
+For every active job step, the plugin initializes one IQM QDMI session on each
+allocated node after Slurm drops privileges. This verifies the endpoint,
+credentials, selected quantum computer, and architecture before any task starts
+on that node. The result is cached per node for the step, so multi-task launches
+on one node do not repeat the backend requests or routine task diagnostics. An
+N-node job therefore performs N validation sessions. Validation uses the exact
+SPANK job environment; daemon-only `slurmd` or `slurmstepd` IQM variables are
+ignored. Every validation request has a non-optional 30-second default timeout.
+
 ### Compatibility and Requirements
 
-- **Slurm Version**: Slurm 17.11 or newer. The optional Slurm license alignment
+- **Slurm Version**: Slurm 20.02 or newer. The optional Slurm license alignment
   check (see
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses))
   additionally requires Slurm 23.02 or newer, since it relies on the
@@ -143,7 +152,8 @@ sudo cmake --install build-spank --component iqm-spank-plugin
 ```
 
 This installs the compiled `.so` file to the Slurm plugin directory and places
-the template configuration in `plugstack.conf.d/`.
+the template configuration in `plugstack.conf.d/`. The IQM QDMI implementation
+used for launch-time validation is linked directly into the plugin.
 
 Deploy the plugin on login/submit nodes (for `srun`/`sbatch` command line
 parsing) and on compute nodes running `slurmd`/`slurmstepd`. Controller-only
@@ -160,13 +170,16 @@ The whole directive must be a single line; plugstack.conf does not support line
 continuation.
 
 ```text
-required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech iqm_tokens_file=/etc/iqm/tokens.json partitions=quantum,debug iqm_license_prefix=iqm_qc_ iqm_require_license=1
+required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech iqm_tokens_file=/etc/iqm/tokens.json partitions=quantum,debug iqm_validation_timeout=30 iqm_license_prefix=iqm_qc_ iqm_require_license=1
 ```
 
 - `iqm_base_url`: Default API endpoint.
 - `iqm_tokens_file`: Path to the shared token file.
 - `partitions`: Comma-separated list of partitions where this plugin will run.
   If omitted, the plugin evaluates all partitions.
+- `iqm_validation_timeout`: Positive whole-second timeout applied to each HTTP
+  request during mandatory backend validation (default: `30`, allowed range: `1`
+  to `3600`). Invalid values log a warning and use the 30-second default.
 - `iqm_license_prefix`: Prefix used to derive the expected Slurm license name
   from `IQM_QC_ALIAS` (default: `iqm_qc_`). See
   [Limiting Concurrent Access with Slurm Licenses](#limiting-concurrent-access-with-slurm-licenses).
@@ -260,6 +273,9 @@ activation prints a log entry when a job starts on an active partition:
   directory and that the drop-in file is read-permitted.
 - **Permission Denied**: The `slurmd` process user must have read access to the
   compiled `.so` library and the specified `iqm_tokens_file`.
+- **"IQM backend validation failed"**: Check that the compute node can reach
+  `IQM_BASE_URL`, that its credentials are valid, and that the selected QC
+  exists. Validation is mandatory and rejects the step before any task starts.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,6 +81,13 @@ FoMaC::get_iqm_session(const std::string &base_url,
         tokens_file->size() + 1, tokens_file->c_str());
   }
 
+  // Optionally override the one-hour default timeout for every HTTP request
+  // made by this session.
+  const uint64_t request_timeout_milliseconds = 30'000;
+  ret = IQM_QDMI_device_session_set_parameter(
+      session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+      sizeof(request_timeout_milliseconds), &request_timeout_milliseconds);
+
   // Initialize the session
   IQM_QDMI_device_session_init(session);
 
@@ -103,6 +110,11 @@ used to set various parameters for the session:
   ({cpp:enumerator}`~QDMI_DEVICE_SESSION_PARAMETER_T::QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2`):
   Optional alias of the specific quantum computer to use. If not set, falls back
   to `IQM_QC_ALIAS`.
+- **HTTP Request Timeout**
+  ({cpp:enumerator}`~QDMI_DEVICE_SESSION_PARAMETER_T::QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3`):
+  Optional positive `uint64_t` duration in milliseconds applied to every HTTP
+  request made by the session. If not set, each request uses the default
+  one-hour timeout.
 - **Authentication Token**
   ({cpp:enumerator}`~QDMI_DEVICE_SESSION_PARAMETER_T::QDMI_DEVICE_SESSION_PARAMETER_TOKEN`):
   Bearer token for authentication. If not set, falls back to the `IQM_TOKEN`

--- a/include/http_client.hpp
+++ b/include/http_client.hpp
@@ -25,13 +25,16 @@
 
 #include "iqm_qdmi/constants.h"
 
+#include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/body.h>
 #include <cpr/cprtypes.h>
 #include <cpr/response.h>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <optional>
+#include <type_traits>
 
 namespace iqm::http {
 
@@ -54,10 +57,12 @@ enum class ERROR_LOG_POLICY : uint8_t {
  *
  * @param url The target URL for the GET request.
  * @param bearer_token Bearer token used for authentication, if configured.
+ * @param timeout Overall timeout for the request and any rate-limit retries.
  * @return CPR response object.
  */
 cpr::Response Get(const cpr::Url &url,
-                  const std::optional<cpr::Bearer> &bearer_token);
+                  const std::optional<cpr::Bearer> &bearer_token,
+                  std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
  * @brief Perform an optional HTTP GET request.
@@ -67,10 +72,13 @@ cpr::Response Get(const cpr::Url &url,
  *
  * @param url The target URL for the GET request.
  * @param bearer_token Bearer token used for authentication, if configured.
+ * @param timeout Overall timeout for the request and any rate-limit retries.
  * @return CPR response object.
  */
-cpr::Response Get_optional(const cpr::Url &url,
-                           const std::optional<cpr::Bearer> &bearer_token);
+cpr::Response
+Get_optional(const cpr::Url &url,
+             const std::optional<cpr::Bearer> &bearer_token,
+             std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
  * @brief Perform an HTTP POST request.
@@ -84,12 +92,14 @@ cpr::Response Get_optional(const cpr::Url &url,
  * @param bearer_token Bearer token used for authentication, if configured.
  * @param data The request body data.
  * @param additional_headers Additional HTTP headers to include.
+ * @param timeout Overall timeout for the request and any rate-limit retries.
  * @return CPR response object.
  */
 cpr::Response Post(const cpr::Url &url,
                    const std::optional<cpr::Bearer> &bearer_token,
                    const cpr::Body &data,
-                   const cpr::Header &additional_headers = {});
+                   const cpr::Header &additional_headers = {},
+                   std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
  * @brief Classify an HTTP response and log diagnostics.
@@ -102,6 +112,33 @@ QDMI_STATUS Handle_response(
 
 namespace internal {
 /**
+ * @brief Clamp a logical timeout to the integer range used by a transport.
+ *
+ * CPR passes timeouts to libcurl as a `long`, which is only 32 bits on
+ * Windows. The logical request budget remains unchanged; only an individual
+ * transport attempt is clamped.
+ *
+ * @tparam TransportRep Integral representation accepted by the transport.
+ * @param timeout Logical request timeout.
+ * @return Timeout representable by the transport.
+ */
+template <typename TransportRep>
+[[nodiscard]] constexpr auto
+Clamp_timeout_for_transport(const std::chrono::milliseconds timeout)
+    -> std::chrono::milliseconds {
+  static_assert(std::is_integral_v<TransportRep>);
+  using TimeoutRep = std::chrono::milliseconds::rep;
+  if constexpr (std::numeric_limits<TransportRep>::digits >=
+                std::numeric_limits<TimeoutRep>::digits) {
+    return timeout;
+  } else {
+    constexpr auto transport_maximum = std::chrono::milliseconds{
+        static_cast<TimeoutRep>(std::numeric_limits<TransportRep>::max())};
+    return timeout > transport_maximum ? transport_maximum : timeout;
+  }
+}
+
+/**
  * @brief Function hooks used to intercept HTTP calls and retry delays.
  *
  * Tests override these to exercise get()/post()/retry logic without a live
@@ -110,14 +147,15 @@ namespace internal {
  */
 struct Hooks {
   /// Hook for GET requests.
-  std::function<cpr::Response(const cpr::Url &url,
-                              const std::optional<cpr::Bearer> &bearer_token,
-                              const cpr::Header &headers)>
-      get;
-  /// Hook for POST requests.
   std::function<cpr::Response(
       const cpr::Url &url, const std::optional<cpr::Bearer> &bearer_token,
-      const cpr::Header &headers, const cpr::Body &body)>
+      const cpr::Header &headers, std::chrono::milliseconds timeout)>
+      get;
+  /// Hook for POST requests.
+  std::function<cpr::Response(const cpr::Url &url,
+                              const std::optional<cpr::Bearer> &bearer_token,
+                              const cpr::Header &headers, const cpr::Body &body,
+                              std::chrono::milliseconds timeout)>
       post;
   /// Hook for the retry backoff delay, given a delay in seconds.
   std::function<void(int)> sleep;

--- a/spank/CMakeLists.txt
+++ b/spank/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(${BUILD_IQM_SPANK_TARGET} MODULE iqm_spank_plugin.cpp)
 target_compile_features(${BUILD_IQM_SPANK_TARGET} PRIVATE cxx_std_20)
 target_include_directories(${BUILD_IQM_SPANK_TARGET}
                            PRIVATE ${SLURM_SPANK_INCLUDE_DIR})
+target_link_libraries(
+  ${BUILD_IQM_SPANK_TARGET} PRIVATE iqm::qdmi_device_internals
+                                    qdmi::qdmi_project_warnings)
 set_target_properties(${BUILD_IQM_SPANK_TARGET} PROPERTIES PREFIX "")
 
 # Detect the Slurm plugin directory for the SPANK plugin.

--- a/spank/Dockerfile
+++ b/spank/Dockerfile
@@ -77,7 +77,7 @@ RUN SLURM_LIB_DIR=$(dpkg-architecture -qDEB_HOST_MULTIARCH | xargs -I{} echo /us
     cmake --build /workspace/build-spank-docker --target iqm-spank-plugin && \
     cmake --install /workspace/build-spank-docker --component iqm-spank-plugin && \
     rm -rf /workspace/build-spank-docker && \
-    echo "required $SLURM_LIB_DIR/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech" > /etc/slurm/plugstack.conf.d/iqm-qdmi.conf
+    echo "required $SLURM_LIB_DIR/iqm-spank-plugin.so iqm_base_url=http://127.0.0.1:18080 iqm_validation_timeout=1" > /etc/slurm/plugstack.conf.d/iqm-qdmi.conf
 
 # Create a sentinel file to detect bind-mount shadowing
 RUN touch /workspace/.built-in-image

--- a/spank/README.md
+++ b/spank/README.md
@@ -22,6 +22,6 @@ for the plugin license text.
 
 Unlike the core QDMI-on-IQM library, this plugin is tied directly to the Slurm
 ABI of the target system. It must be compiled against the target cluster's Slurm
-header files (`slurm/spank.h`) and rebuilt whenever the cluster's Slurm version
-is upgraded. For detailed version compatibility and compiler requirements, see
-the [SPANK Plugin Guide](../docs/spank_plugin.md).
+20.02-or-newer header files (`slurm/spank.h`) and rebuilt whenever the cluster's
+Slurm version is upgraded. For detailed version compatibility and compiler
+requirements, see the [SPANK Plugin Guide](../docs/spank_plugin.md).

--- a/spank/iqm-qdmi.conf.in
+++ b/spank/iqm-qdmi.conf.in
@@ -23,4 +23,4 @@
 # values. The whole directive must stay on a single line; plugstack.conf does
 # not support line continuation. See the plugin README for details.
 
-# required @IQM_QDMI_SPANK_INSTALL_DIR@/iqm-spank-plugin.so partitions= iqm_base_url= iqm_tokens_file= iqm_qc_id= iqm_qc_alias= iqm_license_prefix= iqm_require_license=
+# required @IQM_QDMI_SPANK_INSTALL_DIR@/iqm-spank-plugin.so partitions= iqm_base_url= iqm_tokens_file= iqm_qc_id= iqm_qc_alias= iqm_validation_timeout=30 iqm_license_prefix= iqm_require_license=

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -50,6 +50,8 @@
  *
  * Additional plugstack-only arguments:
  *   - partitions=quantum,quantum-dev (comma-separated, restricts activation)
+ *   - iqm_validation_timeout=30 (per-request backend-validation timeout in
+ *     seconds; default: 30, allowed range: 1-3600)
  *   - iqm_license_prefix=iqm_qc_ (prefix used to derive the expected Slurm
  *     license name from IQM_QC_ALIAS; default: "iqm_qc_")
  *   - iqm_require_license=1 (reject jobs whose Slurm license request is
@@ -58,6 +60,10 @@
  *
  * Partition detection uses the `SLURM_JOB_PARTITION` environment variable
  * (set by Slurm in every job), which is portable across all Slurm versions.
+ *
+ * Before any task starts, the plugin initializes an IQM QDMI session once per
+ * node for each job step to verify that the configured backend and target QC
+ * are available.
  *
  * When `IQM_QC_ALIAS` is resolved, the plugin can optionally check that the
  * job's Slurm license request (the native `--licenses`/`-L` submission
@@ -85,10 +91,16 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
+#include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
 #include <format>
 #include <optional>
+// POSIX setenv and unsetenv are declared by stdlib.h, not cstdlib.
+// NOLINTNEXTLINE(modernize-deprecated-headers)
+#include <stdlib.h>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -99,10 +111,14 @@
 // functions. This is unavoidable when interfacing with the Slurm C API.
 
 extern "C" {
+#include <iqm_qdmi/device.h>
 #include <slurm/slurm_errno.h>
 #include <slurm/slurm_version.h>
 #include <slurm/spank.h>
 }
+
+static_assert(SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20, 2, 0),
+              "The IQM SPANK plugin requires Slurm 20.02 or newer");
 
 namespace {
 
@@ -117,6 +133,24 @@ struct Config_mapping {
   const char *option_name;
   /// srun option usage description.
   const char *option_usage;
+};
+
+/// A SPANK environment variable and its corresponding QDMI session parameter.
+struct Session_parameter_mapping {
+  /// Environment variable in the effective job environment.
+  const char *env_var;
+  /// QDMI session parameter receiving the value.
+  QDMI_Device_Session_Parameter parameter;
+};
+
+/// Cached result of the once-per-node, per-job-step validation.
+struct Validation_state {
+  /// Whether the plugin applies to this job step.
+  bool active = true;
+  /// Whether validation has finished.
+  bool complete = false;
+  /// Whether all validation checks succeeded.
+  bool successful = false;
 };
 
 /// All recognized configuration entries and their mappings.
@@ -139,6 +173,80 @@ constexpr std::array<Config_mapping, 4> K_CONFIG_MAPPINGS = {{
      .option_usage = "Quantum computer alias"},
 }};
 
+/// Effective job values passed explicitly to the validation session.
+constexpr std::array<Session_parameter_mapping, 5> K_SESSION_PARAMETERS = {{
+    {.env_var = "IQM_BASE_URL",
+     .parameter = QDMI_DEVICE_SESSION_PARAMETER_BASEURL},
+    {.env_var = "IQM_TOKEN", .parameter = QDMI_DEVICE_SESSION_PARAMETER_TOKEN},
+    {.env_var = "IQM_TOKENS_FILE",
+     .parameter = QDMI_DEVICE_SESSION_PARAMETER_AUTHFILE},
+    {.env_var = "IQM_QC_ID",
+     .parameter = QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1},
+    {.env_var = "IQM_QC_ALIAS",
+     .parameter = QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2},
+}};
+
+/// Default per-request timeout for launch-time backend validation.
+constexpr uint64_t K_DEFAULT_VALIDATION_TIMEOUT_MILLISECONDS = 30'000;
+/// Longest accepted validation request timeout.
+constexpr uint64_t K_MAX_VALIDATION_TIMEOUT_SECONDS = 3'600;
+
+/**
+ * @brief Hide daemon environment defaults while IQM validates explicit values.
+ *
+ * The effective SPANK job values are passed as QDMI session parameters. Hiding
+ * the corresponding process variables prevents slurmstepd service defaults
+ * from supplying values that are absent from the job.
+ */
+class ScopedSessionEnvironment final {
+public:
+  ScopedSessionEnvironment() {
+    for (std::size_t i = 0; i < K_SESSION_PARAMETERS.size(); ++i) {
+      const auto *env_var = K_SESSION_PARAMETERS[i].env_var;
+      if (const auto *value = std::getenv(env_var); value != nullptr) {
+        original_values_[i] = value;
+      }
+      if (unsetenv(env_var) != 0) {
+        valid_ = false;
+        break;
+      }
+      ++hidden_values_;
+    }
+  }
+
+  ScopedSessionEnvironment(const ScopedSessionEnvironment &) = delete;
+  ScopedSessionEnvironment &
+  operator=(const ScopedSessionEnvironment &) = delete;
+  ScopedSessionEnvironment(ScopedSessionEnvironment &&) = delete;
+  ScopedSessionEnvironment &operator=(ScopedSessionEnvironment &&) = delete;
+
+  ~ScopedSessionEnvironment() {
+    for (std::size_t i = 0; i < hidden_values_; ++i) {
+      if (set_value(K_SESSION_PARAMETERS[i].env_var, original_values_[i]) !=
+          0) {
+        slurm_spank_log(
+            "[iqm_spank_plugin] error: failed to restore process environment");
+      }
+    }
+  }
+
+  [[nodiscard]] bool valid() const { return valid_; }
+
+private:
+  static int set_value(const char *name,
+                       const std::optional<std::string> &value) {
+    if (value.has_value()) {
+      return setenv(name, value->c_str(), 1);
+    }
+    return unsetenv(name);
+  }
+
+  std::array<std::optional<std::string>, K_SESSION_PARAMETERS.size()>
+      original_values_{};
+  std::size_t hidden_values_ = 0;
+  bool valid_ = true;
+};
+
 /**
  * @brief Parses plugstack.conf arguments, processes srun options, and injects
  * IQM environment variables into Slurm jobs.
@@ -148,14 +256,14 @@ constexpr std::array<Config_mapping, 4> K_CONFIG_MAPPINGS = {{
  *      `key=value` pairs from the plugstack.conf line.
  *   2. `register_options()` is called from `slurm_spank_init` to register
  *      `--iqm-*` srun command-line options.
- *   3. `inject_environment()` is called from `slurm_spank_task_init` (remote
+ *   3. `inject_environment()` is called from `slurm_spank_user_init` (remote
  *      context) to set environment variables in the job via `spank_setenv()`.
  *   4. `validate_environment()` is called after injection to perform
- *      superficial configuration validation. Deeper validation is deferred to
- *      the IQM QDMI device implementation.
- *   5. `validate_license_alignment()` is called after `validate_environment()`
- *      to check that the job's Slurm license request matches the targeted
- *      QC alias.
+ *      superficial configuration validation.
+ *   5. `validate_backend()` initializes an IQM QDMI session to verify the
+ *      configured backend and target QC before tasks are allowed to start.
+ *   6. `validate_license_alignment()` is called from task init for local task
+ *      zero, after Slurm makes `SLURM_JOB_LICENSES` available.
  */
 class IQMSpankConfigManager final {
 public:
@@ -205,6 +313,11 @@ public:
 
       if (!matched && key == "iqm_require_license") {
         require_license_ = parse_bool_arg(value, "iqm_require_license");
+        matched = true;
+      }
+
+      if (!matched && key == "iqm_validation_timeout") {
+        validation_timeout_milliseconds_ = parse_timeout_arg(value);
         matched = true;
       }
 
@@ -305,12 +418,9 @@ public:
   /**
    * @brief Validate that the effective configuration is non-contradictory.
    *
-   * Performs only superficial SPANK-side checks:
+   * Performs superficial SPANK-side checks before backend validation:
    *   1. `IQM_BASE_URL` must be set.
    *   2. `IQM_TOKEN` and `IQM_TOKENS_FILE` must not both be set.
-   *
-   * Deeper semantic/runtime validation is intentionally deferred to the
-   * IQM QDMI device implementation.
    *
    * @param spank SPANK handle for the current hook invocation.
    * @return `ESPANK_SUCCESS` if valid, `ESPANK_ERROR` on conflict.
@@ -345,6 +455,112 @@ public:
                 "auth_source=%s",
                 has_base_url ? "set" : "unset", auth_source);
 
+    return ESPANK_SUCCESS;
+  }
+
+  /**
+   * @brief Initialize a QDMI session to verify backend and target availability.
+   *
+   * Effective values are read from the SPANK job environment after injection
+   * and passed directly to the QDMI session, avoiding any dependency on the
+   * slurmstepd process environment.
+   *
+   * @param spank SPANK handle for the current remote job step.
+   * @return `ESPANK_SUCCESS` when the backend session is available,
+   *   `ESPANK_ERROR` otherwise.
+   */
+  [[nodiscard]] int validate_backend(spank_t spank) const {
+    const ScopedSessionEnvironment environment_scope;
+    if (!environment_scope.valid()) {
+      slurm_spank_log("[iqm_spank_plugin] error: failed to isolate backend "
+                      "validation from the daemon environment");
+      return ESPANK_ERROR;
+    }
+
+    if (IQM_QDMI_device_initialize() != QDMI_SUCCESS) {
+      slurm_spank_log(
+          "[iqm_spank_plugin] error: failed to initialize the IQM QDMI device");
+      return ESPANK_ERROR;
+    }
+
+    struct Qdmi_guard {
+      IQM_QDMI_Device_Session session = nullptr;
+
+      Qdmi_guard() = default;
+      Qdmi_guard(const Qdmi_guard &) = delete;
+      Qdmi_guard &operator=(const Qdmi_guard &) = delete;
+      Qdmi_guard(Qdmi_guard &&) = delete;
+      Qdmi_guard &operator=(Qdmi_guard &&) = delete;
+
+      ~Qdmi_guard() {
+        if (session != nullptr) {
+          IQM_QDMI_device_session_free(session);
+        }
+        IQM_QDMI_device_finalize();
+      }
+    } guard;
+
+    try {
+      if (IQM_QDMI_device_session_alloc(&guard.session) != QDMI_SUCCESS) {
+        slurm_spank_log(
+            "[iqm_spank_plugin] error: failed to allocate an IQM QDMI session");
+        return ESPANK_ERROR;
+      }
+
+      for (const auto &[env_var, parameter] : K_SESSION_PARAMETERS) {
+        const auto value = get_spank_env(spank, env_var);
+        if (!value.has_value()) {
+          continue;
+        }
+        if (IQM_QDMI_device_session_set_parameter(
+                guard.session, parameter, value->size() + 1, value->c_str()) !=
+            QDMI_SUCCESS) {
+          slurm_spank_log("[iqm_spank_plugin] error: invalid value for %s",
+                          env_var);
+          return ESPANK_ERROR;
+        }
+      }
+
+      if (IQM_QDMI_device_session_set_parameter(
+              guard.session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+              sizeof(validation_timeout_milliseconds_),
+              &validation_timeout_milliseconds_) != QDMI_SUCCESS) {
+        slurm_spank_log(
+            "[iqm_spank_plugin] error: invalid IQM validation timeout");
+        return ESPANK_ERROR;
+      }
+
+      if (IQM_QDMI_device_session_init(guard.session) != QDMI_SUCCESS) {
+        slurm_spank_log(
+            "[iqm_spank_plugin] error: IQM backend validation failed");
+        return ESPANK_ERROR;
+      }
+
+      QDMI_Device_Status status = QDMI_DEVICE_STATUS_OFFLINE;
+      if (IQM_QDMI_device_session_query_device_property(
+              guard.session, QDMI_DEVICE_PROPERTY_STATUS, sizeof(status),
+              &status, nullptr) != QDMI_SUCCESS ||
+          (status != QDMI_DEVICE_STATUS_IDLE &&
+           status != QDMI_DEVICE_STATUS_BUSY)) {
+        slurm_spank_log(
+            "[iqm_spank_plugin] error: targeted IQM quantum computer is not "
+            "available");
+        return ESPANK_ERROR;
+      }
+    } catch (const std::exception &error) {
+      slurm_spank_log(
+          "[iqm_spank_plugin] error: IQM backend validation raised an "
+          "exception: %s",
+          error.what());
+      return ESPANK_ERROR;
+    } catch (...) {
+      slurm_spank_log(
+          "[iqm_spank_plugin] error: IQM backend validation raised an unknown "
+          "exception");
+      return ESPANK_ERROR;
+    }
+
+    slurm_debug("[iqm_spank_plugin] IQM backend validation status=ok");
     return ESPANK_SUCCESS;
   }
 
@@ -583,10 +799,35 @@ public:
     const auto configured_count = static_cast<int>(
         std::count_if(plugstack_values_.cbegin(), plugstack_values_.cend(),
                       [](const auto &v) { return v.has_value(); }));
-    slurm_debug("[iqm_spank_plugin] parsed %d plugstack argument(s), "
-                "%zu active partition(s), require_license=%s",
-                configured_count, active_partitions_.size(),
-                require_license_ ? "true" : "false");
+    slurm_debug(
+        "[iqm_spank_plugin] parsed %d plugstack argument(s), "
+        "%zu active partition(s), require_license=%s, "
+        "validation_timeout_ms=%llu",
+        configured_count, active_partitions_.size(),
+        require_license_ ? "true" : "false",
+        static_cast<unsigned long long>(validation_timeout_milliseconds_));
+  }
+
+  /// Reset validation before a remote job step is processed.
+  void reset_validation() { validation_state_ = {}; }
+
+  /// Record that the partition filter disabled this plugin for the job step.
+  void skip_validation() {
+    validation_state_ = {.active = false, .complete = true, .successful = true};
+  }
+
+  /**
+   * @brief Store the final validation result for task-init enforcement.
+   * @param successful Whether every validation check succeeded.
+   */
+  void finish_validation(const bool successful) {
+    validation_state_ = {
+        .active = true, .complete = true, .successful = successful};
+  }
+
+  /// Return the cached validation result.
+  [[nodiscard]] Validation_state validation_state() const {
+    return validation_state_;
   }
 
 private:
@@ -660,6 +901,33 @@ private:
         "false, no, off, disabled)",
         static_cast<int>(value.size()), value.data(), arg_name);
     return false;
+  }
+
+  /**
+   * @brief Parse a launch-validation request timeout in whole seconds.
+   *
+   * Invalid values log a warning and retain the non-optional 30-second
+   * default. The upper bound prevents accidentally restoring the one-hour
+   * general-purpose HTTP timeout on Slurm's task-launch path.
+   *
+   * @param value The raw plugstack argument value.
+   * @return The timeout in milliseconds.
+   */
+  [[nodiscard]] static uint64_t parse_timeout_arg(std::string_view value) {
+    uint64_t timeout_seconds = 0;
+    const auto *first = value.data();
+    const auto *last = first + value.size();
+    const auto result = std::from_chars(first, last, timeout_seconds);
+    if (result.ec == std::errc{} && result.ptr == last &&
+        timeout_seconds >= 1 &&
+        timeout_seconds <= K_MAX_VALIDATION_TIMEOUT_SECONDS) {
+      return timeout_seconds * 1'000;
+    }
+    slurm_spank_log(
+        "[iqm_spank_plugin] warning: invalid iqm_validation_timeout '%.*s'; "
+        "using 30 seconds (expected an integer from 1 to 3600)",
+        static_cast<int>(value.size()), value.data());
+    return K_DEFAULT_VALIDATION_TIMEOUT_MILLISECONDS;
   }
 
   /**
@@ -805,6 +1073,13 @@ private:
   /// mismatches warn and an absent request is ignored. Configurable via
   /// `iqm_require_license` (default: false/off).
   bool require_license_ = false;
+
+  /// Once-per-node, per-job-step validation result consumed by task-init hooks.
+  Validation_state validation_state_{};
+
+  /// Per-request timeout used by mandatory backend validation.
+  uint64_t validation_timeout_milliseconds_ =
+      K_DEFAULT_VALIDATION_TIMEOUT_MILLISECONDS;
 };
 
 /// Global plugin configuration instance. Populated once during SPANK init,
@@ -838,6 +1113,22 @@ void Emit_hook_log(const char *hook_name) {
   slurm_spank_log("[iqm_spank_plugin] hook=%s", hook_name);
 }
 
+/**
+ * @brief Determine whether this hook invocation belongs to local task zero.
+ *
+ * Hooks without a remote task context are treated as primary. If Slurm cannot
+ * provide a task ID, retaining the historical task-zero behavior preserves
+ * diagnostics and license enforcement.
+ */
+bool Is_primary_task(spank_t spank) {
+  if (spank_remote(spank) != 1) {
+    return true;
+  }
+  int local_task_id = 0;
+  return spank_get_item(spank, S_TASK_ID, &local_task_id) != ESPANK_SUCCESS ||
+         local_task_id == 0;
+}
+
 } // namespace
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -864,6 +1155,9 @@ int slurm_spank_init(spank_t spank, const int ac, char **av) {
   Emit_hook_log("slurm_spank_init");
   g_config.parse_plugstack_args(ac, av);
   g_config.log_parsed_config();
+  if (spank_remote(spank) == 1) {
+    g_config.reset_validation();
+  }
   return g_config.register_options(spank);
 }
 
@@ -878,10 +1172,58 @@ int slurm_spank_init_post_opt(spank_t /* spank */, const int /* ac */,
 }
 
 /**
+ * @brief SPANK job-step user init hook (unprivileged context).
+ *
+ * Injects IQM environment variables and validates the resulting
+ * configuration and IQM backend exactly once per node for each remote job
+ * step.
+ *
+ * The hook intentionally returns success after caching a failure. Returning
+ * an error from `slurm_spank_user_init` can drain the node; the cached result
+ * is enforced safely from `slurm_spank_task_init` instead.
+ *
+ * @return `ESPANK_SUCCESS`.
+ */
+int slurm_spank_user_init(spank_t spank, const int /* ac */, char ** /* av */) {
+  Emit_hook_log("slurm_spank_user_init");
+
+  if (spank_remote(spank) != 1) {
+    return ESPANK_SUCCESS;
+  }
+
+  if (g_config.validation_state().complete) {
+    return ESPANK_SUCCESS;
+  }
+
+  if (!g_config.is_active_for_job(spank)) {
+    g_config.skip_validation();
+    return ESPANK_SUCCESS;
+  }
+
+  if (g_config.inject_environment(spank) != ESPANK_SUCCESS) {
+    g_config.finish_validation(false);
+    return ESPANK_SUCCESS;
+  }
+
+  const auto environment_rc =
+      IQMSpankConfigManager::validate_environment(spank);
+
+  IQMSpankConfigManager::check_tokens_file_access(spank);
+
+  bool successful = environment_rc == ESPANK_SUCCESS;
+  if (successful) {
+    successful = g_config.validate_backend(spank) == ESPANK_SUCCESS;
+  }
+  g_config.finish_validation(successful);
+  return ESPANK_SUCCESS;
+}
+
+/**
  * @brief SPANK task init hook (unprivileged context).
  *
- * Injects IQM environment variables into the job environment and performs
- * validation of the resulting configuration.
+ * Enforces the validation result cached once per node for the remote job step.
+ * Slurm only exposes `SLURM_JOB_LICENSES` at task-init time, so local task zero
+ * also performs the inexpensive license-alignment check and emits diagnostics.
  *
  * Slurm-ABI note: slurmstepd (`task.c`, `spank_user_task(...) < 0`) only
  * treats a *negative* return from this specific hook as fatal — it does
@@ -894,29 +1236,35 @@ int slurm_spank_init_post_opt(spank_t /* spank */, const int /* ac */,
  * @return `ESPANK_SUCCESS` on success, `-1` if validation failed.
  */
 int slurm_spank_task_init(spank_t spank, const int /* ac */, char ** /* av */) {
-  Emit_hook_log("slurm_spank_task_init");
-
-  // Partition filter: skip if job is not on an active partition.
-  if (!g_config.is_active_for_job(spank)) {
+  if (spank_remote(spank) != 1) {
+    Emit_hook_log("slurm_spank_task_init");
     return ESPANK_SUCCESS;
   }
 
-  if (const auto rc = g_config.inject_environment(spank);
-      rc != ESPANK_SUCCESS) {
+  const bool is_primary_task = Is_primary_task(spank);
+  if (is_primary_task) {
+    Emit_hook_log("slurm_spank_task_init");
+  }
+
+  const auto validation = g_config.validation_state();
+  if (!validation.active) {
+    return ESPANK_SUCCESS;
+  }
+  if (!validation.complete || !validation.successful) {
+    if (is_primary_task) {
+      slurm_spank_log("[iqm_spank_plugin] error: job rejected because IQM "
+                      "validation failed");
+    }
     return -1;
   }
 
-  const auto validation_rc = IQMSpankConfigManager::validate_environment(spank);
-  const auto license_validation_rc = g_config.validate_license_alignment(spank);
+  if (!is_primary_task) {
+    return ESPANK_SUCCESS;
+  }
 
-  // Auth file accessibility check (warning only).
-  IQMSpankConfigManager::check_tokens_file_access(spank);
-
-  // Structured diagnostic summary.
+  const auto license_rc = g_config.validate_license_alignment(spank);
   g_config.emit_diagnostics(spank);
-
-  if (validation_rc != ESPANK_SUCCESS ||
-      license_validation_rc != ESPANK_SUCCESS) {
+  if (license_rc != ESPANK_SUCCESS) {
     return -1;
   }
   return ESPANK_SUCCESS;
@@ -926,9 +1274,11 @@ int slurm_spank_task_init(spank_t spank, const int /* ac */, char ** /* av */) {
  * @brief SPANK task init hook (privileged context).
  * @return `ESPANK_SUCCESS`.
  */
-int slurm_spank_task_init_privileged(spank_t /* spank */, const int /* ac */,
+int slurm_spank_task_init_privileged(spank_t spank, const int /* ac */,
                                      char ** /* av */) {
-  Emit_hook_log("slurm_spank_task_init_privileged");
+  if (Is_primary_task(spank)) {
+    Emit_hook_log("slurm_spank_task_init_privileged");
+  }
   return ESPANK_SUCCESS;
 }
 

--- a/spank/noxfile.py
+++ b/spank/noxfile.py
@@ -64,6 +64,14 @@ def smoke_tests(session: nox.Session) -> None:
         default=os.environ.get("IQM_TOKENS_FILE"),
         help="Optional tokens file path to validate with test_env_injection.sh.",
     )
+    parser.add_argument(
+        "--request-count-url",
+        help="Optional mock-backend counter URL for once-per-node validation.",
+    )
+    parser.add_argument(
+        "--hang-base-url",
+        help="Optional mock-backend URL for request-timeout validation.",
+    )
     args, posargs = parser.parse_known_args(session.posargs)
     if posargs:
         joined_args = " ".join(posargs)
@@ -95,6 +103,10 @@ def smoke_tests(session: nox.Session) -> None:
     ]
     if args.test_tokens_file:
         env_args.extend(["--test-tokens-file", args.test_tokens_file])
+    if args.request_count_url:
+        env_args.extend(["--request-count-url", args.request_count_url])
+    if args.hang_base_url:
+        env_args.extend(["--hang-base-url", args.hang_base_url])
 
     session.run(*env_args, external=True)
 

--- a/spank/test/entrypoint.sh
+++ b/spank/test/entrypoint.sh
@@ -32,8 +32,26 @@ if [[ ! -f /workspace/.built-in-image ]]; then
 
   # The CMake installation writes a commented-out template of iqm-qdmi.conf.
   # We must activate it by writing the uncommented, active required line.
-  echo "required $SLURM_LIB_DIR/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech" \
+  echo "required $SLURM_LIB_DIR/iqm-spank-plugin.so iqm_base_url=http://127.0.0.1:18080 iqm_validation_timeout=1" \
     | sudo tee /etc/slurm/plugstack.conf.d/iqm-qdmi.conf
+fi
+
+# Start the credential-free IQM API fixture used by mandatory backend checks.
+echo "=== Starting local IQM API fixture ==="
+uv run --script /workspace/spank/test/mock_iqm_backend.py \
+  >/tmp/mock-iqm-backend.log 2>&1 &
+mock_iqm_pid=$!
+trap 'kill "$mock_iqm_pid" 2>/dev/null || true' EXIT
+for _ in {1..30}; do
+  if curl --fail --silent http://127.0.0.1:18080/request-count >/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+if ! curl --fail --silent http://127.0.0.1:18080/request-count >/dev/null; then
+  echo "ERROR: Local IQM API fixture did not start"
+  cat /tmp/mock-iqm-backend.log
+  exit 1
 fi
 
 # Start Munge service
@@ -46,7 +64,15 @@ sudo /usr/sbin/slurmctld || { echo "ERROR: slurmctld failed to start"; exit 1; }
 
 # Start Slurmd
 echo "=== Starting Slurmd ==="
-sudo /usr/sbin/slurmd -N localhost || { echo "ERROR: slurmd failed to start"; exit 1; }
+# Poison the daemon-only IQM environment. The plugin must validate the SPANK
+# job environment instead of inheriting any of these service-process values.
+sudo env \
+  IQM_BASE_URL="http://127.0.0.1:1" \
+  IQM_TOKEN="daemon-only-token" \
+  IQM_TOKENS_FILE="/daemon-only/missing-tokens.json" \
+  IQM_QC_ID="daemon-only-qc-id" \
+  IQM_QC_ALIAS="daemon-only-qc-alias" \
+  /usr/sbin/slurmd -N localhost || { echo "ERROR: slurmd failed to start"; exit 1; }
 
 # Wait for node to be ready
 echo "=== Waiting for Slurm node to become ready ==="
@@ -64,4 +90,4 @@ if ! sinfo -h -n "localhost" -o "%t" | grep -qE "idle|alloc"; then
   exit 1
 fi
 
-exec "$@"
+"$@"

--- a/spank/test/mock_iqm_backend.py
+++ b/spank/test/mock_iqm_backend.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 IQM Finland Oy
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
+"""Minimal local IQM API used by the Docker SPANK tests."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import ClassVar
+
+
+class IQMRequestHandler(BaseHTTPRequestHandler):
+    """Serve the IQM endpoints required by QDMI session initialization."""
+
+    request_count: ClassVar[int] = 0
+
+    def do_GET(self) -> None:
+        """Return a minimal successful response for a supported IQM endpoint."""
+        path = self.path
+        if path == "/request-count":
+            self._send_json(self.request_count)
+            return
+
+        type(self).request_count += 1
+        if path.startswith("/hang/"):
+            time.sleep(3)
+            path = path.removeprefix("/hang")
+
+        if path == "/api/v1/quantum-computers":
+            self._send_json({
+                "quantum_computers": [
+                    {"id": "qc-default", "alias": "default"},
+                    {"id": "qc-emerald", "alias": "emerald"},
+                    {"id": "qc-emerald-mock", "alias": "emerald:mock"},
+                ]
+            })
+            return
+        if path.endswith("/artifacts/static-quantum-architectures"):
+            self._send_json([
+                {
+                    "qubits": ["QB1"],
+                    "computational_resonators": [],
+                    "connectivity": [],
+                }
+            ])
+            return
+        if path.endswith("/dynamic-quantum-architecture"):
+            self._send_json({
+                "calibration_set_id": "00000000-0000-0000-0000-000000000000",
+                "gates": {},
+            })
+            return
+        if path.endswith("/metrics"):
+            self._send_json({"observations": []})
+            return
+        if path == "/cocos/health":
+            self._send_json({"services": [], "warnings": []})
+            return
+
+        self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Suppress routine request logs in the test container."""
+
+    def _send_json(self, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        with contextlib.suppress(BrokenPipeError):
+            self.wfile.write(body)
+
+
+def main() -> None:
+    """Run the mock server until the test container exits."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=18080, type=int)
+    args = parser.parse_args()
+    ThreadingHTTPServer((args.host, args.port), IQMRequestHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/spank/test/run_docker_tests.sh
+++ b/spank/test/run_docker_tests.sh
@@ -31,6 +31,17 @@ show_logs() {
 # If any command fails, dump logs before exiting
 trap show_logs ERR
 
+echo "=== Verifying self-contained SPANK plugin installation ==="
+plugin_path=$(find /usr/lib -name iqm-spank-plugin.so -print -quit)
+if [[ -z "${plugin_path}" ]]; then
+  echo "IQM SPANK plugin was not installed" >&2
+  exit 1
+fi
+if ldd "${plugin_path}" | grep -Fq libiqm-qdmi-device; then
+  echo "IQM SPANK plugin unexpectedly depends on the shared IQM QDMI device" >&2
+  exit 1
+fi
+
 echo "=== Verifying basic Slurm srun connectivity ==="
 srun --partition=debug --immediate=5 /bin/true
 
@@ -43,7 +54,9 @@ uvx nox -s smoke_tests -- \
   --partition debug \
   --hook-mode full \
   --require-all-hooks \
-  --test-base-url "https://resonance.iqm.tech"
+  --test-base-url "http://127.0.0.1:18080" \
+  --request-count-url "http://127.0.0.1:18080/request-count" \
+  --hang-base-url "http://127.0.0.1:18080/hang"
 
 # Running resonance tests if authentication is configured
 if [[ -n "${IQM_TOKEN:-}" || -n "${IQM_TOKENS_FILE:-}" ]]; then

--- a/spank/test/test_env_injection.sh
+++ b/spank/test/test_env_injection.sh
@@ -28,9 +28,14 @@
 #   1. Plugstack-configured variables are visible in the job environment.
 #   2. User-set variables override plugstack defaults (precedence).
 #   3. Unconfigured variables are absent from the job environment.
-#   4. Conflicting auth is rejected.
-#   5. srun options have highest precedence.
-#   6. Missing IQM_BASE_URL is rejected.
+#   4. Configured token files are visible in the job environment.
+#   5. Conflicting auth is rejected.
+#   6. srun options have highest precedence.
+#   7. Missing IQM_BASE_URL is rejected.
+#   8. An unavailable IQM backend is rejected.
+#   9. Daemon-only IQM variables do not affect backend validation.
+#  10. Backend validation and task diagnostics run once per node and job step.
+#  11. Backend validation fails within its configured HTTP timeout.
 
 set -euo pipefail
 
@@ -38,6 +43,8 @@ partition=""
 srun_cmd="srun"
 test_base_url="https://test.example.com"
 test_tokens_file=""
+request_count_url=""
+hang_base_url=""
 
 passed=0
 failed=0
@@ -105,6 +112,10 @@ Options:
                            (default: https://test.example.com).
   --test-tokens-file <f>   Expected IQM_TOKENS_FILE from plugstack config
                            (if set).
+  --request-count-url <u>  Optional mock-backend counter endpoint used to
+                           verify once-per-node, per-step validation.
+  --hang-base-url <u>      Optional mock-backend URL that accepts requests but
+                           delays responses beyond the configured timeout.
   -h, --help               Show this help.
 
 Examples:
@@ -137,6 +148,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --test-tokens-file)
       test_tokens_file="$2"
+      shift 2
+      ;;
+    --request-count-url)
+      request_count_url="$2"
+      shift 2
+      ;;
+    --hang-base-url)
+      hang_base_url="$2"
       shift 2
       ;;
     -h | --help)
@@ -198,7 +217,11 @@ fi
 
 echo "--- Test 2: User override takes precedence ---" >&2
 
-override_base_url="https://user-override.example.com"
+if [[ "$test_base_url" == */ ]]; then
+  override_base_url="${test_base_url%/}"
+else
+  override_base_url="${test_base_url}/"
+fi
 job_base_url_override=$(IQM_BASE_URL="$override_base_url" get_job_env "IQM_BASE_URL") || true
 
 if [[ "$job_base_url_override" == "$override_base_url" ]]; then
@@ -274,7 +297,7 @@ fi
 
 echo "--- Test 6: srun --iqm-base-url overrides plugstack and user env ---" >&2
 
-srun_override_base_url="https://srun-override.example.com"
+srun_override_base_url="$test_base_url"
 
 # Run srun with --iqm-base-url, plus IQM_BASE_URL in env to test full precedence.
 override_args=(--immediate=3 -N1 -n1)
@@ -327,6 +350,139 @@ elif [[ $missing_url_rc -ne 0 ]]; then
   pass "srun failed (rc=$missing_url_rc) when IQM_BASE_URL is empty"
 else
   fail "Missing IQM_BASE_URL was not rejected"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: Unavailable IQM backend is rejected
+# ---------------------------------------------------------------------------
+
+echo "--- Test 8: Unavailable IQM backend is rejected ---" >&2
+
+unavailable_args=(--immediate=3 --overcommit -N1 -n2)
+if [[ -n "$partition" ]]; then
+  unavailable_args+=(--partition "$partition")
+fi
+unavailable_args+=(--iqm-base-url=http://127.0.0.1:1)
+
+set +e
+unavailable_output=$("$srun_cmd" "${unavailable_args[@]}" /bin/true 2>&1)
+unavailable_rc=$?
+set -e
+rejection_log_count=$(grep -Fc \
+  "[iqm_spank_plugin] error: job rejected because IQM validation failed" \
+  <<<"$unavailable_output" || true)
+
+if [[ $unavailable_rc -eq 0 ]]; then
+  fail "srun succeeded despite an unavailable IQM backend"
+elif echo "$unavailable_output" | grep -Fq "IQM backend validation failed"; then
+  pass "Unavailable IQM backend rejected before task launch"
+else
+  fail "srun failed (rc=$unavailable_rc) without the backend-validation message"
+fi
+
+if [[ $rejection_log_count -eq 1 ]]; then
+  pass "Multi-task validation failure emitted one rejection diagnostic"
+else
+  fail "Expected one cached-failure diagnostic, observed $rejection_log_count"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: Daemon-only IQM variables do not affect validation
+# ---------------------------------------------------------------------------
+
+echo "--- Test 9: Daemon IQM environment is isolated from jobs ---" >&2
+
+if run_srun /bin/sh -c \
+  'test -z "${IQM_TOKEN:-}" && test -z "${IQM_TOKENS_FILE:-}" && test -z "${IQM_QC_ID:-}" && test -z "${IQM_QC_ALIAS:-}"' \
+  >/dev/null; then
+  pass "Backend validation ignored daemon-only IQM variables"
+else
+  fail "Daemon-only IQM variables affected validation or reached the job"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: Backend validation and diagnostics run once per node and job step
+# ---------------------------------------------------------------------------
+
+echo "--- Test 10: Backend validation and diagnostics run once per node and job step ---" >&2
+
+if [[ -z "$request_count_url" ]]; then
+  skip "No --request-count-url provided; skipping once-per-node assertions"
+else
+  reference_before=$(curl --fail --silent "$request_count_url")
+  if run_srun /bin/true >/dev/null; then
+    reference_after=$(curl --fail --silent "$request_count_url")
+    reference_delta=$((reference_after - reference_before))
+  else
+    reference_delta=0
+  fi
+
+  before_count=$(curl --fail --silent "$request_count_url")
+  once_args=(--immediate=3 --overcommit -N1 -n2)
+  if [[ -n "$partition" ]]; then
+    once_args+=(--partition "$partition")
+  fi
+
+  set +e
+  once_output=$("$srun_cmd" "${once_args[@]}" /bin/true 2>&1)
+  once_rc=$?
+  set -e
+  after_count=$(curl --fail --silent "$request_count_url")
+  request_delta=$((after_count - before_count))
+  task_init_log_count=$(grep -Ec \
+    '\[iqm_spank_plugin\] hook=slurm_spank_task_init$' <<<"$once_output" || true)
+  privileged_log_count=$(grep -Ec \
+    '\[iqm_spank_plugin\] hook=slurm_spank_task_init_privileged$' \
+    <<<"$once_output" || true)
+  diagnostic_log_count=$(grep -Ec \
+    '\[iqm_spank_plugin\] job=.* partition=' <<<"$once_output" || true)
+
+  if [[ $once_rc -ne 0 ]]; then
+    fail "Two-task srun failed (rc=$once_rc)"
+  elif [[ $reference_delta -gt 0 && $request_delta -eq $reference_delta ]]; then
+    pass "Two-task single-node step performed one backend validation"
+  else
+    fail "Expected the two-task step to match one validation's $reference_delta requests, observed $request_delta"
+  fi
+
+  if [[ $task_init_log_count -eq 1 && $privileged_log_count -eq 1 && $diagnostic_log_count -eq 1 ]]; then
+    pass "Two-task job step emitted task hooks and summary diagnostics once"
+  else
+    fail "Expected one task-init, privileged-task-init, and summary diagnostic; observed $task_init_log_count, $privileged_log_count, and $diagnostic_log_count"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: A backend that accepts but never responds is bounded by HTTP timeout
+# ---------------------------------------------------------------------------
+
+echo "--- Test 11: Backend validation request timeout ---" >&2
+
+if [[ -z "$hang_base_url" ]]; then
+  skip "No --hang-base-url provided; skipping request-timeout assertion"
+else
+  timeout_args=(--immediate=3 -N1 -n1)
+  if [[ -n "$partition" ]]; then
+    timeout_args+=(--partition "$partition")
+  fi
+
+  start_seconds=$SECONDS
+  set +e
+  IQM_BASE_URL="$hang_base_url" timeout 8s "$srun_cmd" \
+    "${timeout_args[@]}" /bin/true >/dev/null 2>&1
+  timeout_rc=$?
+  set -e
+  elapsed_seconds=$((SECONDS - start_seconds))
+
+  if [[ $timeout_rc -eq 124 ]]; then
+    fail "Backend validation exceeded the 8-second outer test bound"
+  elif [[ $timeout_rc -eq 0 ]]; then
+    fail "Backend validation unexpectedly accepted a timed-out request"
+  elif [[ $elapsed_seconds -le 5 ]]; then
+    pass "Backend validation rejected a non-responsive endpoint in ${elapsed_seconds}s"
+  else
+    fail "Backend validation took ${elapsed_seconds}s despite the configured one-second request timeout"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/spank/test/test_hook_logs.sh
+++ b/spank/test/test_hook_logs.sh
@@ -189,6 +189,7 @@ local_hooks=(
 full_hooks=(
   "slurm_spank_init"
   "slurm_spank_init_post_opt"
+  "slurm_spank_user_init"
   "slurm_spank_task_init"
   "slurm_spank_task_init_privileged"
   "slurm_spank_exit"

--- a/src/internal/CMakeLists.txt
+++ b/src/internal/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
          ${PUBLIC_HEADER_FILES})
 target_compile_definitions(
   ${QDMI_INTERNAL_TARGET_NAME}
+  PUBLIC $<$<PLATFORM_ID:Windows>:NOMINMAX>
   PRIVATE QDMI_VERSION="${QDMI_VERSION}"
           IQM_QDMI_DEVICE_VERSION="${CMAKE_PROJECT_VERSION}"
           IQM_QDMI_device_EXPORTS)

--- a/src/internal/http_client.cpp
+++ b/src/internal/http_client.cpp
@@ -67,11 +67,14 @@ cpr::Header Make_json_headers(const cpr::Header &additional_headers) {
 
 void Apply_common_options(cpr::Session &session, const cpr::Url &url,
                           const std::optional<cpr::Bearer> &bearer_token,
-                          const cpr::Header &headers) {
+                          const cpr::Header &headers,
+                          const std::chrono::milliseconds timeout) {
   session.SetUrl(url);
   session.SetHeader(headers);
   session.SetUserAgent(cpr::UserAgent{"QDMI-on-IQM"});
-  session.SetTimeout(cpr::Timeout{std::chrono::seconds{3600}});
+  using CprTimeoutRep = decltype(cpr::Timeout{timeout}.Milliseconds());
+  session.SetTimeout(
+      cpr::Timeout{Clamp_timeout_for_transport<CprTimeoutRep>(timeout)});
   session.SetRedirect(cpr::Redirect{true});
   session.SetVerifySsl(cpr::VerifySsl{true});
   if (bearer_token.has_value()) {
@@ -81,17 +84,19 @@ void Apply_common_options(cpr::Session &session, const cpr::Url &url,
 
 cpr::Response Default_get(const cpr::Url &url,
                           const std::optional<cpr::Bearer> &bearer_token,
-                          const cpr::Header &headers) {
+                          const cpr::Header &headers,
+                          const std::chrono::milliseconds timeout) {
   cpr::Session session;
-  Apply_common_options(session, url, bearer_token, headers);
+  Apply_common_options(session, url, bearer_token, headers, timeout);
   return session.Get();
 }
 
 cpr::Response Default_post(const cpr::Url &url,
                            const std::optional<cpr::Bearer> &bearer_token,
-                           const cpr::Header &headers, const cpr::Body &body) {
+                           const cpr::Header &headers, const cpr::Body &body,
+                           const std::chrono::milliseconds timeout) {
   cpr::Session session;
-  Apply_common_options(session, url, bearer_token, headers);
+  Apply_common_options(session, url, bearer_token, headers, timeout);
   session.SetBody(body);
   return session.Post();
 }
@@ -135,10 +140,29 @@ void Log_error(const ERROR_LOG_POLICY policy, const std::string &message) {
 /// HTTP 429 rate limiting.
 template <typename Perform_attempt>
 cpr::Response Perform_with_retries(const cpr::Url &url,
+                                   const std::chrono::milliseconds timeout,
                                    Perform_attempt perform_attempt) {
   const auto &hooks = Get_hooks();
+  const auto start = std::chrono::steady_clock::now();
+  const auto remaining_timeout = [&]() {
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+    return elapsed >= timeout ? std::chrono::milliseconds::zero()
+                              : timeout - elapsed;
+  };
   for (uint8_t attempt = 0; attempt <= RATE_LIMIT_RETRY_COUNT; ++attempt) {
-    const auto http_response = perform_attempt();
+    const auto remaining = remaining_timeout();
+    if (remaining <= std::chrono::milliseconds::zero()) {
+      cpr::Response response;
+      response.url = url;
+      response.error =
+          cpr::Error{static_cast<int>(cpr::ErrorCode::OPERATION_TIMEDOUT),
+                     "Request and rate-limit retry deadline exceeded"};
+      return response;
+    }
+
+    const auto http_response =
+        perform_attempt(attempt == 0 ? timeout : remaining);
 
     if (http_response.error) {
       return http_response;
@@ -149,6 +173,15 @@ cpr::Response Perform_with_retries(const cpr::Url &url,
     }
 
     const int delay_seconds = Retry_after_seconds(http_response);
+    const auto retry_delay = std::chrono::seconds{delay_seconds};
+    const auto retry_budget = remaining_timeout();
+    if (retry_delay >= retry_budget) {
+      LOG_DEBUG("Request to URL '" + url.str() +
+                "' hit HTTP 429 rate limiting, but Retry-After exceeds the "
+                "remaining request timeout; not retrying");
+      return http_response;
+    }
+
     LOG_DEBUG("Request to URL '" + url.str() +
               "' hit HTTP 429 rate limiting; retrying after " +
               std::to_string(delay_seconds) +
@@ -336,27 +369,33 @@ QDMI_STATUS Handle_response(const cpr::Response &response,
 }
 
 cpr::Response Get(const cpr::Url &url,
-                  const std::optional<cpr::Bearer> &bearer_token) {
+                  const std::optional<cpr::Bearer> &bearer_token,
+                  const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing GET request to " + url.str());
   const auto &hooks = internal::Get_hooks();
   const auto headers = internal::Make_headers();
   return internal::Perform_with_retries(
-      url, [&]() { return hooks.get(url, bearer_token, headers); });
+      url, timeout, [&](const auto remaining) {
+        return hooks.get(url, bearer_token, headers, remaining);
+      });
 }
 
 cpr::Response Get_optional(const cpr::Url &url,
-                           const std::optional<cpr::Bearer> &bearer_token) {
+                           const std::optional<cpr::Bearer> &bearer_token,
+                           const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing GET request to " + url.str());
   const auto &hooks = internal::Get_hooks();
   const auto headers = internal::Make_headers();
   return internal::Perform_with_retries(
-      url, [&]() { return hooks.get(url, bearer_token, headers); });
+      url, timeout, [&](const auto remaining) {
+        return hooks.get(url, bearer_token, headers, remaining);
+      });
 }
 
 cpr::Response Post(const cpr::Url &url,
                    const std::optional<cpr::Bearer> &bearer_token,
-                   const cpr::Body &data,
-                   const cpr::Header &additional_headers) {
+                   const cpr::Body &data, const cpr::Header &additional_headers,
+                   const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing POST request to " + url.str());
   if (const auto &data_str = data.str(); !data_str.empty()) {
     LOG_DEBUG("POST data: " + data_str);
@@ -364,7 +403,9 @@ cpr::Response Post(const cpr::Url &url,
   const auto &hooks = internal::Get_hooks();
   const auto headers = internal::Make_json_headers(additional_headers);
   return internal::Perform_with_retries(
-      url, [&]() { return hooks.post(url, bearer_token, headers, data); });
+      url, timeout, [&](const auto remaining) {
+        return hooks.post(url, bearer_token, headers, data, remaining);
+      });
 }
 
 } // namespace iqm::http

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -80,6 +80,9 @@ struct IQM_QDMI_Device_Session_impl_d {
   /// API configuration
   std::unique_ptr<iqm::APIConfig> api_config_;
 
+  /// Timeout applied to each HTTP request made by this session.
+  std::chrono::milliseconds request_timeout_ = std::chrono::hours{1};
+
   /// Session status
   IQM_QDMI_DEVICE_SESSION_STATUS session_status_ =
       IQM_QDMI_DEVICE_SESSION_STATUS::ALLOCATED;
@@ -323,7 +326,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   const auto qc_list_url =
       session->api_config_->url(iqm::API_ENDPOINT::GET_QUANTUM_COMPUTERS);
   const auto bearer_token = session->token_manager_->get_bearer_token();
-  const auto qc_list_response = iqm::http::Get(qc_list_url, bearer_token);
+  const auto qc_list_response =
+      iqm::http::Get(qc_list_url, bearer_token, session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(qc_list_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -387,7 +391,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   const auto arch_url = session->api_config_->url(
       iqm::API_ENDPOINT::GET_STATIC_QUANTUM_ARCHITECTURE,
       *session->quantum_computer_alias_);
-  const auto arch_response = iqm::http::Get(arch_url, bearer_token);
+  const auto arch_response =
+      iqm::http::Get(arch_url, bearer_token, session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(arch_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -470,7 +475,8 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
   const auto dyn_arch_url = session->api_config_->url(
       iqm::API_ENDPOINT::GET_DYNAMIC_QUANTUM_ARCHITECTURE,
       *session->quantum_computer_alias_, session->calibration_set_id_);
-  const auto dyn_arch_response = iqm::http::Get(dyn_arch_url, bearer_token);
+  const auto dyn_arch_response =
+      iqm::http::Get(dyn_arch_url, bearer_token, session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(dyn_arch_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -538,7 +544,7 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
       *session->quantum_computer_alias_, session->calibration_set_id_);
   const auto bearer_token = session->token_manager_->get_bearer_token();
   const auto calibration_response =
-      iqm::http::Get(calibration_url, bearer_token);
+      iqm::http::Get(calibration_url, bearer_token, session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(calibration_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -702,7 +708,8 @@ int IQM_QDMI_device_session_init(IQM_QDMI_Device_Session session) {
   const auto cocos_health_url =
       session->api_config_->url(iqm::API_ENDPOINT::COCOS_HEALTH);
   const auto cocos_health_response = iqm::http::Get_optional(
-      cocos_health_url, session->token_manager_->get_bearer_token());
+      cocos_health_url, session->token_manager_->get_bearer_token(),
+      session->request_timeout_);
   const auto status = iqm::http::Handle_response(
       cocos_health_response, iqm::http::ERROR_LOG_POLICY::LOG_AS_DEBUG);
   session->supports_calibration_jobs_ = (status == QDMI_SUCCESS);
@@ -760,6 +767,24 @@ int IQM_QDMI_device_session_set_parameter(IQM_QDMI_Device_Session session,
   case QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2:
     value_str = &session->quantum_computer_alias_;
     break;
+  case QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3: {
+    if (value == nullptr) {
+      return QDMI_SUCCESS;
+    }
+    if (size != sizeof(uint64_t)) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    uint64_t timeout_milliseconds = 0;
+    std::memcpy(&timeout_milliseconds, value, sizeof(timeout_milliseconds));
+    if (timeout_milliseconds == 0 ||
+        timeout_milliseconds >
+            static_cast<uint64_t>(std::chrono::milliseconds::max().count())) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    session->request_timeout_ = std::chrono::milliseconds{
+        static_cast<std::chrono::milliseconds::rep>(timeout_milliseconds)};
+    return QDMI_SUCCESS;
+  }
   default:
     return QDMI_ERROR_NOTSUPPORTED;
   }
@@ -1005,7 +1030,8 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
                                       *job->session_->quantum_computer_alias_);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      json_program.dump(), {{"Expect", "100-continue"}});
+      json_program.dump(), {{"Expect", "100-continue"}},
+      job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1044,7 +1070,8 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
       iqm::API_ENDPOINT::SUBMIT_CALIBRATION_JOB);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      static_cast<const char *>(job->program_), {{"Expect", "100-continue"}});
+      static_cast<const char *>(job->program_), {{"Expect", "100-continue"}},
+      job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1113,7 +1140,8 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
           : job->session_->api_config_->url(iqm::API_ENDPOINT::CANCEL_JOB,
                                             job->job_id_);
   const auto job_abortion_response = iqm::http::Post(
-      job_abortion_url, job->session_->token_manager_->get_bearer_token(), "");
+      job_abortion_url, job->session_->token_manager_->get_bearer_token(), "",
+      {}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_abortion_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1143,7 +1171,8 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
           : job->session_->api_config_->url(iqm::API_ENDPOINT::GET_JOB_STATUS,
                                             job->job_id_);
   const auto job_status_response = iqm::http::Get(
-      job_status_url, job->session_->token_manager_->get_bearer_token());
+      job_status_url, job->session_->token_manager_->get_bearer_token(),
+      job->session_->request_timeout_);
   const auto status_code = iqm::http::Handle_response(job_status_response);
   if (status_code != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1270,7 +1299,8 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
       const auto job_results_url = job->session_->api_config_->url(
           iqm::API_ENDPOINT::GET_JOB_ARTIFACT_MEASUREMENT_COUNTS, job->job_id_);
       const auto job_results_response = iqm::http::Get(
-          job_results_url, job->session_->token_manager_->get_bearer_token());
+          job_results_url, job->session_->token_manager_->get_bearer_token(),
+          job->session_->request_timeout_);
       const auto status = iqm::http::Handle_response(job_results_response);
       if (status != QDMI_SUCCESS) {
         // Only mark the job as failed for truly fatal errors, but always
@@ -1352,7 +1382,8 @@ int IQM_QDMI_device_job_get_results_calibration_id(IQM_QDMI_Device_Job job,
     const auto job_calibration_url = job->session_->api_config_->url(
         iqm::API_ENDPOINT::GET_CALIBRATION_JOB_STATUS, job->job_id_);
     const auto job_calibration_response = iqm::http::Get(
-        job_calibration_url, job->session_->token_manager_->get_bearer_token());
+        job_calibration_url, job->session_->token_manager_->get_bearer_token(),
+        job->session_->request_timeout_);
     const auto status = iqm::http::Handle_response(job_calibration_response);
     if (status != QDMI_SUCCESS) {
       // Only mark the job as failed for truly fatal errors, but always
@@ -1415,9 +1446,9 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
     LOG_INFO("Fetching shot measurements for job " + job->job_id_);
     const auto job_measurements_url = job->session_->api_config_->url(
         iqm::API_ENDPOINT::GET_JOB_ARTIFACT_MEASUREMENTS, job->job_id_);
-    const auto job_measurements_response =
-        iqm::http::Get(job_measurements_url,
-                       job->session_->token_manager_->get_bearer_token());
+    const auto job_measurements_response = iqm::http::Get(
+        job_measurements_url, job->session_->token_manager_->get_bearer_token(),
+        job->session_->request_timeout_);
     const auto status = iqm::http::Handle_response(job_measurements_response);
     if (status != QDMI_SUCCESS) {
       // Only mark the job as failed for truly fatal errors, but always

--- a/test/unit/http_stub.cpp
+++ b/test/unit/http_stub.cpp
@@ -21,6 +21,7 @@
 
 #include "http_client.hpp"
 
+#include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/body.h>
 #include <cpr/cprtypes.h>
@@ -60,9 +61,11 @@ HttpStub::HttpStub() {
 
   hooks.get = [this](const cpr::Url &url,
                      const std::optional<cpr::Bearer> &bearer_token,
-                     const cpr::Header & /*headers*/) {
+                     const cpr::Header & /*headers*/,
+                     const std::chrono::milliseconds timeout) {
     get_urls_.push_back(url.str());
     get_bearer_tokens_.push_back(bearer_token);
+    get_timeouts_.push_back(timeout);
     if (get_responses_.empty()) {
       ADD_FAILURE() << "Unexpected GET request to '" << url
                     << "': no scripted response was queued";
@@ -81,9 +84,11 @@ HttpStub::HttpStub() {
   hooks.post = [this](const cpr::Url &url,
                       const std::optional<cpr::Bearer> &bearer_token,
                       const cpr::Header & /*headers*/,
-                      const cpr::Body & /*body*/) {
+                      const cpr::Body & /*body*/,
+                      const std::chrono::milliseconds timeout) {
     post_urls_.push_back(url.str());
     post_bearer_tokens_.push_back(bearer_token);
+    post_timeouts_.push_back(timeout);
     if (post_responses_.empty()) {
       ADD_FAILURE() << "Unexpected POST request to '" << url
                     << "': no scripted response was queued";
@@ -143,6 +148,10 @@ HttpStub::get_bearer_tokens() const {
   return get_bearer_tokens_;
 }
 
+const std::vector<std::chrono::milliseconds> &HttpStub::get_timeouts() const {
+  return get_timeouts_;
+}
+
 const std::vector<std::string> &HttpStub::post_urls() const {
   return post_urls_;
 }
@@ -150,6 +159,10 @@ const std::vector<std::string> &HttpStub::post_urls() const {
 const std::vector<std::optional<cpr::Bearer>> &
 HttpStub::post_bearer_tokens() const {
   return post_bearer_tokens_;
+}
+
+const std::vector<std::chrono::milliseconds> &HttpStub::post_timeouts() const {
+  return post_timeouts_;
 }
 
 size_t HttpStub::sleep_call_count() const { return sleep_durations_.size(); }

--- a/test/unit/http_stub.hpp
+++ b/test/unit/http_stub.hpp
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/cprtypes.h>
 #include <cstddef>
@@ -96,11 +97,17 @@ public:
   /// Bearer tokens passed to GET requests, in call order.
   [[nodiscard]] const std::vector<std::optional<cpr::Bearer>> &
   get_bearer_tokens() const;
+  /// Timeouts passed to GET requests, in call order.
+  [[nodiscard]] const std::vector<std::chrono::milliseconds> &
+  get_timeouts() const;
   /// URLs requested via POST, in call order.
   [[nodiscard]] const std::vector<std::string> &post_urls() const;
   /// Bearer tokens passed to POST requests, in call order.
   [[nodiscard]] const std::vector<std::optional<cpr::Bearer>> &
   post_bearer_tokens() const;
+  /// Timeouts passed to POST requests, in call order.
+  [[nodiscard]] const std::vector<std::chrono::milliseconds> &
+  post_timeouts() const;
   /// Number of retry-delay ("sleep") calls triggered by HTTP 429 retries.
   [[nodiscard]] size_t sleep_call_count() const;
   /// Retry-delay durations requested by HTTP 429 handling, in call order.
@@ -111,8 +118,10 @@ private:
   std::deque<Scripted_response> post_responses_;
   std::vector<std::string> get_urls_;
   std::vector<std::optional<cpr::Bearer>> get_bearer_tokens_;
+  std::vector<std::chrono::milliseconds> get_timeouts_;
   std::vector<std::string> post_urls_;
   std::vector<std::optional<cpr::Bearer>> post_bearer_tokens_;
+  std::vector<std::chrono::milliseconds> post_timeouts_;
   std::vector<int> sleep_durations_;
 };
 

--- a/test/unit/test_http_client.cpp
+++ b/test/unit/test_http_client.cpp
@@ -22,11 +22,13 @@
 #include "iqm_qdmi/constants.h"
 #include "logging.hpp"
 
+#include <chrono>
 #include <cpr/cprtypes.h>
 #include <cpr/response.h>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -210,6 +212,34 @@ TEST(HttpClientTest, BearerTokenIsPassedToHooks) {
             "test-token");
 }
 
+TEST(HttpClientTest, ExplicitTimeoutIsPassedToHooks) {
+  iqm::test_support::HttpStub http_stub;
+  http_stub.queue_get(200).queue_post(200);
+  constexpr auto timeout = std::chrono::milliseconds{1'234};
+
+  const auto get_response =
+      iqm::http::Get("https://example.test/jobs", std::nullopt, timeout);
+  const auto post_response = iqm::http::Post("https://example.test/jobs",
+                                             std::nullopt, "{}", {}, timeout);
+
+  EXPECT_EQ(iqm::http::Handle_response(get_response), QDMI_SUCCESS);
+  EXPECT_EQ(iqm::http::Handle_response(post_response), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_timeouts(),
+            std::vector<std::chrono::milliseconds>{timeout});
+  EXPECT_EQ(http_stub.post_timeouts(),
+            std::vector<std::chrono::milliseconds>{timeout});
+}
+
+TEST(HttpClientTest, TimeoutIsClampedToTransportRepresentation) {
+  constexpr auto timeout = std::chrono::milliseconds::max();
+  constexpr auto clamped =
+      iqm::http::internal::Clamp_timeout_for_transport<std::int32_t>(timeout);
+  EXPECT_EQ(clamped.count(), std::numeric_limits<std::int32_t>::max());
+  EXPECT_EQ(
+      iqm::http::internal::Clamp_timeout_for_transport<std::int64_t>(timeout),
+      timeout);
+}
+
 TEST(HttpClientTest, RetriesHttp429UsingRetryAfterUntilSuccess) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
@@ -241,6 +271,43 @@ TEST(HttpClientTest, RetriesHttp429UsingCaseInsensitiveRetryAfterHeader) {
 
   EXPECT_EQ(status, QDMI_SUCCESS);
   EXPECT_EQ(http_stub.sleep_durations(), std::vector<int>{7});
+}
+
+TEST(HttpClientTest, RateLimitRetryDoesNotOutliveRequestTimeout) {
+  const LoggerCapture logger_capture;
+  iqm::test_support::HttpStub http_stub;
+  http_stub.queue_get(429, "", {{"Retry-After", "30"}}).queue_get(200);
+
+  const auto response =
+      iqm::http::Get("https://example.test/jobs", std::nullopt,
+                     std::chrono::milliseconds{1'000});
+  const auto status = iqm::http::Handle_response(response);
+
+  EXPECT_EQ(status, QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(response.status_code, 429);
+  EXPECT_EQ(http_stub.sleep_call_count(), 0U);
+  EXPECT_EQ(http_stub.get_timeouts(), std::vector<std::chrono::milliseconds>{
+                                          std::chrono::milliseconds{1'000}});
+  EXPECT_NE(logger_capture.str().find(
+                "Retry-After exceeds the remaining request timeout"),
+            std::string::npos);
+}
+
+TEST(HttpClientTest, MaximumRequestTimeoutDoesNotOverflowRetryBudget) {
+  iqm::test_support::HttpStub http_stub;
+  http_stub.queue_get(429, "", {{"Retry-After", "30"}}).queue_get(200);
+  constexpr auto timeout = std::chrono::milliseconds::max();
+
+  const auto response =
+      iqm::http::Get("https://example.test/jobs", std::nullopt, timeout);
+  const auto status = iqm::http::Handle_response(response);
+
+  EXPECT_EQ(status, QDMI_SUCCESS);
+  ASSERT_EQ(http_stub.get_timeouts().size(), 2U);
+  EXPECT_EQ(http_stub.get_timeouts().front(), timeout);
+  EXPECT_GT(http_stub.get_timeouts().back(), std::chrono::milliseconds::zero());
+  EXPECT_LE(http_stub.get_timeouts().back(), timeout);
+  EXPECT_EQ(http_stub.sleep_durations(), std::vector<int>{30});
 }
 
 TEST(HttpClientTest,

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -21,8 +21,11 @@
 #include "iqm_qdmi/device.h"
 #include "logging.hpp"
 
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -614,6 +617,17 @@ TEST_F(DeviceTest, SessionParameterValidation) {
   EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2, 6, "value"),
             QDMI_SUCCESS);
+  const uint64_t timeout_milliseconds = 1'234;
+  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+                sizeof(timeout_milliseconds), &timeout_milliseconds),
+            QDMI_SUCCESS);
+  const uint64_t maximum_timeout =
+      static_cast<uint64_t>(std::chrono::milliseconds::max().count());
+  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+                sizeof(maximum_timeout), &maximum_timeout),
+            QDMI_SUCCESS);
 }
 
 TEST_F(DeviceTest, SessionParameterInvalidArguments) {
@@ -630,9 +644,6 @@ TEST_F(DeviceTest, SessionParameterInvalidArguments) {
 
 TEST_F(DeviceTest, SessionParameterUnsupportedParameters) {
   // Test unsupported custom parameters
-  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
-                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3, 6, "value"),
-            QDMI_ERROR_NOTSUPPORTED);
   EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
                 session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM4, 6, "value"),
             QDMI_ERROR_NOTSUPPORTED);
@@ -661,6 +672,22 @@ TEST_F(DeviceTest, SessionParameterNullValueSupport) {
   EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
                 session, QDMI_DEVICE_SESSION_PARAMETER_AUTHFILE, 0, nullptr),
             QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3, 0, nullptr),
+            QDMI_SUCCESS);
+}
+
+TEST_F(DeviceTest, SessionRequestTimeoutRejectsInvalidValues) {
+  const uint64_t zero_timeout = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+                sizeof(zero_timeout), &zero_timeout),
+            QDMI_ERROR_INVALIDARGUMENT);
+  const uint32_t wrong_size = 10;
+  EXPECT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+                sizeof(wrong_size), &wrong_size),
+            QDMI_ERROR_INVALIDARGUMENT);
 }
 
 TEST_F(DeviceTest, SessionInitializationWithoutParameters) {
@@ -1026,6 +1053,23 @@ TEST_F(DeviceIntegrationMockTest, HTTPTimeoutHandling) {
   http_stub.queue_get(408);
 
   EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_TIMEOUT);
+}
+
+TEST_F(DeviceIntegrationMockTest,
+       SessionRequestTimeoutAppliesToInitialization) {
+  const uint64_t timeout_milliseconds = 1'234;
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM3,
+                sizeof(timeout_milliseconds), &timeout_milliseconds),
+            QDMI_SUCCESS);
+  queue_successful_initialization();
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  ASSERT_EQ(http_stub.get_timeouts().size(), 5U);
+  EXPECT_TRUE(
+      std::ranges::all_of(http_stub.get_timeouts(), [](const auto timeout) {
+        return timeout == std::chrono::milliseconds{1'234};
+      }));
 }
 
 TEST_F(DeviceIntegrationMockTest, HTTPAuthenticationFailure) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary
- add a configurable per-session HTTP request budget, including bounded rate-limit retries and portable transport timeout clamping
- validate the effective IQM backend and target QC once per node and Slurm job step before task launch
- compile the IQM QDMI implementation directly into the SPANK module, avoiding a separate shared-library deployment and runtime loader setup
- isolate validation from daemon-only IQM environment variables, pass effective job values explicitly, cache the result for task hooks, and emit diagnostics once per node and step
- exercise validation with a dependency-free PEP 723 fixture run through `uv run --script`, without installing a system Python
- require Slurm 20.02 or newer

## Validation
- `uvx nox -s lint`
- 67/67 offline unit and mock tests
- exact-head Linux/Slurm Docker suite: 12 environment/validation checks passed, 1 optional token-file check skipped, and 6/6 license checks passed
- runtime dependency inspection confirms the plugin has no `libiqm-qdmi-device` dependency
- fresh independent read-only verification of the final branch

The 10 live Resonance integration tests require backend credentials and were not run locally.
