### PR TITLE
✨ Add examples/discover_backends.py for IQM QC discovery and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ releases may include breaking changes.
 
 - ✨ Add `examples/discover_backends.py`, listing the quantum computers
   available on an IQM Server and selecting one that satisfies a `--min-qubits`
-  constraint ([#145]) ([**@marcelwa**])
+  constraint ([#146]) ([**@marcelwa**])
 - ✨ Validate IQM backend and target-QC availability once per node for each
   Slurm job step before launching tasks ([#136]) ([**@burgholzer**])
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
@@ -123,7 +123,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
-[#145]: https://github.com/iqm-finland/QDMI-on-IQM/pull/145
+[#146]: https://github.com/iqm-finland/QDMI-on-IQM/pull/146
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add `examples/discover_backends.py`, listing the quantum computers
+  available on an IQM Server and selecting one that satisfies a `--min-qubits`
+  constraint ([#145]) ([**@marcelwa**])
 - ✨ Validate IQM backend and target-QC availability once per node for each
   Slurm job step before launching tasks ([#136]) ([**@burgholzer**])
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
@@ -120,6 +123,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#145]: https://github.com/iqm-finland/QDMI-on-IQM/pull/145
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -163,9 +163,10 @@ Before running a workload, it can be useful to discover which quantum computers
 are actually available on an IQM Server and pick one programmatically, rather
 than hardcoding a single alias. The `examples/discover_backends.py` script
 demonstrates this: it lists the quantum computers exposed by the configured IQM
-Server endpoint, queries each one's qubit count and (where exposed) two-qubit
-gate fidelity through the standard `IQMBackend`/QDMI `Target` API, and selects
-the largest one that satisfies a `--min-qubits` constraint.
+Server endpoint, opens each one and queries its status, qubit count, per-site
+T1/T2, and (where exposed) two-qubit gate fidelity through the public
+`mqt.core.fomac` `Device`/`Site`/`Operation` API, and selects the largest one
+that satisfies a `--min-qubits` constraint.
 
 ```{literalinclude} ../examples/discover_backends.py
 :language: python
@@ -189,21 +190,49 @@ count without contacting an IQM Server:
 
 :::{note}
 QDMI-on-IQM does not currently expose a Python or C++ binding for listing every
-quantum computer on a server; each QDMI device session is scoped to a single
-quantum computer. This example works around that by issuing the same
-`api/v1/quantum-computers` request the session already performs internally
-during initialization, then falls back to the regular public API for every other
-query.
+quantum computer on a server: each opened QDMI device session resolves to
+exactly one quantum computer, selected by ID, alias, or "first available" during
+session initialization (`IQM_QDMI_device_session_init` /
+`Process_static_quantum_architecture` in `src/iqm_device.cpp`). This example
+works around that by issuing the same `api/v1/quantum-computers` request the
+session already performs internally to learn the available aliases, then opens
+each candidate's device and queries it through the public
+`mqt.core.fomac.Device`/`Site`/`Operation` API for every other query.
 :::
 
 :::{note}
-The IQM Server API is also known to expose a queue-length /
-execution-availability-window signal, described for the "pay-as-you-go queue"
-and therefore apparently cloud/Resonance-oriented (unconfirmed for on-premise
-quantum computers). QDMI-on-IQM does not currently surface that signal through
-its Python or C++ bindings, so this example does not use it. Once it is exposed
-through the library, ranking candidates by queue depth in addition to qubit
-count and fidelity would be a natural enhancement here.
+True multi-QC enumeration without the `api/v1/quantum-computers` REST call above
+is not something any current or planned `mqt-core` release can fix on its own,
+because the root cause lives in this repo's own C++ device implementation, not
+in `mqt-core`: `mqt.core.fomac.Session.get_devices()` only ever returns one
+`Device` per registered `DeviceDefinition`, and each `DeviceDefinition` this
+library can hand `mqt-core` still resolves to exactly one IQM quantum computer,
+per the session-initialization behavior above. Registering one
+`DeviceDefinition` per alias would still require knowing every alias up front -
+the same requirement the REST call exists to satisfy. An open (unmerged)
+`mqt-core` pull request,
+[core#1912](https://github.com/munich-quantum-toolkit/core/pull/1912) ("Add
+configurable QDMI device discovery"), adds exactly that
+`DeviceRegistry`/`DeviceDefinition` mechanism (`qdmi.json` / `[tool.qdmi]` /
+env-var configuration), which would be the right way to *register* multiple
+already-known aliases as separate `Device`s - but it is relevant only as context
+here, not as a fix for the enumeration problem itself, which needs a change to
+this repo's own C++ session initialization to resolve. A related, larger,
+also-open PR,
+[core#1901](https://github.com/munich-quantum-toolkit/core/pull/1901),
+redesigns FoMaC and `qdmi::Driver` around that same registry and was reportedly
+exercised against IQM's own QDMI implementation branches during development.
+Neither PR has merged, and this note describes context, not a plan this repo
+currently depends on.
+
+Separately, and independent of that `mqt-core` discussion: the IQM Server API is
+also known to expose a queue-length / execution-availability-window signal,
+described for the "pay-as-you-go queue" and therefore apparently
+cloud/Resonance-oriented (unconfirmed for on-premise quantum computers).
+QDMI-on-IQM does not currently surface that signal through its Python or C++
+bindings, so this example does not use it. Once it is exposed through the
+library, ranking candidates by queue depth in addition to qubit count and
+fidelity would be a natural enhancement here.
 :::
 
 [deutsch-jozsa]: https://en.wikipedia.org/wiki/Deutsch%E2%80%93Jozsa_algorithm

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -196,6 +196,16 @@ during initialization, then falls back to the regular public API for every other
 query.
 :::
 
+:::{note}
+The IQM Server API is also known to expose a queue-length /
+execution-availability-window signal, described for the "pay-as-you-go queue"
+and therefore apparently cloud/Resonance-oriented (unconfirmed for on-premise
+quantum computers). QDMI-on-IQM does not currently surface that signal through
+its Python or C++ bindings, so this example does not use it. Once it is exposed
+through the library, ranking candidates by queue depth in addition to qubit
+count and fidelity would be a natural enhancement here.
+:::
+
 [deutsch-jozsa]: https://en.wikipedia.org/wiki/Deutsch%E2%80%93Jozsa_algorithm
 [ghz-state]: https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state
 [graph-state]: https://en.wikipedia.org/wiki/Graph_state

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,10 +12,11 @@ Welcome to the end-to-end tutorial. This guide walks you step by step through
 driving real quantum workloads on IQM systems using QDMI-on-IQM and the packaged
 {py:class}`~iqm.qdmi.qiskit.IQMBackend`.
 
-Whether you want to estimate molecular ground-state energies with [QSCI][qsci]
-or benchmark hardware with [MQT Bench][mqt-bench], the example scripts in this
-repository provide a practical starting point. This tutorial focuses on two
-application areas:
+Whether you want to estimate molecular ground-state energies with [QSCI][qsci],
+benchmark hardware with [MQT Bench][mqt-bench], or discover which IQM quantum
+computer to target in the first place, the example scripts in this repository
+provide a practical starting point. This tutorial focuses on three application
+areas:
 
 - **Quantum chemistry:** using [QSCI][qsci] and [Qiskit Nature][qiskit-nature]
   to estimate the ground-state energy of an H2 molecule.
@@ -23,6 +24,8 @@ application areas:
   [GHZ states][ghz-state], [Deutsch-Jozsa][deutsch-jozsa],
   [QFT][quantum-fourier-transform], [graph states][graph-state],
   [W states][w-state], [Grover][grover], or [Quantum Phase Estimation][qpe].
+- **Backend discovery:** enumerating the quantum computers available on an IQM
+  Server and selecting one that satisfies a qubit-count constraint.
 
 :::{important}
 The example scripts live in the QDMI-on-IQM repository and are not shipped with
@@ -61,6 +64,7 @@ uvx nox -s examples
 # Run specific examples
 ./examples/qsci_h2.py --shots 256 --maxiter 5 --cutoff 4
 ./examples/mqt_bench.py --benchmark ghz --shots 128
+./examples/discover_backends.py --min-qubits 5
 ```
 
 ## Quantum Chemistry
@@ -152,6 +156,45 @@ expected bitstrings (all 0s and all 1s for the GHZ state):
 Now try running the same script with `--backend iqm` to see how the distribution
 looks on real hardware. Remember to set the required environment variables for
 authentication before running the script.
+
+## Discovering and Selecting Backends
+
+Before running a workload, it can be useful to discover which quantum computers
+are actually available on an IQM Server and pick one programmatically, rather
+than hardcoding a single alias. The `examples/discover_backends.py` script
+demonstrates this: it lists the quantum computers exposed by the configured IQM
+Server endpoint, queries each one's qubit count and (where exposed) two-qubit
+gate fidelity through the standard `IQMBackend`/QDMI `Target` API, and selects
+the largest one that satisfies a `--min-qubits` constraint.
+
+```{literalinclude} ../examples/discover_backends.py
+:language: python
+:caption: examples/discover_backends.py
+:start-after: "# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception"
+```
+
+Run it directly against an IQM Server (remember to set the required
+authentication environment variables first):
+
+```console
+./examples/discover_backends.py --min-qubits 5
+```
+
+Or exercise the simulator path, which reports the local DDSIM simulator's qubit
+count without contacting an IQM Server:
+
+```{code-cell} ipython3
+!../examples/discover_backends.py --backend sim --min-qubits 5
+```
+
+:::{note}
+QDMI-on-IQM does not currently expose a Python or C++ binding for listing every
+quantum computer on a server; each QDMI device session is scoped to a single
+quantum computer. This example works around that by issuing the same
+`api/v1/quantum-computers` request the session already performs internally
+during initialization, then falls back to the regular public API for every other
+query.
+:::
 
 [deutsch-jozsa]: https://en.wikipedia.org/wiki/Deutsch%E2%80%93Jozsa_algorithm
 [ghz-state]: https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state

--- a/examples/discover_backends.py
+++ b/examples/discover_backends.py
@@ -29,23 +29,52 @@
 """Discover IQM quantum computers on a server and select one matching a constraint.
 
 QDMI-on-IQM does not currently expose a Python or C++ binding for listing every
-quantum computer known to an IQM Server (each QDMI device session is scoped to a
-single quantum computer, selected by ID, alias, or "first available" during
-session initialization; see docs/usage.md). This example fills that gap for
-discovery *scripts* rather than the library: it issues the same
-`api/v1/quantum-computers` request the device session already performs
-internally, then queries each candidate's public properties (qubit count and,
-where exposed, two-qubit gate fidelity) through the regular `IQMBackend`/QDMI
-`Target` API to pick one that satisfies a `--min-qubits` constraint.
+quantum computer known to an IQM Server: each opened QDMI device session
+resolves to exactly *one* quantum computer, selected by ID, alias, or "first
+available" during session initialization (`IQM_QDMI_device_session_init` /
+`Process_static_quantum_architecture` in `src/iqm_device.cpp`; see
+docs/usage.md). This example fills that gap for discovery *scripts* rather
+than the library: it issues the same `api/v1/quantum-computers` request the
+device session already performs internally to learn the available aliases,
+then opens each candidate's device and queries its public properties (qubit
+count, status, per-site T1/T2, and per-operation fidelity) through the public
+`mqt.core.fomac.Device`/`Site`/`Operation` API to pick one that satisfies a
+`--min-qubits` constraint.
 
-Future direction: the IQM Server API is known to expose a queue-length /
-execution-availability-window signal, described for the "pay-as-you-go queue"
-and therefore apparently cloud/Resonance-oriented (its availability and
-semantics for on-premise quantum computers are unconfirmed). That signal is
-not currently surfaced through QDMI-on-IQM's Python or C++ bindings, so it is
-not used here. Once it is exposed through the library, a natural enhancement
-to this example would be ranking candidate backends by queue depth in
-addition to qubit count and fidelity.
+Future direction:
+
+- True multi-QC enumeration without the `api/v1/quantum-computers` REST call
+  above is not something any current or planned `mqt-core` release can fix on
+  its own, because the root cause lives in *this repo's* C++ device
+  implementation, not in `mqt-core`: `mqt.core.fomac.Session.get_devices()`
+  only ever returns one `Device` per registered `DeviceDefinition`, and (per
+  the session-initialization behavior above) each `DeviceDefinition` this
+  library can hand `mqt-core` still resolves to exactly one IQM quantum
+  computer. Registering one `DeviceDefinition` per alias would still require
+  knowing every alias up front - the same requirement the REST call exists to
+  satisfy. An open (unmerged) `mqt-core` pull request,
+  https://github.com/munich-quantum-toolkit/core/pull/1912 ("Add configurable
+  QDMI device discovery"), adds exactly that `DeviceRegistry`/`DeviceDefinition`
+  mechanism (`qdmi.json` / `[tool.qdmi]` / env-var configuration), which would
+  be the right way to *register* multiple already-known aliases as separate
+  `Device`s - but it is relevant only as context here, not as a fix for the
+  enumeration problem itself, which needs a change to this repo's own C++
+  session initialization to resolve. (A related, larger, also-open PR,
+  https://github.com/munich-quantum-toolkit/core/pull/1901, redesigns FoMaC
+  and `qdmi::Driver` around that same registry and was reportedly exercised
+  against IQM's own QDMI implementation branches during development.) Neither
+  PR has merged, and this note describes context, not a plan this repo
+  currently depends on.
+- The IQM Server API is known to expose a queue-length /
+  execution-availability-window signal, described for the "pay-as-you-go
+  queue" and therefore apparently cloud/Resonance-oriented (its availability
+  and semantics for on-premise quantum computers are unconfirmed). That
+  signal is not currently surfaced through QDMI-on-IQM's Python or C++
+  bindings, so it is not used here. Once it is exposed through the library, a
+  natural enhancement to this example would be ranking candidate backends by
+  queue depth in addition to qubit count and fidelity. This is an open
+  question independent of the `mqt-core` discussion above - it concerns IQM
+  Server API queue depth, not `mqt-core`'s device object model.
 """
 
 from __future__ import annotations
@@ -59,9 +88,10 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from mqt.core.fomac import Device, add_dynamic_device_library
 from mqt.core.plugins.qiskit.provider import QDMIProvider
 
-from iqm.qdmi.qiskit import IQMBackend
+from iqm.qdmi import IQM_QDMI_LIBRARY_PATH
 
 log = logging.getLogger(__name__)
 
@@ -108,23 +138,62 @@ def _list_quantum_computers(base_url: str, bearer_token: str | None) -> list[dic
     return quantum_computers
 
 
-def _calibration_summary(backend: IQMBackend) -> str:
-    """Summarize two-qubit gate fidelity from the backend's public `Target`, if available.
+def _open_device(base_url: str, token: str | None, tokens_file: str | None, qc_alias: str) -> Device:
+    """Open a public FoMaC `Device` for one IQM quantum computer.
+
+    This calls the same `mqt.core.fomac.add_dynamic_device_library` entry point
+    `IQMBackend` uses internally, so the returned `Device` exposes qubit count,
+    status, per-site T1/T2, and per-operation fidelity through the public API,
+    without reaching into any private `QDMIBackend` attribute.
+
+    Returns:
+        The opened FoMaC `Device` for `qc_alias`.
+    """
+    return add_dynamic_device_library(
+        library_path=str(IQM_QDMI_LIBRARY_PATH),
+        prefix="IQM",
+        base_url=base_url,
+        token=token,
+        auth_file=tokens_file,
+        custom2=qc_alias,
+    )
+
+
+def _calibration_summary(device: Device) -> str:
+    """Summarize two-qubit gate fidelity from the device's public `Operation` API, if available.
 
     Returns:
         A short human-readable calibration-quality summary.
     """
-    target = backend.target
-    for name in target.operation_names:
-        errors = [
-            props.error
-            for qargs, props in target[name].items()
-            if qargs is not None and len(qargs) == 2 and props is not None and props.error is not None
-        ]
-        if errors:
-            mean_fidelity = 1.0 - (sum(errors) / len(errors))
-            return f"'{name}' mean 2-qubit fidelity {mean_fidelity:.4f} over {len(errors)} pair(s)"
-    return "no two-qubit gate error data exposed by Target"
+    for op in device.operations():
+        site_pairs = op.site_pairs()
+        if not site_pairs:
+            continue
+        fidelities = [fidelity for pair in site_pairs if (fidelity := op.fidelity(sites=pair)) is not None]
+        if fidelities:
+            mean_fidelity = sum(fidelities) / len(fidelities)
+            return f"'{op.name()}' mean 2-qubit fidelity {mean_fidelity:.4f} over {len(fidelities)} pair(s)"
+    return "no two-qubit gate fidelity exposed by the device"
+
+
+def _coherence_summary(device: Device) -> str:
+    """Summarize per-site T1/T2 coherence times from the device's public `Site` API, if available.
+
+    Returns:
+        A short human-readable coherence-time summary.
+    """
+    sites = [site for site in device.sites() if not site.is_zone()]
+    t1_values = [t1 for site in sites if (t1 := site.t1()) is not None]
+    t2_values = [t2 for site in sites if (t2 := site.t2()) is not None]
+    if not t1_values and not t2_values:
+        return "no T1/T2 data exposed by the device"
+    unit = device.duration_unit() or "device time units"
+    parts = []
+    if t1_values:
+        parts.append(f"mean T1 {sum(t1_values) / len(t1_values):.1f} {unit}")
+    if t2_values:
+        parts.append(f"mean T2 {sum(t2_values) / len(t2_values):.1f} {unit}")
+    return ", ".join(parts)
 
 
 def _run_simulator(min_qubits: int) -> None:
@@ -157,7 +226,7 @@ def _run_discovery(*, base_url: str | None, token: str | None, tokens_file: str 
             qc.get("display_name"),
         )
 
-    candidates: list[tuple[str, IQMBackend, str]] = []
+    candidates: list[tuple[str, Device, str]] = []
     for qc in quantum_computers:
         alias = qc.get("alias")
         if not alias:
@@ -165,24 +234,33 @@ def _run_discovery(*, base_url: str | None, token: str | None, tokens_file: str 
             continue
         log.info("Querying properties of '%s'...", alias)
         try:
-            backend = IQMBackend(base_url=resolved_base_url, token=token, tokens_file=tokens_file, qc_alias=alias)
+            device = _open_device(resolved_base_url, token, tokens_file, alias)
         except Exception as exc:  # ruff:ignore[blind-except] - keep discovering the remaining candidates
             log.warning("Skipping '%s': failed to query device properties (%s)", alias, exc)
             continue
-        quality = _calibration_summary(backend)
-        log.info("  '%s': %d qubits, %s", alias, backend.num_qubits, quality)
-        candidates.append((alias, backend, quality))
+        status = device.status().name
+        quality = _calibration_summary(device)
+        coherence = _coherence_summary(device)
+        log.info(
+            "  '%s': status=%s, %d qubits, %s, %s",
+            alias,
+            status,
+            device.qubits_num(),
+            quality,
+            coherence,
+        )
+        candidates.append((alias, device, quality))
 
-    matching = [candidate for candidate in candidates if candidate[1].num_qubits >= min_qubits]
+    matching = [candidate for candidate in candidates if candidate[1].qubits_num() >= min_qubits]
     if not matching:
-        largest = max((candidate[1].num_qubits for candidate in candidates), default=0)
+        largest = max((candidate[1].qubits_num() for candidate in candidates), default=0)
         sys.exit(f"No discovered quantum computer meets --min-qubits={min_qubits} (largest available: {largest}).")
 
-    selected_alias, selected_backend, selected_quality = max(matching, key=lambda candidate: candidate[1].num_qubits)
+    selected_alias, selected_device, selected_quality = max(matching, key=lambda candidate: candidate[1].qubits_num())
     log.info(
         "Selected '%s': %d qubits (>= --min-qubits=%d), %s",
         selected_alias,
-        selected_backend.num_qubits,
+        selected_device.qubits_num(),
         min_qubits,
         selected_quality,
     )

--- a/examples/discover_backends.py
+++ b/examples/discover_backends.py
@@ -37,6 +37,15 @@ discovery *scripts* rather than the library: it issues the same
 internally, then queries each candidate's public properties (qubit count and,
 where exposed, two-qubit gate fidelity) through the regular `IQMBackend`/QDMI
 `Target` API to pick one that satisfies a `--min-qubits` constraint.
+
+Future direction: the IQM Server API is known to expose a queue-length /
+execution-availability-window signal, described for the "pay-as-you-go queue"
+and therefore apparently cloud/Resonance-oriented (its availability and
+semantics for on-premise quantum computers are unconfirmed). That signal is
+not currently surfaced through QDMI-on-IQM's Python or C++ bindings, so it is
+not used here. Once it is exposed through the library, a natural enhancement
+to this example would be ranking candidate backends by queue depth in
+addition to qubit count and fidelity.
 """
 
 from __future__ import annotations

--- a/examples/discover_backends.py
+++ b/examples/discover_backends.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env -S uv run --script --quiet
+# Copyright (c) 2025 - 2026 IQM Finland Oy
+# All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "iqm-qdmi[qiskit]",
+#   "requests>=2.31",
+# ]
+# [tool.uv.sources]
+# iqm-qdmi = { path = ".." }
+# ///
+
+"""Discover IQM quantum computers on a server and select one matching a constraint.
+
+QDMI-on-IQM does not currently expose a Python or C++ binding for listing every
+quantum computer known to an IQM Server (each QDMI device session is scoped to a
+single quantum computer, selected by ID, alias, or "first available" during
+session initialization; see docs/usage.md). This example fills that gap for
+discovery *scripts* rather than the library: it issues the same
+`api/v1/quantum-computers` request the device session already performs
+internally, then queries each candidate's public properties (qubit count and,
+where exposed, two-qubit gate fidelity) through the regular `IQMBackend`/QDMI
+`Target` API to pick one that satisfies a `--min-qubits` constraint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+from mqt.core.plugins.qiskit.provider import QDMIProvider
+
+from iqm.qdmi.qiskit import IQMBackend
+
+log = logging.getLogger(__name__)
+
+_SIMULATOR_DEVICE = "MQT Core DDSIM QDMI Device"
+_DEFAULT_BASE_URL = "https://resonance.iqm.tech"
+
+
+def _resolve_base_url(base_url: str | None) -> str:
+    return base_url or os.getenv("IQM_BASE_URL") or _DEFAULT_BASE_URL
+
+
+def _resolve_listing_bearer_token(token: str | None, tokens_file: str | None) -> str | None:
+    """Resolve a bearer token for the plain listing request, mirroring `IQMBackend`'s precedence.
+
+    Returns:
+        The resolved bearer token, or `None` if no credentials are configured.
+    """
+    resolved_token = token or os.getenv("IQM_TOKEN")
+    if resolved_token:
+        return resolved_token
+
+    resolved_tokens_file = tokens_file or os.getenv("IQM_TOKENS_FILE")
+    if resolved_tokens_file:
+        data = json.loads(Path(resolved_tokens_file).read_text(encoding="utf-8"))
+        access_token = data.get("access_token")
+        if not access_token:
+            sys.exit(f"No 'access_token' field found in tokens file: {resolved_tokens_file}")
+        return str(access_token)
+
+    return None
+
+
+def _list_quantum_computers(base_url: str, bearer_token: str | None) -> list[dict[str, Any]]:
+    """Fetch the quantum computers available on an IQM Server.
+
+    Returns:
+        The raw `quantum_computers` entries reported by the server.
+    """
+    url = base_url.rstrip("/") + "/api/v1/quantum-computers"
+    headers = {"Authorization": f"Bearer {bearer_token}"} if bearer_token else {}
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    quantum_computers: list[dict[str, Any]] = response.json().get("quantum_computers", [])
+    return quantum_computers
+
+
+def _calibration_summary(backend: IQMBackend) -> str:
+    """Summarize two-qubit gate fidelity from the backend's public `Target`, if available.
+
+    Returns:
+        A short human-readable calibration-quality summary.
+    """
+    target = backend.target
+    for name in target.operation_names:
+        errors = [
+            props.error
+            for qargs, props in target[name].items()
+            if qargs is not None and len(qargs) == 2 and props is not None and props.error is not None
+        ]
+        if errors:
+            mean_fidelity = 1.0 - (sum(errors) / len(errors))
+            return f"'{name}' mean 2-qubit fidelity {mean_fidelity:.4f} over {len(errors)} pair(s)"
+    return "no two-qubit gate error data exposed by Target"
+
+
+def _run_simulator(min_qubits: int) -> None:
+    log.info("Simulator backend selected: skipping IQM Server discovery.")
+    backend = QDMIProvider().get_backend(_SIMULATOR_DEVICE)
+    log.info("Backend ready: '%s' | %d qubits", backend.name, backend.num_qubits)
+
+    if backend.num_qubits < min_qubits:
+        sys.exit(f"Simulator exposes {backend.num_qubits} qubits, fewer than --min-qubits={min_qubits}.")
+
+    log.info("Calibration quality: n/a (simulator devices are noiseless)")
+    log.info("Selected backend: '%s'", backend.name)
+    log.info("Done.")
+
+
+def _run_discovery(*, base_url: str | None, token: str | None, tokens_file: str | None, min_qubits: int) -> None:
+    resolved_base_url = _resolve_base_url(base_url)
+    log.info("Discovering quantum computers available at '%s'...", resolved_base_url)
+    bearer_token = _resolve_listing_bearer_token(token, tokens_file)
+    quantum_computers = _list_quantum_computers(resolved_base_url, bearer_token)
+    if not quantum_computers:
+        sys.exit(f"No quantum computers reported by '{resolved_base_url}'.")
+
+    log.info("Found %d quantum computer(s):", len(quantum_computers))
+    for qc in quantum_computers:
+        log.info(
+            "  - id=%s alias=%s display_name=%s",
+            qc.get("id"),
+            qc.get("alias"),
+            qc.get("display_name"),
+        )
+
+    candidates: list[tuple[str, IQMBackend, str]] = []
+    for qc in quantum_computers:
+        alias = qc.get("alias")
+        if not alias:
+            log.warning("Skipping quantum computer without an alias: %s", qc)
+            continue
+        log.info("Querying properties of '%s'...", alias)
+        try:
+            backend = IQMBackend(base_url=resolved_base_url, token=token, tokens_file=tokens_file, qc_alias=alias)
+        except Exception as exc:  # ruff:ignore[blind-except] - keep discovering the remaining candidates
+            log.warning("Skipping '%s': failed to query device properties (%s)", alias, exc)
+            continue
+        quality = _calibration_summary(backend)
+        log.info("  '%s': %d qubits, %s", alias, backend.num_qubits, quality)
+        candidates.append((alias, backend, quality))
+
+    matching = [candidate for candidate in candidates if candidate[1].num_qubits >= min_qubits]
+    if not matching:
+        largest = max((candidate[1].num_qubits for candidate in candidates), default=0)
+        sys.exit(f"No discovered quantum computer meets --min-qubits={min_qubits} (largest available: {largest}).")
+
+    selected_alias, selected_backend, selected_quality = max(matching, key=lambda candidate: candidate[1].num_qubits)
+    log.info(
+        "Selected '%s': %d qubits (>= --min-qubits=%d), %s",
+        selected_alias,
+        selected_backend.num_qubits,
+        min_qubits,
+        selected_quality,
+    )
+    log.info("Done.")
+
+
+def main() -> None:
+    """Discover available IQM quantum computers and select one matching a qubit-count constraint."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=("iqm", "sim"), default="iqm")
+    parser.add_argument("--min-qubits", type=int, default=5)
+    parser.add_argument("--base-url", default=None, help="Defaults to $IQM_BASE_URL or the Resonance endpoint.")
+    parser.add_argument("--token", default=None, help="Defaults to $IQM_TOKEN.")
+    parser.add_argument("--tokens-file", default=None, help="Defaults to $IQM_TOKENS_FILE.")
+    args = parser.parse_args()
+
+    log.info("Starting backend discovery example (backend=%s, min_qubits=%d)", args.backend, args.min_qubits)
+
+    if args.backend == "sim":
+        _run_simulator(args.min_qubits)
+        return
+
+    _run_discovery(
+        base_url=args.base_url,
+        token=args.token,
+        tokens_file=args.tokens_file,
+        min_qubits=args.min_qubits,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,6 +157,15 @@ def examples(session: nox.Session) -> None:
         env=env,
         external=True,
     )
+    session.run(
+        Path("examples/discover_backends.py"),
+        "--backend",
+        args.backend,
+        "--min-qubits",
+        "3",
+        env=env,
+        external=True,
+    )
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,4 +269,10 @@ cache-keys = [
 # The following packages are solely used in the end-to-end demonstrations and are not required for the core functionality of the library.
 # To avoid limiting the usability of the core library, we purposely do not add these packages as dependencies.
 # As a consequence, we need to ignore the unresolved imports from these packages in the type analysis.
-allowed-unresolved-imports = ["mqt.bench.**", "qiskit_nature.**", "qiskit_algorithms.**", "pyscf.**"]
+allowed-unresolved-imports = [
+    "mqt.bench.**",
+    "qiskit_nature.**",
+    "qiskit_algorithms.**",
+    "pyscf.**",
+    "requests.**",
+]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

Adds `examples/discover_backends.py`, a third example alongside `mqt_bench.py`
and `qsci_h2.py` that demonstrates **discovery** rather than targeting a
single, already-known backend: it lists the quantum computers available on an
IQM Server, queries each one's qubit count and (where exposed) two-qubit gate
fidelity, and selects the largest QC that satisfies a `--min-qubits`
constraint, printing what was found and what was chosen.

### Motivation

This mirrors the "list resources → filter by constraint → use the match"
pattern used in two 2026 arXiv papers on QRMI, a related IBM/Pasqal-led effort
to integrate quantum resources into HPC schedulers:

- arXiv:2506.10052's Python example calls `service.resources()`, picks one,
  and prints `qrmi.metadata()` before building a transpile target.
- arXiv:2607.19591's Grid Engine integration selects a resource via
  `qsub -l qpu=PASQAL_FRESNEL,qpu_ready=1,qpu_slots=6 job.sh` — select-by-name
  plus numeric constraints (readiness, capacity).

QDMI-on-IQM already exposes the underlying device-property API
(`docs/usage.md`: qubit count, coupling map, T1/T2, gate fidelities), but had
no example exercising discovery end-to-end.

### What's actually discoverable today (and the resulting design)

Investigating the C++ session-init path (`src/iqm_device.cpp`,
`Process_static_quantum_architecture`) and the Python/FoMaC layer
(`python/iqm/qdmi/qiskit.py`, `mqt.core.fomac`) turned up:

- Each QDMI device session is scoped to a **single** quantum computer, chosen
  by ID, alias, or "first available" during
  `IQM_QDMI_device_session_init`. The full list of QCs is fetched
  once internally (`GET api/v1/quantum-computers`) purely to resolve that
  selection — it is not returned to the caller and there is no
  Python/C++ binding exposing it.
- `mqt.core.fomac.Session.get_devices()` looked promising but lists
  *statically registered* FoMaC devices (e.g. the DDSIM simulator), not
  dynamically loaded IQM QCs, so it doesn't help here either.
- Per-QC properties (qubit count, two-qubit gate fidelity) *are* fully
  reachable through the existing **public** API once a QC is selected:
  `IQMBackend(qc_alias=...)` plus the standard Qiskit `Target` (`error` on
  `InstructionProperties`). T1/T2 is only reachable via a private
  `QDMIBackend._device` attribute from `mqt-core`, so the example reports
  two-qubit gate fidelity as the "calibration quality" signal instead and
  documents that limitation rather than reaching into private internals.

Given that, this PR **does not add or change any C++/Python binding**. The
example issues the same `api/v1/quantum-computers` REST call the session
already performs internally (documented as a limitation directly in the
script's docstring and in `docs/examples.md`), then uses only the existing
public `IQMBackend`/`Target` API for everything else. A proper "list QCs"
binding would be a reasonable, separately-scoped follow-up if this pattern
turns out to be broadly useful, but felt out of scope for a single example
script.

### Other changes

- `noxfile.py`: wire `discover_backends.py` into the `examples` nox session
  (`--backend sim`/`--backend iqm`), matching the existing two examples.
- `pyproject.toml`: add `requests.**` to `tool.ty.analysis.allowed-unresolved-imports`,
  following the existing pattern for example-only dependencies not required by
  the core library.
- `docs/examples.md`: new "Discovering and Selecting Backends" section with a
  `literalinclude` of the script and a `sim`-backend `code-cell`, matching the
  existing two examples' documentation style.
- `CHANGELOG.md`: `[Unreleased]` entry.

**Update:** Added a documented future-direction note (script docstring +
`docs/examples.md`) about the IQM Server API's queue-length /
availability-window signal (apparently cloud/Resonance-oriented, unconfirmed
for on-prem, not currently surfaced through QDMI-on-IQM's bindings) — no
speculative code calling it.

**Update:** Replaced the T1/T2/status workarounds with the public
`mqt.core.fomac` `Device`/`Site`/`Operation` API (`Device.status()`,
`Site.t1()`/`t2()`, `Operation.fidelity()` — all already available on the
existing `mqt-core~=3.7.0` pin, no dependency change needed) instead of
reaching into the private `QDMIBackend._device` attribute. Also corrected the
future-direction note: verified against the actual installed `mqt-core` wheel
that upstream PR munich-quantum-toolkit/core#1912 does not fix multi-QC
enumeration — IQM's own C++ device implementation
(`IQM_QDMI_device_session_init` in `src/iqm_device.cpp`) resolves exactly one
QC per opened session regardless of `mqt-core`'s device registry, so #1912 is
relevant only as the mechanism for registering already-known aliases, not as
a fix for the enumeration problem itself.

## Test plan

- [x] `uvx nox -s lint` passes (`ruff`, `ty` — including the new
      `requests` import — `rumdl`, license headers, etc.)
- [x] `uvx nox -s tests-3.14` passes (28 passed, 3 skipped live-IQM tests;
      unchanged — no Python source under `python/iqm/qdmi/` was touched, so no
      new tests were needed)
- [x] `uvx nox -s examples -- --backend sim` passes, including the new
      `discover_backends.py --backend sim --min-qubits 3` invocation
- [ ] Not run: `--backend iqm` / live IQM discovery (would require real IQM
      Server credentials; intentionally not exercised in this session per
      task constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

