### PR TITLE
✨ RFC prototype: mirror IQM QC availability into a Slurm Dynamic License

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ releases may include breaking changes.
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114], [#134]) ([**@marcelwa**], [**@burgholzer**])
 - ✨ Add an RFC-quality prototype daemon (`spank/dynamic_license_daemon.py`)
-  polling QDMI device status into a Slurm Dynamic License via `sacctmgr`, plus
-  documentation of its open questions ([#145]) ([**@marcelwa**])
+  mirroring a Slurm-mediated job's claim on an IQM QC (via a file-based lease
+  lock, `spank/license_lock.py`, with QDMI status and an experimental IQM Server
+  API queue-depth probe as optional supplementary signals) into a Slurm Dynamic
+  License via `sacctmgr`, plus documentation of its design and open questions
+  ([#145]) ([**@marcelwa**])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ releases may include breaking changes.
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114], [#134]) ([**@marcelwa**], [**@burgholzer**])
+- ✨ Add an RFC-quality prototype daemon (`spank/dynamic_license_daemon.py`)
+  polling QDMI device status into a Slurm Dynamic License via `sacctmgr`, plus
+  documentation of its open questions ([#145]) ([**@marcelwa**])
 
 ### Changed
 
@@ -120,6 +123,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#145]: https://github.com/iqm-finland/QDMI-on-IQM/pull/145
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -254,6 +254,104 @@ that pressure itself, ahead of the QC's own queue.
 5. Optionally, add the license name to `AccountingStorageTRES` in `slurm.conf`
    to track its usage in Slurm accounting.
 
+### Reflecting Live QC Availability with Dynamic Licenses
+
+:::{warning}
+**This section describes an RFC-quality prototype, not a supported feature.** It
+is exploratory groundwork intended to prompt a design discussion, not something
+to deploy as-is on a production cluster. The polling daemon it describes lives
+at `spank/dynamic_license_daemon.py`; it is a standalone script, not an
+installed package entry point, and the SPANK plugin itself is unaware of it.
+:::
+
+The static license pool above (a fixed `Licenses=iqm_qc_emerald:4` count) caps
+how many jobs Slurm lets through concurrently, but that cap is not tied to
+whether the QC is actually free right now. A job can pass Slurm's static count
+and then still sit queued behind the QC's own internal queue. Slurm's
+**Dynamic License** mechanism (Slurm 23.02+) addresses this: instead of a fixed
+count, a Dynamic License's available count (`lastconsumed`) can be updated live
+by an external process via
+
+```bash
+sacctmgr -i modify resource iqm_qc_emerald set lastconsumed=<0|1>
+```
+
+so the scheduler only lets a job proceed once the license shows as available.
+This is the approach taken by IBM/Pasqal's QRMI (Quantum Resource Management
+Interface) papers for their own Slurm integration, which flag the same static-
+license gap this section addresses and propose Dynamic Licenses as the fix —
+while explicitly accepting the poll-interval-vs-staleness race condition
+described below as a known limitation rather than something to fully solve.
+
+**Setup** (requires Slurm 23.02 or newer):
+
+```bash
+sacctmgr add resource name=iqm_qc_emerald count=1 cluster=<cluster> \
+  allowed=100 type=license
+```
+
+**Running the daemon:**
+
+```bash
+python3 spank/dynamic_license_daemon.py --qc-alias emerald
+```
+
+Every option has an environment variable equivalent
+(`IQM_DYNAMIC_LICENSE_RESOURCE_NAME`,
+`IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS`, `IQM_DYNAMIC_LICENSE_CLUSTER`,
+`IQM_DYNAMIC_LICENSE_DRY_RUN`, plus the existing
+`IQM_BASE_URL`/`IQM_TOKEN`/`IQM_TOKENS_FILE`/`IQM_QC_ID`/`IQM_QC_ALIAS` for QC
+selection and credentials); see `--help` for the full list. Running it requires
+`mqt-core`, i.e. `iqm-qdmi[qiskit]` installed in the daemon's environment.
+
+**What "availability" actually means here.** Be skeptical of this signal before
+relying on it. The daemon polls
+{cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_STATUS` (exposed
+at the Python level via `mqt.core.fomac.Device.status()`), which is the only
+QC-status property QDMI-on-IQM exposes today. As implemented, this property is
+**local to the querying session**: it is set to `IDLE` when a session
+initializes and to `BUSY` only when *that same session* submits a job — it does
+not reflect whether other users' sessions currently have work running on the QC.
+A polling daemon that never submits jobs itself will, in practice, observe
+`IDLE` continuously, except when the QC is genuinely unreachable (session
+initialization failing, which the daemon treats as unavailable, fail-closed).
+Neither the C++ core nor the IQM Server API endpoints used elsewhere in this
+codebase (`GET /api/v1/quantum-computers`, `GET /cocos/health`) currently expose
+real queue depth or cross-tenant occupancy. This prototype therefore does not
+yet solve the problem it targets — it wires up the polling-and-`sacctmgr`
+mechanics against the only status signal QDMI currently exposes, so that
+mechanism is ready to plug into a real occupancy signal if/when one becomes
+available (e.g. a future IQM Server API queue-depth endpoint, or a
+`QDMI_DEVICE_PROPERTY_STATUS` implementation that reflects global rather than
+session-local state).
+
+**Open questions for reviewers:**
+
+- **The core gap above**: is extending the IQM Server API (or QDMI's status
+  implementation) to expose real, cross-tenant queue depth in scope, and if so,
+  is polling still the right model, or should the QC push state changes?
+- **Poll-interval-vs-staleness race**: even with a real occupancy signal, there
+  is an inherent window between a state change on the QC and the daemon's next
+  poll (and `sacctmgr` update) during which Slurm's view is stale. The QRMI
+  papers accept this as a known limitation rather than solving it; do we accept
+  the same tradeoff, and if so, what poll interval is an acceptable staleness
+  bound for this cluster's job mix?
+- **Where does the daemon run, and as whom?** A single system-level daemon per
+  QC (e.g. under systemd, on a login or admin node) needs `sacctmgr` write
+  access, which is a privileged operation. What identity/credentials should it
+  run as, and how is that access scoped down from a general admin account?
+- **One daemon instance per QC**: the current design polls one QC per process
+  invocation. A cluster with several QCs needs one instance per QC (per alias);
+  is that the right granularity, or should a single daemon poll multiple QCs?
+- **Interaction with `iqm_require_license`**: the SPANK plugin's fail-closed
+  `iqm_require_license=1` option only checks that a matching `--licenses`
+  request was made — it does not know whether that license is a static or
+  Dynamic License, nor whether the daemon updating it is alive. If the daemon
+  dies or falls behind, Slurm will hold jobs on a Dynamic License that never
+  updates again; is a staleness/liveness check needed (e.g. a systemd watchdog,
+  or Slurm-side alerting on an unchanged `lastconsumed` value) before this is
+  trusted in place of the static pool?
+
 ### Troubleshooting
 
 The plugin logs to the standard `slurmd.log` on compute nodes. Successful

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -259,9 +259,10 @@ that pressure itself, ahead of the QC's own queue.
 :::{warning}
 **This section describes an RFC-quality prototype, not a supported feature.** It
 is exploratory groundwork intended to prompt a design discussion, not something
-to deploy as-is on a production cluster. The polling daemon it describes lives
-at `spank/dynamic_license_daemon.py`; it is a standalone script, not an
-installed package entry point, and the SPANK plugin itself is unaware of it.
+to deploy as-is on a production cluster. The tooling it describes lives at
+`spank/dynamic_license_daemon.py` and `spank/license_lock.py`; these are
+standalone scripts, not installed package entry points, and the SPANK plugin
+itself (`iqm_spank_plugin.cpp`) is unaware of and unmodified by any of this.
 :::
 
 The static license pool above (a fixed `Licenses=iqm_qc_emerald:4` count) caps
@@ -290,6 +291,89 @@ sacctmgr add resource name=iqm_qc_emerald count=1 cluster=<cluster> \
   allowed=100 type=license
 ```
 
+#### What "availability" can actually mean here
+
+The open question in an earlier revision of this section was whether any signal
+exists for real, cross-tenant QC occupancy. A closer read of the IQM Server API
+reference answers part of that, with an important caveat:
+**the answer differs by deployment type**, and this prototype is designed around
+that split rather than around a single assumed-universal signal.
+
+- **No reservation/exclusive-lock endpoint exists anywhere in the API.**
+  Confirmed both from this codebase (QDMI exposes no such call) and from the
+  full API surface. There is no IQM-server-side primitive to "reserve" a QC for
+  exclusive use.
+- **Cloud/pay-as-you-go QCs do expose a real, cross-tenant queue-depth signal**:
+  a "get quantum computer queue status" endpoint returning
+  `{"available": [...], "queue_length": <int>}` — a genuine improvement over
+  anything session-local. Its exact path is **not confirmed** (the reference
+  text available while writing this section shows the schema and description but
+  not the raw path), so it is deliberately not hardcoded anywhere in this PR;
+  see `QueueLengthSignal` below.
+- There is also a credit-priced **timeslot booking API** (list/book/cancel
+  timeslots, atomic, explicitly unavailable for mock QCs) that is closer to a
+  genuine reservation primitive — but it is account/credit-based and its
+  applicability to **on-premise** devices is unconfirmed. Resonance is known to
+  manage its own pay-as-you-go queue this way; that does not necessarily hold
+  for on-prem Station Control deployments, which is exactly the deployment type
+  this document's static-license section already flags as needing Slurm-side
+  concurrency control the most. Treat this API as cloud/Resonance-oriented until
+  someone with on-prem API access confirms otherwise.
+- QDMI's own `QDMI_DEVICE_PROPERTY_STATUS` (exposed at the Python level via
+  `mqt.core.fomac.Device.status()`) remains **session-local**: `IDLE` at session
+  init, `BUSY` only when *that same session* submits a job. It says nothing
+  about other tenants and works identically (i.e., uselessly for this purpose)
+  regardless of deployment type.
+
+**Design response: don't build the enforcement mechanism on a signal that might
+not exist (on-prem) or that we can't yet confirm the shape of (cloud).**
+Instead, `dynamic_license_daemon.py` treats
+**the SPANK plugin's own acquire/release of a QC as the authoritative signal**,
+and any QC-side status API as, at best, an optional supplementary check.
+Concretely, the daemon polls one or more independent, combinable
+**signal sources** (`--signal-source`, repeatable; a QC is reported unavailable
+if *any* enabled source says so):
+
+- **`lock` (default)**: reads a small file-based lease lock
+  (`spank/license_lock.py`) that directly models "does a Slurm-mediated job
+  currently hold this QC" — the thing we actually want to gate on, and the one
+  fact that is guaranteed to be knowable uniformly across cloud and on-prem,
+  because it comes from Slurm's own job lifecycle rather than from the QC. The
+  lock is driven by Slurm's native `Prolog`/`Epilog` (or
+  `TaskProlog`/`TaskEpilog`) script hooks — configured in `slurm.conf`, so
+  **no SPANK plugin C++ changes are required**:
+
+  ```bash
+  # TaskProlog, run as the job before the task starts:
+  python3 /path/to/spank/license_lock.py acquire \
+    --resource-name "iqm_qc_${IQM_QC_ALIAS}" --ttl-seconds 21600
+
+  # TaskEpilog, run after the task ends (including on failure/cancellation):
+  python3 /path/to/spank/license_lock.py release \
+    --resource-name "iqm_qc_${IQM_QC_ALIAS}"
+  ```
+
+  Leases carry a TTL so a crashed job (whose epilog never runs) cannot leak the
+  lock forever. **This wiring is not implemented by this PR** — only the lock
+  primitive and the daemon-side read of it are. Until a cluster wires up the
+  Prolog/Epilog calls above, the lock is simply never held and this source
+  always reports "available"; that is an explicit, logged no-op-by-default
+  rather than a silent lie.
+- **`qdmi-status` (legacy, off by default)**: the original session-local QDMI
+  probe from an earlier revision of this prototype. Kept for backwards
+  compatibility and as an optional supplementary check; not recommended as the
+  sole source, for the reasons above.
+- **`queue-length` (experimental, off by default, cloud/pay-as-you-go QCs only)**:
+  best-effort polling of the queue-status endpoint described above. Because the
+  exact path is unconfirmed, this source requires an explicit
+  `--queue-status-url-template` (a URL template with a `{qc_id}` placeholder)
+  rather than shipping a guessed, hardcoded path. Any request failure (wrong
+  path, 404, network error, unexpected schema) degrades to "inconclusive" rather
+  than "busy", so a wrong or unavailable endpoint fails open on this one source
+  (the overall verdict still falls back to `lock`/other enabled sources).
+  **Do not enable this on-premise** until someone with real API/dashboard access
+  confirms it applies there.
+
 **Running the daemon:**
 
 ```bash
@@ -297,52 +381,50 @@ python3 spank/dynamic_license_daemon.py --qc-alias emerald
 ```
 
 Every option has an environment variable equivalent
-(`IQM_DYNAMIC_LICENSE_RESOURCE_NAME`,
+(`IQM_DYNAMIC_LICENSE_RESOURCE_NAME`, `IQM_DYNAMIC_LICENSE_SIGNAL_SOURCES`,
+`IQM_DYNAMIC_LICENSE_LOCK_DIR`, `IQM_DYNAMIC_LICENSE_QUEUE_STATUS_URL_TEMPLATE`,
 `IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS`, `IQM_DYNAMIC_LICENSE_CLUSTER`,
 `IQM_DYNAMIC_LICENSE_DRY_RUN`, plus the existing
 `IQM_BASE_URL`/`IQM_TOKEN`/`IQM_TOKENS_FILE`/`IQM_QC_ID`/`IQM_QC_ALIAS` for QC
-selection and credentials); see `--help` for the full list. Running it requires
-`mqt-core`, i.e. `iqm-qdmi[qiskit]` installed in the daemon's environment.
-
-**What "availability" actually means here.** Be skeptical of this signal before
-relying on it. The daemon polls
-{cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_STATUS` (exposed
-at the Python level via `mqt.core.fomac.Device.status()`), which is the only
-QC-status property QDMI-on-IQM exposes today. As implemented, this property is
-**local to the querying session**: it is set to `IDLE` when a session
-initializes and to `BUSY` only when *that same session* submits a job — it does
-not reflect whether other users' sessions currently have work running on the QC.
-A polling daemon that never submits jobs itself will, in practice, observe
-`IDLE` continuously, except when the QC is genuinely unreachable (session
-initialization failing, which the daemon treats as unavailable, fail-closed).
-Neither the C++ core nor the IQM Server API endpoints used elsewhere in this
-codebase (`GET /api/v1/quantum-computers`, `GET /cocos/health`) currently expose
-real queue depth or cross-tenant occupancy. This prototype therefore does not
-yet solve the problem it targets — it wires up the polling-and-`sacctmgr`
-mechanics against the only status signal QDMI currently exposes, so that
-mechanism is ready to plug into a real occupancy signal if/when one becomes
-available (e.g. a future IQM Server API queue-depth endpoint, or a
-`QDMI_DEVICE_PROPERTY_STATUS` implementation that reflects global rather than
-session-local state).
+selection and credentials); see `--help` for the full list. The `lock` source
+has no extra dependencies; `qdmi-status` requires `mqt-core`, i.e.
+`iqm-qdmi[qiskit]` installed in the daemon's environment.
 
 **Open questions for reviewers:**
 
-- **The core gap above**: is extending the IQM Server API (or QDMI's status
-  implementation) to expose real, cross-tenant queue depth in scope, and if so,
-  is polling still the right model, or should the QC push state changes?
-- **Poll-interval-vs-staleness race**: even with a real occupancy signal, there
-  is an inherent window between a state change on the QC and the daemon's next
+- **Is the `lock`-as-authoritative-signal design the right call?** It sidesteps
+  the on-prem/cloud signal-availability gap above, at the cost of only tracking
+  "did a Slurm job claim this QC," not the QC's true internal state (e.g. a QC
+  could still be busy from non-Slurm-mediated access). Is that an acceptable
+  scope for this mechanism, or is closing that gap (e.g. by confirming and
+  wiring up the queue-status endpoint for cloud QCs, and finding an on-prem
+  equivalent) a prerequisite before this is trusted in place of the static pool?
+- **Who wires the Prolog/Epilog hooks, and how robustly?** This PR ships the
+  lock primitive and documents the intended `TaskProlog`/`TaskEpilog` calls
+  above, but does not wire them into any packaged Slurm configuration. Should
+  that wiring ship as part of this mechanism (e.g. a documented drop-in script
+  pair, or eventually a real SPANK-plugin-side acquire/release), or remain an
+  administrator's responsibility?
+- **Poll-interval-vs-staleness race**: even with the lock as the primary signal,
+  there is an inherent window between a lock state change and the daemon's next
   poll (and `sacctmgr` update) during which Slurm's view is stale. The QRMI
-  papers accept this as a known limitation rather than solving it; do we accept
-  the same tradeoff, and if so, what poll interval is an acceptable staleness
-  bound for this cluster's job mix?
+  papers accept the equivalent tradeoff as a known limitation rather than
+  solving it; do we accept the same here, and if so, what poll interval is an
+  acceptable staleness bound for this cluster's job mix?
 - **Where does the daemon run, and as whom?** A single system-level daemon per
   QC (e.g. under systemd, on a login or admin node) needs `sacctmgr` write
   access, which is a privileged operation. What identity/credentials should it
   run as, and how is that access scoped down from a general admin account?
-- **One daemon instance per QC**: the current design polls one QC per process
-  invocation. A cluster with several QCs needs one instance per QC (per alias);
-  is that the right granularity, or should a single daemon poll multiple QCs?
+  Separately, the lock directory needs to be writable by every node running the
+  Prolog/Epilog hooks and readable by the daemon — likely a shared filesystem
+  path, which has its own consistency caveats.
+- **One daemon instance (and one lock) per QC**: the current design polls one QC
+  per process invocation and the lock supports a single holder per resource,
+  matching a `Licenses=<resource>:1` grant. A cluster with several QCs needs one
+  daemon instance per QC (per alias); pool sizes greater than 1
+  (`Licenses=<resource>:4`) are not supported by the lock as implemented — is
+  single-holder-per-resource the right scope for this mechanism, or does it need
+  to model a counted pool?
 - **Interaction with `iqm_require_license`**: the SPANK plugin's fail-closed
   `iqm_require_license=1` option only checks that a matching `--licenses`
   request was made — it does not know whether that license is a static or

--- a/spank/dynamic_license_daemon.py
+++ b/spank/dynamic_license_daemon.py
@@ -17,13 +17,13 @@
 # You should have received a copy of the GNU General Public License along
 # with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Prototype daemon that mirrors an IQM QC's device status into a Slurm Dynamic License.
+"""Prototype daemon that mirrors IQM QC availability into a Slurm Dynamic License.
 
 **This is an RFC-quality prototype, not production-ready tooling.** See
 `docs/spank_plugin.md` (section "Reflecting Live QC Availability with Dynamic
-Licenses") for the design rationale, the honest limitations of the "QC status"
-signal used here, and the open questions this prototype intentionally leaves
-for reviewers.
+Licenses") for the design rationale, the honest limitations of each
+availability signal below, and the open questions this prototype
+intentionally leaves for reviewers.
 
 In short: the SPANK plugin's static `Licenses=` mechanism (see "Limiting
 Concurrent Access with Slurm Licenses" in the same document) caps how many
@@ -34,10 +34,29 @@ license's available count live via
 
     sacctmgr -i modify resource <name> set lastconsumed=<0|1>
 
-This script polls `QDMI_DEVICE_PROPERTY_STATUS` for a given QC (via the
-`mqt.core.fomac` bindings that back this package's Qiskit integration) and
-drives that command accordingly, so Slurm can hold jobs back until the QC
-reports itself idle.
+This script polls one or more configurable **signal sources** for a given QC
+and drives that command accordingly, so Slurm can hold jobs back until the QC
+looks available. Three sources are available, and more than one can be
+combined (a QC is reported unavailable if *any* enabled source says so):
+
+- `lock` (**default, and the recommended primary source**): reads the
+  file-based lease lock in `license_lock.py`, which models "does a
+  Slurm-mediated job currently hold this QC" directly. It requires wiring a
+  Slurm `Prolog`/`Epilog` (or `TaskProlog`/`TaskEpilog`) script to call
+  `license_lock.py acquire`/`release` -- see `docs/spank_plugin.md`. Until
+  that is wired up for a given cluster, the lock is simply never held and
+  this source always reports "available".
+- `qdmi-status` (legacy, off by default): polls
+  `QDMI_DEVICE_PROPERTY_STATUS`. This is a **session-local** signal -- see
+  `is_available()`'s docstring -- and does not reflect other tenants' usage
+  of the QC. Kept for backwards compatibility and as an optional
+  supplementary check, not recommended as the sole source.
+- `queue-length` (**experimental, off by default, cloud/pay-as-you-go QCs
+  only**): best-effort polling of an IQM Server API queue-status endpoint
+  that reports a real, cross-tenant `queue_length`. The exact endpoint path
+  is *not confirmed* and is deliberately not hardcoded here -- see
+  `QueueLengthSignal` and `docs/spank_plugin.md`. Its applicability to
+  on-premise deployments is unverified; do not enable it there.
 
 Usage:
 
@@ -51,13 +70,19 @@ environment variable equivalent.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, Protocol
+
+import license_lock
 
 if TYPE_CHECKING:
     from mqt.core.fomac import Device
@@ -68,6 +93,9 @@ LOGGER = logging.getLogger("iqm_dynamic_license_daemon")
 #: license consumed, i.e. `lastconsumed=1`). Everything else (currently only
 #: `IDLE`) is reflected as "available" (`lastconsumed=0`).
 _UNAVAILABLE_STATUS_NAMES = frozenset({"OFFLINE", "BUSY", "ERROR", "MAINTENANCE", "CALIBRATION"})
+
+#: Recognized `--signal-source`/`IQM_DYNAMIC_LICENSE_SIGNAL_SOURCES` values.
+KNOWN_SIGNAL_SOURCES = ("lock", "qdmi-status", "queue-length")
 
 
 @dataclass(frozen=True)
@@ -84,6 +112,10 @@ class DaemonConfig:
     tokens_file: str | None
     qc_id: str | None
     qc_alias: str | None
+    signal_sources: tuple[str, ...]
+    lock_dir: Path
+    queue_status_url_template: str | None
+    http_timeout_seconds: float
 
 
 def _env_default(name: str, fallback: str | None = None) -> str | None:
@@ -113,13 +145,16 @@ def _env_truthy(name: str, *, default: bool = False) -> bool:
 def parse_args(argv: list[str] | None = None) -> DaemonConfig:
     """Parse command-line arguments, falling back to `IQM_*` environment variables.
 
+    Exits the process (via `argparse`) if required arguments are missing or
+    an unrecognized `--signal-source` value is given.
+
     Returns:
         The resolved `DaemonConfig` for this run.
     """
     parser = argparse.ArgumentParser(
         prog="dynamic_license_daemon",
         description=(
-            "Prototype daemon mirroring an IQM QC's QDMI device status into a Slurm Dynamic License "
+            "Prototype daemon mirroring IQM QC availability into a Slurm Dynamic License "
             "via `sacctmgr -i modify resource <name> set lastconsumed=<0|1>`. RFC-quality; see "
             "docs/spank_plugin.md for the caveats before relying on this."
         ),
@@ -134,10 +169,44 @@ def parse_args(argv: list[str] | None = None) -> DaemonConfig:
         ),
     )
     parser.add_argument(
+        "--signal-source",
+        dest="signal_sources",
+        action="append",
+        choices=KNOWN_SIGNAL_SOURCES,
+        default=None,
+        help=(
+            "Availability signal to consult; may be given multiple times to combine sources "
+            "(unavailable if any reports so). Defaults to `IQM_DYNAMIC_LICENSE_SIGNAL_SOURCES` "
+            "(comma-separated), then to just `lock`. See the module docstring for what each source means."
+        ),
+    )
+    parser.add_argument(
+        "--lock-dir",
+        default=_env_default("IQM_DYNAMIC_LICENSE_LOCK_DIR", "/var/run/iqm-dynamic-license"),
+        help="Lease lock directory used by the `lock` source (`IQM_DYNAMIC_LICENSE_LOCK_DIR`); "
+        "must match what Prolog/Epilog scripts pass to license_lock.py.",
+    )
+    parser.add_argument(
+        "--queue-status-url-template",
+        default=_env_default("IQM_DYNAMIC_LICENSE_QUEUE_STATUS_URL_TEMPLATE"),
+        help=(
+            "EXPERIMENTAL, required by the `queue-length` source: a URL template with a `{qc_id}` "
+            "placeholder for the (unconfirmed) IQM Server API queue-status endpoint. Left unset by "
+            "design -- see docs/spank_plugin.md before setting this "
+            "(`IQM_DYNAMIC_LICENSE_QUEUE_STATUS_URL_TEMPLATE`)."
+        ),
+    )
+    parser.add_argument(
         "--poll-interval",
         type=float,
         default=float(_env_default("IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS", "30") or 30),
         help="Seconds between polls (default: 30, or `IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS`).",
+    )
+    parser.add_argument(
+        "--http-timeout",
+        type=float,
+        default=float(_env_default("IQM_DYNAMIC_LICENSE_HTTP_TIMEOUT_SECONDS", "10") or 10),
+        help="Timeout in seconds for the `queue-length` source's HTTP request (default: 10).",
     )
     parser.add_argument(
         "--cluster",
@@ -184,6 +253,18 @@ def parse_args(argv: list[str] | None = None) -> DaemonConfig:
     if not resource_name:
         parser.error("--resource-name/IQM_DYNAMIC_LICENSE_RESOURCE_NAME is required when --qc-alias is not set")
 
+    if args.signal_sources:
+        signal_sources = tuple(args.signal_sources)
+    else:
+        env_sources = _env_default("IQM_DYNAMIC_LICENSE_SIGNAL_SOURCES")
+        signal_sources = tuple(s.strip() for s in env_sources.split(",") if s.strip()) if env_sources else ("lock",)
+    unknown = [s for s in signal_sources if s not in KNOWN_SIGNAL_SOURCES]
+    if unknown:
+        known = ", ".join(KNOWN_SIGNAL_SOURCES)
+        parser.error(f"unknown --signal-source value(s): {', '.join(unknown)} (known: {known})")
+    if "queue-length" in signal_sources and not args.queue_status_url_template:
+        parser.error("--signal-source queue-length requires --queue-status-url-template (see docs/spank_plugin.md)")
+
     logging.basicConfig(
         level=args.log_level.upper(),
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
@@ -200,15 +281,155 @@ def parse_args(argv: list[str] | None = None) -> DaemonConfig:
         tokens_file=args.tokens_file,
         qc_id=args.qc_id,
         qc_alias=args.qc_alias,
+        signal_sources=signal_sources,
+        lock_dir=Path(args.lock_dir),
+        queue_status_url_template=args.queue_status_url_template,
+        http_timeout_seconds=args.http_timeout,
     )
+
+
+class AvailabilitySignal(Protocol):
+    """A single, independently pollable availability signal."""
+
+    name: ClassVar[str]
+
+    def probe(self) -> bool | None:
+        """Return `True`/`False` if this source has an opinion, `None` if unknown right now."""
+        ...
+
+
+@dataclass
+class LockSignal:
+    """Primary signal: whether a Slurm-mediated job holds the file-based lease lock.
+
+    See `license_lock.py` for the acquire/release semantics and how it is
+    meant to be wired via Slurm `Prolog`/`Epilog` scripts. Until that wiring
+    exists on a given cluster, the lock is never held and this always
+    reports available (`True`) -- it does not silently guess.
+    """
+
+    name: ClassVar[str] = "lock"
+    lock_dir: Path
+    resource_name: str
+
+    def probe(self) -> bool | None:
+        """Return `True` if unlocked, `False` if a live lease is held.
+
+        Returns:
+            `True` when no live lease is held for `resource_name`, `False`
+            otherwise. This source never returns `None`: an unreadable lease
+            file is already treated as "not held" by `license_lock.is_held`.
+        """
+        held = license_lock.is_held(self.lock_dir, self.resource_name)
+        LOGGER.debug("lock signal: held=%s", held)
+        return not held
+
+
+@dataclass
+class QdmiStatusSignal:
+    """Legacy/secondary signal: QDMI's `QDMI_DEVICE_PROPERTY_STATUS`.
+
+    Kept open for the daemon's lifetime: `Device.status()` is a cheap, local
+    property read, so there is no need to reopen a session on every poll.
+    """
+
+    name: ClassVar[str] = "qdmi-status"
+    device: Device
+
+    def probe(self) -> bool | None:
+        """Return whether the device looks available, per `QDMI_DEVICE_PROPERTY_STATUS`.
+
+        Returns:
+            `True` if the device reports `IDLE`, `False` for any other
+            status. **This is a session-local signal**: it reflects only
+            whether *this daemon's own* session has an outstanding job (it
+            never submits one), not whether other tenants are using the QC.
+            See the module docstring and `docs/spank_plugin.md`.
+        """
+        status = self.device.status()
+        unavailable = status.name in _UNAVAILABLE_STATUS_NAMES
+        LOGGER.debug("qdmi-status signal: %s (available=%s)", status.name, not unavailable)
+        return not unavailable
+
+
+@dataclass
+class QueueLengthSignal:
+    """EXPERIMENTAL signal: a real, cross-tenant queue-depth count -- if it exists for this QC.
+
+    The IQM Server API exposes a "get quantum computer queue status"
+    endpoint returning a body of the shape
+    `{"available": [...], "queue_length": <int>}` for pay-as-you-go/cloud
+    QCs, per the API reference. Its exact path is not confirmed (the
+    reference text available while writing this does not show raw paths),
+    and its applicability to on-premise/Station Control deployments is
+    unverified -- Resonance is known to manage its own queue this way, but
+    that does not necessarily hold for on-prem devices. Hence this class
+    requires the caller to supply the URL template explicitly (see
+    `--queue-status-url-template`) rather than guessing a path, and treats
+    any request failure (network error, 404, unexpected schema, ...) as
+    "unknown" rather than "busy", so a wrong/missing endpoint degrades to a
+    no-op instead of wrongly blocking every job.
+    """
+
+    name: ClassVar[str] = "queue-length"
+    url_template: str
+    qc_id: str
+    token: str | None
+    timeout_seconds: float
+    _warned: bool = False
+
+    def probe(self) -> bool | None:
+        """Return whether the reported queue is empty, or `None` if the probe was inconclusive.
+
+        Returns:
+            `True` if `queue_length == 0`, `False` if `queue_length > 0`,
+            `None` if the request failed or the response did not match the
+            expected shape (logged once at WARNING, then DEBUG, to avoid
+            repeated noise every poll interval).
+        """
+        url = self.url_template.format(qc_id=self.qc_id)
+        request = urllib.request.Request(url, headers={"Authorization": f"Bearer {self.token}"} if self.token else {})  # ruff: ignore[suspicious-url-open-usage]
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:  # ruff: ignore[suspicious-url-open-usage]
+                payload = json.loads(response.read())
+            queue_length = int(payload["queue_length"])
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+            log = LOGGER.warning if not self._warned else LOGGER.debug
+            log("queue-length signal inconclusive (%s: %s); ignoring this source for now", type(e).__name__, e)
+            self._warned = True
+            return None
+        LOGGER.debug("queue-length signal: queue_length=%d", queue_length)
+        return queue_length == 0
+
+
+def build_signals(config: DaemonConfig) -> list[AvailabilitySignal]:
+    """Instantiate the `AvailabilitySignal`s selected by `config.signal_sources`.
+
+    Returns:
+        One `AvailabilitySignal` per entry in `config.signal_sources`, in
+        that order.
+    """
+    signals: list[AvailabilitySignal] = []
+    for source in config.signal_sources:
+        if source == "lock":
+            signals.append(LockSignal(lock_dir=config.lock_dir, resource_name=config.resource_name))
+        elif source == "qdmi-status":
+            signals.append(QdmiStatusSignal(device=load_device(config)))
+        elif source == "queue-length":
+            assert config.queue_status_url_template is not None
+            signals.append(
+                QueueLengthSignal(
+                    url_template=config.queue_status_url_template,
+                    qc_id=config.qc_id or config.qc_alias or "",
+                    token=config.token,
+                    timeout_seconds=config.http_timeout_seconds,
+                )
+            )
+    return signals
 
 
 def load_device(config: DaemonConfig) -> Device:
     """Load the packaged IQM QDMI device library and open a session for the target QC.
-
-    Kept open for the daemon's lifetime: `Device.status()` is a cheap, local
-    property read (see the module docstring and `docs/spank_plugin.md` for why
-    that matters), so there is no need to reopen a session on every poll.
 
     Returns:
         The initialized `mqt.core.fomac.Device` handle for the target QC.
@@ -238,18 +459,41 @@ def load_device(config: DaemonConfig) -> Device:
     )
 
 
-def is_available(device: Device) -> bool:
-    """Return whether `device` currently looks available, per `QDMI_DEVICE_PROPERTY_STATUS`.
+def _probe_signal(signal: AvailabilitySignal) -> bool | None:
+    """Probe a single `signal`, converting any exception into a fail-closed `False`.
 
     Returns:
-        `True` if the device reports `IDLE`, `False` for any other status
-        (including statuses this prototype cannot reach in practice today --
-        see the module docstring's honesty caveat).
+        The signal's own `probe()` result, or `False` if it raised.
     """
-    status = device.status()
-    unavailable = status.name in _UNAVAILABLE_STATUS_NAMES
-    LOGGER.debug("QDMI device status: %s (available=%s)", status.name, not unavailable)
-    return not unavailable
+    try:
+        return signal.probe()
+    except Exception:
+        LOGGER.exception("Signal %s raised; treating as unavailable (fail-closed)", signal.name)
+        return False
+
+
+def is_available(signals: list[AvailabilitySignal]) -> bool:
+    """Combine all `signals` into a single availability verdict.
+
+    The QC is reported unavailable if *any* signal explicitly says so
+    (conservative, fail-closed composition). If every signal is inconclusive
+    (`None`) -- including the degenerate case of no signals at all -- the QC
+    is also reported unavailable, since there is then no positive evidence
+    that it is free.
+
+    Returns:
+        `True` only if at least one signal reported `True` and none reported
+        `False`.
+    """
+    results = {signal.name: _probe_signal(signal) for signal in signals}
+
+    LOGGER.debug("Signal results: %s", results)
+    if any(result is False for result in results.values()):
+        return False
+    if any(result is True for result in results.values()):
+        return True
+    LOGGER.warning("No signal produced a definite result; treating QC as unavailable (fail-closed)")
+    return False
 
 
 def apply_lastconsumed(config: DaemonConfig, *, available: bool) -> None:
@@ -275,22 +519,20 @@ def apply_lastconsumed(config: DaemonConfig, *, available: bool) -> None:
 def run(config: DaemonConfig) -> None:
     """Run the poll loop (or a single poll, if `config.once`)."""
     LOGGER.info(
-        "Starting dynamic license daemon: resource=%s qc_id=%s qc_alias=%s poll_interval=%ss dry_run=%s",
+        "Starting dynamic license daemon: resource=%s qc_id=%s qc_alias=%s signal_sources=%s "
+        "poll_interval=%ss dry_run=%s",
         config.resource_name,
         config.qc_id,
         config.qc_alias,
+        ",".join(config.signal_sources),
         config.poll_interval_seconds,
         config.dry_run,
     )
-    device = load_device(config)
+    signals = build_signals(config)
 
     last_applied: bool | None = None
     while True:
-        try:
-            available = is_available(device)
-        except Exception:
-            LOGGER.exception("Failed to query device status; treating QC as unavailable (fail-closed)")
-            available = False
+        available = is_available(signals)
 
         if available != last_applied:
             apply_lastconsumed(config, available=available)

--- a/spank/dynamic_license_daemon.py
+++ b/spank/dynamic_license_daemon.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 IQM Finland Oy
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Prototype daemon that mirrors an IQM QC's device status into a Slurm Dynamic License.
+
+**This is an RFC-quality prototype, not production-ready tooling.** See
+`docs/spank_plugin.md` (section "Reflecting Live QC Availability with Dynamic
+Licenses") for the design rationale, the honest limitations of the "QC status"
+signal used here, and the open questions this prototype intentionally leaves
+for reviewers.
+
+In short: the SPANK plugin's static `Licenses=` mechanism (see "Limiting
+Concurrent Access with Slurm Licenses" in the same document) caps how many
+jobs Slurm lets through, but that cap is a fixed number, not a live read of
+whether the quantum computer (QC) is actually free right now. Slurm's Dynamic
+License mechanism (Slurm 23.02+) allows an external process to update a
+license's available count live via
+
+    sacctmgr -i modify resource <name> set lastconsumed=<0|1>
+
+This script polls `QDMI_DEVICE_PROPERTY_STATUS` for a given QC (via the
+`mqt.core.fomac` bindings that back this package's Qiskit integration) and
+drives that command accordingly, so Slurm can hold jobs back until the QC
+reports itself idle.
+
+Usage:
+
+    python3 dynamic_license_daemon.py --qc-alias emerald
+
+Run with `--help` for the full list of options; every option also has an
+`IQM_DYNAMIC_LICENSE_*` (or, for credentials/QC selection, plain `IQM_*`)
+environment variable equivalent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mqt.core.fomac import Device
+
+LOGGER = logging.getLogger("iqm_dynamic_license_daemon")
+
+#: `Device.Status` values that should be reflected as "unavailable" (Slurm
+#: license consumed, i.e. `lastconsumed=1`). Everything else (currently only
+#: `IDLE`) is reflected as "available" (`lastconsumed=0`).
+_UNAVAILABLE_STATUS_NAMES = frozenset({"OFFLINE", "BUSY", "ERROR", "MAINTENANCE", "CALIBRATION"})
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    """Resolved configuration for a single daemon run."""
+
+    resource_name: str
+    poll_interval_seconds: float
+    cluster: str | None
+    dry_run: bool
+    once: bool
+    base_url: str | None
+    token: str | None
+    tokens_file: str | None
+    qc_id: str | None
+    qc_alias: str | None
+
+
+def _env_default(name: str, fallback: str | None = None) -> str | None:
+    """Return a non-empty environment variable value, or `fallback`.
+
+    Returns:
+        The environment variable's value, or `fallback` if unset/empty.
+    """
+    value = os.getenv(name)
+    return value or fallback
+
+
+def _env_truthy(name: str, *, default: bool = False) -> bool:
+    """Interpret an environment variable as a boolean flag.
+
+    Returns:
+        `True` if the variable is set to a recognized truthy value, `False`
+        if set to a recognized falsy value, and `default` if unset or
+        unrecognized.
+    """
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def parse_args(argv: list[str] | None = None) -> DaemonConfig:
+    """Parse command-line arguments, falling back to `IQM_*` environment variables.
+
+    Returns:
+        The resolved `DaemonConfig` for this run.
+    """
+    parser = argparse.ArgumentParser(
+        prog="dynamic_license_daemon",
+        description=(
+            "Prototype daemon mirroring an IQM QC's QDMI device status into a Slurm Dynamic License "
+            "via `sacctmgr -i modify resource <name> set lastconsumed=<0|1>`. RFC-quality; see "
+            "docs/spank_plugin.md for the caveats before relying on this."
+        ),
+    )
+    parser.add_argument(
+        "--resource-name",
+        default=_env_default("IQM_DYNAMIC_LICENSE_RESOURCE_NAME"),
+        help=(
+            "Name of the Slurm Dynamic License resource to update (as created via `sacctmgr add resource "
+            "name=... type=license`). Defaults to `IQM_DYNAMIC_LICENSE_RESOURCE_NAME`, then to "
+            "`iqm_qc_<qc-alias>` (matching the SPANK plugin's default `iqm_license_prefix`)."
+        ),
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=float(_env_default("IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS", "30") or 30),
+        help="Seconds between polls (default: 30, or `IQM_DYNAMIC_LICENSE_POLL_INTERVAL_SECONDS`).",
+    )
+    parser.add_argument(
+        "--cluster",
+        default=_env_default("IQM_DYNAMIC_LICENSE_CLUSTER"),
+        help="Optional Slurm cluster name to scope the `sacctmgr` update to (`IQM_DYNAMIC_LICENSE_CLUSTER`).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=_env_truthy("IQM_DYNAMIC_LICENSE_DRY_RUN"),
+        help="Log the `sacctmgr` command instead of executing it (`IQM_DYNAMIC_LICENSE_DRY_RUN`).",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Poll a single time and exit, instead of looping forever. Useful for testing or cron-style setups.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=_env_default("IQM_BASE_URL"),
+        help="IQM Server base URL (defaults to `IQM_BASE_URL`, then the packaged default).",
+    )
+    parser.add_argument("--token", default=_env_default("IQM_TOKEN"), help="IQM auth token (`IQM_TOKEN`).")
+    parser.add_argument(
+        "--tokens-file",
+        default=_env_default("IQM_TOKENS_FILE"),
+        help="Path to an IQM tokens file (`IQM_TOKENS_FILE`).",
+    )
+    parser.add_argument("--qc-id", default=_env_default("IQM_QC_ID"), help="Target QC ID (`IQM_QC_ID`).")
+    parser.add_argument("--qc-alias", default=_env_default("IQM_QC_ALIAS"), help="Target QC alias (`IQM_QC_ALIAS`).")
+    parser.add_argument(
+        "--log-level",
+        default=_env_default("IQM_DYNAMIC_LICENSE_LOG_LEVEL", "INFO"),
+        help="Python logging level name (default: INFO).",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.qc_id and not args.qc_alias:
+        parser.error("one of --qc-id/IQM_QC_ID or --qc-alias/IQM_QC_ALIAS is required")
+
+    default_resource_name = f"iqm_qc_{args.qc_alias}" if args.qc_alias else None
+    resource_name = args.resource_name or default_resource_name
+    if not resource_name:
+        parser.error("--resource-name/IQM_DYNAMIC_LICENSE_RESOURCE_NAME is required when --qc-alias is not set")
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    return DaemonConfig(
+        resource_name=resource_name,
+        poll_interval_seconds=args.poll_interval,
+        cluster=args.cluster,
+        dry_run=args.dry_run,
+        once=args.once,
+        base_url=args.base_url,
+        token=args.token,
+        tokens_file=args.tokens_file,
+        qc_id=args.qc_id,
+        qc_alias=args.qc_alias,
+    )
+
+
+def load_device(config: DaemonConfig) -> Device:
+    """Load the packaged IQM QDMI device library and open a session for the target QC.
+
+    Kept open for the daemon's lifetime: `Device.status()` is a cheap, local
+    property read (see the module docstring and `docs/spank_plugin.md` for why
+    that matters), so there is no need to reopen a session on every poll.
+
+    Returns:
+        The initialized `mqt.core.fomac.Device` handle for the target QC.
+
+    Raises:
+        ImportError: If `mqt-core` (the `iqm-qdmi[qiskit]` extra) is not installed.
+    """
+    try:
+        from mqt.core.fomac import add_dynamic_device_library  # ruff: ignore[import-outside-top-level]
+    except ImportError as e:
+        msg = (
+            "This daemon requires `mqt-core`, e.g. via `uv pip install iqm-qdmi[qiskit]`. "
+            "See docs/spank_plugin.md for details."
+        )
+        raise ImportError(msg) from e
+
+    from iqm.qdmi import IQM_QDMI_LIBRARY_PATH  # ruff: ignore[import-outside-top-level]
+
+    return add_dynamic_device_library(
+        library_path=str(IQM_QDMI_LIBRARY_PATH),
+        prefix="IQM",
+        base_url=config.base_url,
+        token=config.token,
+        auth_file=config.tokens_file,
+        custom1=config.qc_id,
+        custom2=config.qc_alias,
+    )
+
+
+def is_available(device: Device) -> bool:
+    """Return whether `device` currently looks available, per `QDMI_DEVICE_PROPERTY_STATUS`.
+
+    Returns:
+        `True` if the device reports `IDLE`, `False` for any other status
+        (including statuses this prototype cannot reach in practice today --
+        see the module docstring's honesty caveat).
+    """
+    status = device.status()
+    unavailable = status.name in _UNAVAILABLE_STATUS_NAMES
+    LOGGER.debug("QDMI device status: %s (available=%s)", status.name, not unavailable)
+    return not unavailable
+
+
+def apply_lastconsumed(config: DaemonConfig, *, available: bool) -> None:
+    """Run (or log, if `--dry-run`) the `sacctmgr` command reflecting `available`."""
+    lastconsumed = 0 if available else 1
+    cmd = ["sacctmgr", "-i", "modify", "resource", config.resource_name]
+    if config.cluster:
+        cmd.append(f"cluster={config.cluster}")
+    cmd += ["set", f"lastconsumed={lastconsumed}"]
+
+    if config.dry_run:
+        LOGGER.info("[dry-run] would run: %s", " ".join(cmd))
+        return
+
+    LOGGER.info("Running: %s", " ".join(cmd))
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)  # ruff: ignore[subprocess-without-shell-equals-true]
+    if result.returncode != 0:
+        LOGGER.error("sacctmgr failed (rc=%s): %s", result.returncode, result.stderr.strip())
+    elif result.stdout.strip():
+        LOGGER.debug("sacctmgr output: %s", result.stdout.strip())
+
+
+def run(config: DaemonConfig) -> None:
+    """Run the poll loop (or a single poll, if `config.once`)."""
+    LOGGER.info(
+        "Starting dynamic license daemon: resource=%s qc_id=%s qc_alias=%s poll_interval=%ss dry_run=%s",
+        config.resource_name,
+        config.qc_id,
+        config.qc_alias,
+        config.poll_interval_seconds,
+        config.dry_run,
+    )
+    device = load_device(config)
+
+    last_applied: bool | None = None
+    while True:
+        try:
+            available = is_available(device)
+        except Exception:
+            LOGGER.exception("Failed to query device status; treating QC as unavailable (fail-closed)")
+            available = False
+
+        if available != last_applied:
+            apply_lastconsumed(config, available=available)
+            last_applied = available
+        else:
+            LOGGER.debug("No status change (available=%s); skipping sacctmgr call", available)
+
+        if config.once:
+            return
+        time.sleep(config.poll_interval_seconds)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for running this module as a script."""
+    config = parse_args(argv)
+    try:
+        run(config)
+    except KeyboardInterrupt:
+        LOGGER.info("Interrupted; exiting")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/spank/license_lock.py
+++ b/spank/license_lock.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 IQM Finland Oy
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""File-based lease lock tracking whether a Slurm-mediated job holds an IQM QC.
+
+**This is an RFC-quality prototype**, see `docs/spank_plugin.md` ("Reflecting
+Live QC Availability with Dynamic Licenses") for the design rationale.
+
+This module is deliberately **not** part of the compiled SPANK plugin and
+requires no changes to `iqm_spank_plugin.cpp`. It is meant to be driven by
+Slurm's native `Prolog`/`Epilog` (or `TaskProlog`/`TaskEpilog`) script hooks,
+configured in `slurm.conf` -- a mechanism entirely orthogonal to the SPANK
+plugin. A job's prolog acquires the lock for its target QC; its epilog
+releases it. `dynamic_license_daemon.py` then reads this lock state as its
+primary "is this QC currently claimed by a Slurm job" signal, rather than
+inferring availability from a QC-side status field of uncertain accuracy (see
+the module docstring of `dynamic_license_daemon.py`).
+
+Each lease carries a TTL so that a crashed job (whose epilog never runs)
+cannot leak the lock forever; a stale lease is treated as released.
+
+This intentionally supports only a single holder per resource, matching the
+common case of a static `Licenses=<resource>:1` grant per job. Pool sizes
+greater than 1 (e.g. `Licenses=<resource>:4`) are out of scope for this
+prototype; see `docs/spank_plugin.md` for the corresponding open question.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+LOGGER = logging.getLogger("iqm_license_lock")
+
+#: Default lease TTL. Chosen to comfortably exceed typical job step
+#: durations while still bounding how long a crashed job's epilog-less exit
+#: can leak the lock; administrators should tune this to their workloads.
+DEFAULT_TTL_SECONDS = 6 * 60 * 60
+
+
+@dataclass(frozen=True)
+class Lease:
+    """A recorded lock lease."""
+
+    holder_id: str
+    expires_at: float
+
+
+def _lock_path(lock_dir: Path, resource_name: str) -> Path:
+    """Return the lease file path for `resource_name` under `lock_dir`.
+
+    Returns:
+        The path of the lease file.
+    """
+    return lock_dir / f"{resource_name}.lease.json"
+
+
+def _read_lease(path: Path) -> Lease | None:
+    """Return the lease recorded at `path`, or `None` if absent/unreadable.
+
+    Returns:
+        The parsed `Lease`, or `None` if the file does not exist or cannot be
+        parsed (treated as "no lease held").
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(raw)
+        return Lease(holder_id=str(data["holder_id"]), expires_at=float(data["expires_at"]))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        LOGGER.warning("Ignoring unreadable lease file %s", path)
+        return None
+
+
+def _write_lease(path: Path, lease: Lease) -> None:
+    """Atomically write `lease` to `path`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
+    tmp_path.write_text(
+        json.dumps({"holder_id": lease.holder_id, "expires_at": lease.expires_at}),
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def is_held(lock_dir: Path, resource_name: str, *, now: float | None = None) -> bool:
+    """Return whether `resource_name` currently has a live (non-expired) lease.
+
+    Returns:
+        `True` if a non-expired lease exists, `False` otherwise (including
+        when the lock directory or lease file does not exist).
+    """
+    lease = _read_lease(_lock_path(lock_dir, resource_name))
+    if lease is None:
+        return False
+    return lease.expires_at > (now if now is not None else time.time())
+
+
+def acquire(
+    lock_dir: Path,
+    resource_name: str,
+    holder_id: str,
+    *,
+    ttl_seconds: float = DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+) -> bool:
+    """Acquire (or renew) the lease for `resource_name` on behalf of `holder_id`.
+
+    Fails only if a *different*, still-live holder already has the lease
+    (single-holder-per-resource semantics; see the module docstring). Safe to
+    call repeatedly by the same holder to renew/extend the lease.
+
+    Returns:
+        `True` if the lease is now held by `holder_id`, `False` if a
+        different holder's live lease blocked acquisition.
+    """
+    effective_now = now if now is not None else time.time()
+    path = _lock_path(lock_dir, resource_name)
+    existing = _read_lease(path)
+    if existing is not None and existing.expires_at > effective_now and existing.holder_id != holder_id:
+        LOGGER.info(
+            "Resource %s already held by %s (expires in %.0fs); not granting to %s",
+            resource_name,
+            existing.holder_id,
+            existing.expires_at - effective_now,
+            holder_id,
+        )
+        return False
+    _write_lease(path, Lease(holder_id=holder_id, expires_at=effective_now + ttl_seconds))
+    LOGGER.info("Resource %s acquired by %s for %.0fs", resource_name, holder_id, ttl_seconds)
+    return True
+
+
+def release(lock_dir: Path, resource_name: str, holder_id: str) -> bool:
+    """Release the lease for `resource_name` if currently held by `holder_id`.
+
+    A release requested by a holder that does not match the recorded lease
+    (e.g. a duplicate/late epilog run after the lease already expired and was
+    reacquired by another job) is a silent no-op, to avoid one job releasing
+    another job's active lease.
+
+    Returns:
+        `True` if a matching lease was removed, `False` otherwise.
+    """
+    path = _lock_path(lock_dir, resource_name)
+    existing = _read_lease(path)
+    if existing is None:
+        return False
+    if existing.holder_id != holder_id:
+        LOGGER.info(
+            "Not releasing resource %s: held by %s, release requested by %s",
+            resource_name,
+            existing.holder_id,
+            holder_id,
+        )
+        return False
+    path.unlink(missing_ok=True)
+    LOGGER.info("Resource %s released by %s", resource_name, holder_id)
+    return True
+
+
+def _default_holder_id() -> str:
+    """Return a default holder identifier derived from the Slurm job environment.
+
+    Returns:
+        `SLURM_JOB_ID` (optionally with `SLURM_STEP_ID`) if set, otherwise
+        the current process ID as a last resort for manual/testing use.
+    """
+    job_id = os.getenv("SLURM_JOB_ID")
+    if job_id:
+        step_id = os.getenv("SLURM_STEP_ID")
+        return f"{job_id}.{step_id}" if step_id else job_id
+    return f"pid:{os.getpid()}"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for running this module as a script (`acquire`/`release`/`status`)."""
+    parser = argparse.ArgumentParser(
+        prog="license_lock",
+        description=(
+            "Manage the file-based lease lock used by dynamic_license_daemon.py to track "
+            "whether a Slurm job currently holds an IQM QC. Intended to be called from Slurm "
+            "Prolog/Epilog scripts."
+        ),
+    )
+    parser.add_argument(
+        "--lock-dir",
+        default=os.getenv("IQM_DYNAMIC_LICENSE_LOCK_DIR", "/var/run/iqm-dynamic-license"),
+        help="Directory holding lease files (default: IQM_DYNAMIC_LICENSE_LOCK_DIR or /var/run/iqm-dynamic-license).",
+    )
+    parser.add_argument("--resource-name", required=True, help="Dynamic License resource name, e.g. iqm_qc_emerald.")
+    parser.add_argument(
+        "--holder-id",
+        default=_default_holder_id(),
+        help="Lease holder identifier (default: $SLURM_JOB_ID[.$SLURM_STEP_ID]).",
+    )
+    parser.add_argument(
+        "--ttl-seconds",
+        type=float,
+        default=float(os.getenv("IQM_DYNAMIC_LICENSE_LOCK_TTL_SECONDS", str(DEFAULT_TTL_SECONDS))),
+        help="Lease TTL for `acquire` (default: IQM_DYNAMIC_LICENSE_LOCK_TTL_SECONDS or 6h).",
+    )
+    parser.add_argument("command", choices=["acquire", "release", "status"])
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    lock_dir = Path(args.lock_dir)
+
+    if args.command == "acquire":
+        granted = acquire(lock_dir, args.resource_name, args.holder_id, ttl_seconds=args.ttl_seconds)
+        sys.exit(0 if granted else 1)
+    elif args.command == "release":
+        released = release(lock_dir, args.resource_name, args.holder_id)
+        sys.exit(0 if released else 1)
+    else:
+        held = is_held(lock_dir, args.resource_name)
+        print("held" if held else "free")  # ruff: ignore[print] -- CLI status output, not diagnostic logging
+        sys.exit(0 if held else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
🤖 *AI text below* 🤖

## What this is

An **RFC-quality prototype**, not a production feature — exploratory
groundwork to prompt a design discussion, not something ready to merge and
deploy as-is. It adds, purely additively:

- `spank/license_lock.py`: a standalone file-based lease lock (acquire/
  release/status), meant to be driven by Slurm's native `Prolog`/`Epilog`
  (or `TaskProlog`/`TaskEpilog`) script hooks configured in `slurm.conf` —
  **not** the SPANK plugin's C++ code.
- `spank/dynamic_license_daemon.py`: a standalone polling daemon (not an
  installed package entry point) that mirrors availability into a Slurm
  **Dynamic License** via `sacctmgr -i modify resource <name> set
  lastconsumed=<0|1>`, combining one or more pluggable **signal sources**.
- A "Reflecting Live QC Availability with Dynamic Licenses" section in
  `docs/spank_plugin.md`, after the existing static-license section.
- A CHANGELOG entry.

The SPANK plugin's C++ code and the existing static-license documentation are
**untouched**.

## Why

The SPANK plugin already supports capping concurrent access to a QC via a
flat, static Slurm license pool (`Licenses=iqm_qc_emerald:4`,
`--licenses=iqm_qc_emerald:1`) — see "Limiting Concurrent Access with Slurm
Licenses" in `docs/spank_plugin.md`. That pool is a **fixed count**, not tied
to whether the QC is actually free right now — a job can pass Slurm's static
count and then still sit queued behind the QC's own internal queue.

Two 2026 arXiv papers on **QRMI** (Quantum Resource Management Interface,
IBM/Pasqal-led) describe exactly this gap in their own Slurm+QRMI
integration, and propose Slurm's **Dynamic License** mechanism (Slurm
≥23.02) as the fix: an external daemon updates a Dynamic License's
`lastconsumed` value live, so the scheduler only lets a job through once the
license shows as available. The papers explicitly flag the resulting
poll-interval-vs-staleness race condition as a known, accepted limitation
rather than something to fully solve — this PR carries that same posture.

## Design evolution during review

The first revision of this PR polled QDMI's `QDMI_DEVICE_PROPERTY_STATUS` as
its only signal, and was upfront that this is **session-local** (`IDLE` at
session init, `BUSY` only when *that same session* submits a job) — it says
nothing about other tenants.

A follow-up look at the actual IQM Server API reference confirmed that gap
and added nuance:

- **No reservation/exclusive-lock endpoint exists anywhere in the API** —
  confirmed independently both from this codebase and from the full API
  surface.
- **Cloud/pay-as-you-go QCs do expose a real, cross-tenant queue-depth
  signal**: a "get quantum computer queue status" endpoint returning
  `{"available": [...], "queue_length": <int>}`. Its exact path is **not
  confirmed** (the reference text available while writing this shows the
  schema/description but not the raw path), so it is **deliberately not
  hardcoded** anywhere in this PR.
- A credit-priced **timeslot booking API** exists and is closer to a genuine
  reservation primitive, but it's account/credit-based, unavailable for mock
  QCs, and its applicability to **on-premise** devices is unconfirmed —
  treat it as cloud/Resonance-oriented until someone with on-prem API access
  says otherwise.

Given that the only universally-available signal — one guaranteed to work
identically for both cloud and on-prem — is not QC-side status at all but
**whether a Slurm-mediated job currently holds the QC**, this PR was
redesigned around that:

- `spank/license_lock.py` provides a small file-based lease lock (with TTLs,
  so a crashed job's missing epilog can't leak a lock forever) modeling
  "does a Slurm job hold this QC," driven by Slurm's native Prolog/Epilog
  hooks — an orthogonal mechanism to the SPANK plugin, requiring **no C++
  changes**.
- `dynamic_license_daemon.py` was refactored around a pluggable
  `AvailabilitySignal` abstraction with three sources, selectable/combinable
  via `--signal-source`:
  - **`lock` (new default)**: reads the lease lock above — the authoritative
    signal.
  - **`qdmi-status` (legacy, off by default)**: the original session-local
    QDMI probe, kept for backwards compatibility.
  - **`queue-length` (experimental, off by default, cloud-only)**:
    best-effort polling of the queue-status endpoint above, gated behind an
    explicit `--queue-status-url-template` (rather than a guessed hardcoded
    path) so it degrades to "inconclusive" instead of silently trusting an
    unconfirmed URL.

## What's prototype-quality vs. production-ready

**Prototype-quality (the whole thing, really):**

- No packaging, systemd units, tests, or CI coverage for either script.
- **The Prolog/Epilog wiring that actually populates the lock is not
  implemented by this PR** — only the lock primitive and the documented
  `TaskProlog`/`TaskEpilog` calls a cluster would need to add. Until that
  wiring exists on a given cluster, the `lock` source always reports
  "available" (an explicit, logged no-op-by-default, not a silent lie).
- The lock supports a single holder per resource (matching
  `Licenses=<resource>:1`); pool sizes greater than 1 are out of scope.
- The `queue-length` source's endpoint path is unconfirmed and must be
  supplied explicitly; it should not be enabled without independent
  verification, and never for on-prem deployments per the caveats above.

**Open questions for reviewers** (see the doc section for full detail):

1. Is the lock-as-authoritative-signal design the right scope? It tracks
   "did a Slurm job claim this QC," not the QC's true internal state.
2. Who wires the Prolog/Epilog hooks, and should that ship as part of this
   mechanism (e.g. a documented drop-in script pair) or stay an
   administrator's responsibility?
3. Given the accepted poll-interval-vs-staleness race, what's an acceptable
   staleness bound / poll interval for a real cluster's job mix?
4. Where should the daemon run, and under what identity/credentials, given
   `sacctmgr` writes are privileged? Where does the lock directory live
   (likely a shared filesystem path, with its own consistency caveats)?
5. Does a cluster with multiple QCs need one daemon instance (and lock) per
   QC, or should this model a counted pool instead of single-holder?
6. How does this interact with the SPANK plugin's fail-closed
   `iqm_require_license=1` option, which has no notion of static vs. Dynamic
   Licenses nor of daemon liveness? Is a staleness/liveness check needed
   before this could be trusted in place of the static pool?

## Testing

- `uvx nox -s lint` passes (ruff, ty, license headers, rumdl, etc.) after
  every commit.
- Manually verified `license_lock.py`'s acquire/renew/expire/release
  semantics with a standalone script (single-holder blocking, TTL expiry,
  wrong-holder release is a no-op).
- Manually verified `dynamic_license_daemon.py --signal-source lock
  --once --dry-run` correctly flips `lastconsumed=0`/`1` based on lock
  state, and that `--signal-source queue-length` without
  `--queue-status-url-template` fails fast with a clear error.
- `uvx nox -s docs` was attempted; it fails on the pre-existing
  `docs/qiskit.md` notebook (401 Unauthorized against
  `https://resonance.iqm.tech`, since this sandbox has no live IQM
  credentials) — unrelated to this change, which only touches static
  Markdown and standalone scripts. `rumdl check`/`fmt` was run directly
  against the changed Markdown files.
- No live Slurm or IQM integration tests were run, per repo guidance.
