### PR TITLE
:memo: Add integration scenarios analysis and administrator guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ releases may include breaking changes.
 - 📝 Add an integration scenarios analysis comparing IQM integration paths
   (direct C++/Python usage, Slurm + SPANK offloading, Spack install, and
   non-Slurm schedulers as forward-looking guidance) and an administrator guide
-  walking through standing up IQM access on a Slurm cluster ([#145] —
-  unverified) ([**@marcelwa**])
+  walking through standing up IQM access on a Slurm cluster ([#147])
+  ([**@marcelwa**])
 
 ### Changed
 
@@ -125,7 +125,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
-[#145]: https://github.com/iqm-finland/QDMI-on-IQM/pull/145
+[#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ releases may include breaking changes.
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
   on-premise QCs ([#114], [#134]) ([**@marcelwa**], [**@burgholzer**])
+- 📝 Add an integration scenarios analysis comparing IQM integration paths
+  (direct C++/Python usage, Slurm + SPANK offloading, Spack install, and
+  non-Slurm schedulers as forward-looking guidance) and an administrator guide
+  walking through standing up IQM access on a Slurm cluster ([#145] —
+  unverified) ([**@marcelwa**])
 
 ### Changed
 
@@ -120,6 +125,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#145]: https://github.com/iqm-finland/QDMI-on-IQM/pull/145
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134
 [#133]: https://github.com/iqm-finland/QDMI-on-IQM/pull/133

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -1,0 +1,161 @@
+# Administrator Guide: Standing Up IQM Access on a Slurm Cluster
+
+This tutorial walks a system administrator through standing up IQM quantum
+computer (QC) access on a Slurm cluster from scratch, using the SPANK plugin and
+a dedicated `quantum` partition. It cross-links the
+[SPANK Plugin Guide](spank_plugin.md) and the [Spack Guide](spack_guide.md)
+rather than repeating their reference material — use this page for the
+end-to-end sequence, and follow the links for full option/flag detail. See
+[Integration Scenarios Analysis](integration_scenarios.md) if you have not yet
+decided this is the right integration path for your site.
+
+## 1. Choose an Install Path
+
+You have two ways to get the plugin and library onto your cluster:
+
+- **Build from source** with CMake, covered in step 2 below.
+- **Install via Spack**, if your site already manages software through Spack
+  environments — see the [Spack Guide](spack_guide.md) for the package
+  definition and `spack install` sequence. Spack changes only how the binaries
+  land on disk, not the Slurm-side configuration in steps 3-4 below, which still
+  applies either way.
+
+## 2. Build and Install the SPANK Plugin
+
+The plugin is tied to your cluster's Slurm daemon ABI, so build it on (or
+against headers matching) the target environment, not a generic build host:
+
+```bash
+cmake -S . -B build-spank -DBUILD_IQM_SPANK=ON
+cmake --build build-spank --target iqm-spank-plugin --parallel
+sudo cmake --install build-spank --component iqm-spank-plugin
+```
+
+This requires Slurm 20.02 or newer, Slurm development headers (`slurm/spank.h`),
+and a C++20-capable compiler (GCC 13+ or Clang 16+) — see
+[Compatibility and Requirements](spank_plugin.md#compatibility-and-requirements)
+for the full list, including the additional Slurm 23.02+ requirement if you plan
+to enable license-based concurrency limits in step 4.
+
+The install step places the compiled `iqm-spank-plugin.so` in the Slurm plugin
+directory and drops a template configuration file into `plugstack.conf.d/`.
+Deploy it to every login node (so `srun`/`sbatch`/`salloc` parse the `--iqm-*`
+flags) and every compute node running `slurmd`/`slurmstepd` (so job steps get
+the injected environment). Controller-only nodes do not need it.
+
+Rebuild and redeploy the plugin after any major or minor Slurm upgrade, since it
+links against your cluster's exact Slurm headers.
+
+## 3. Configure `plugstack.conf`
+
+Edit (or create) a drop-in file, e.g.
+`/etc/slurm/plugstack.conf.d/iqm-qdmi.conf`, as a single line — `plugstack.conf`
+does not support line continuation:
+
+```text
+required /usr/lib/slurm/iqm-spank-plugin.so iqm_base_url=https://resonance.iqm.tech iqm_tokens_file=/etc/iqm/tokens.json partitions=quantum
+```
+
+- `iqm_base_url` is the default IQM service endpoint for jobs that don't
+  override it.
+- `iqm_tokens_file` is a shared token file readable by `slurmd` on the compute
+  nodes — see step 4 for why this, not a bare token, is the site-wide default.
+- `partitions` restricts the plugin to the partitions you list (comma-
+  separated); omit it and the plugin evaluates every partition, which is rarely
+  what you want on a shared cluster.
+
+Make sure your main `/etc/slurm/plugstack.conf` includes the drop-in directory:
+
+```text
+include /etc/slurm/plugstack.conf.d/*.conf
+```
+
+Then apply the change cluster-wide:
+
+```bash
+sudo scontrol reconfigure
+```
+
+Provision the `quantum` partition itself (or whatever name you chose) as a
+regular Slurm partition gating the nodes with QC access — the
+{py:mod}`~iqm.qdmi.offloader` module submits jobs to a partition named `quantum`
+by default, so match that name unless your users configure otherwise. See the
+full option reference, including `iqm_validation_timeout`, `iqm_license_prefix`,
+and `iqm_require_license`, in
+[Configuration](spank_plugin.md#configuration).
+
+## 4. Set Up Authentication
+
+Two mutually exclusive authentication modes are available; the plugin rejects a
+configuration that sets both:
+
+- `IQM_TOKENS_FILE` (recommended for site-wide defaults): a path to a token
+  file, readable by `slurmd` on every compute node that needs it. This is the
+  only supported way to set credentials as a cluster-wide default, because
+  `IQM_TOKEN` passed directly on the command line would leak into shell history,
+  process listings, and Slurm accounting records — see
+  [Credential Security](spank_plugin.md#credential-security).
+- `IQM_TOKEN`: acceptable for a user's own environment variable, not for an
+  administrator-set `plugstack.conf` default.
+
+Whichever you choose, the plugin performs a readability check on the tokens file
+on each compute node before any task starts, as part of its mandatory per-node
+launch-time validation.
+
+## 5. Verify the Install
+
+Confirm the configuration took effect:
+
+```bash
+scontrol show config | grep PlugStackConfig
+```
+
+This should point at your `plugstack.conf.d/` directory. Then submit a real test
+job:
+
+```bash
+srun --partition=quantum --iqm-qc-alias=emerald python -c "from iqm.qdmi.qiskit import IQMBackend; print(IQMBackend().name)"
+```
+
+A successful launch prints a diagnostic summary line to `slurmd.log` on the
+compute node:
+
+```text
+[iqm_spank_plugin] job=12345 partition=quantum base_url=set auth=tokens_file tokens_file_ok=yes
+```
+
+If you are developing or testing the plugin itself rather than verifying a
+production install, you can instead run its test suite in an isolated Docker
+container without touching real Slurm — see
+[Testing with Docker](spank_plugin.md#testing-with-docker).
+
+## 6. Troubleshooting
+
+Read the diagnostic line's fields to localize a failure:
+
+| Symptom | Likely cause | Fix |
+| :--- | :--- | :--- |
+| `base_url=unset` | `iqm_base_url` missing from `plugstack.conf` and not set by the user | Set `iqm_base_url` in the drop-in config, or have the user pass `--iqm-base-url` |
+| `auth=unset` | Neither `IQM_TOKEN` nor `IQM_TOKENS_FILE` reached the job | Set `iqm_tokens_file` in `plugstack.conf`, or have the user pass `--iqm-tokens-file` |
+| Job rejected for setting both token forms | `IQM_TOKEN` and `IQM_TOKENS_FILE` both present | Pick one; the plugin treats using both as a configuration conflict |
+| `tokens_file_ok=no` | Token file missing or unreadable by `slurmd` on that compute node | Fix file permissions/path; the file must be readable on every compute node, not just the login node |
+| Options/flags not recognized (`--iqm-*` rejected) | `plugstack.conf` drop-in directory not included, or not read-permitted | Verify `scontrol show config \| grep PlugStackConfig`, and check file permissions on the drop-in file |
+| "Plugin metadata symbol missing" at `slurmd` startup | Plugin built against incompatible Slurm headers | Rebuild the plugin from source against this cluster's exact `slurm/spank.h` |
+| "IQM backend validation failed" | Compute node can't reach `IQM_BASE_URL`, credentials invalid, or the QC doesn't exist | Check network egress from compute nodes, credential validity, and the QC id/alias spelling |
+
+For the full list of `plugstack.conf` options (including optional Slurm
+license-based concurrency limits) and additional troubleshooting detail, see
+[Troubleshooting](spank_plugin.md#troubleshooting) and
+[Limiting Concurrent Access with Slurm Licenses](spank_plugin.md#limiting-concurrent-access-with-slurm-licenses)
+in the SPANK Plugin Guide.
+
+## 7. Hand Off to Users
+
+Once a test job succeeds, point your users at:
+
+- [Python Package](python_package.md) for the `iqm.qdmi.offloader` module and
+  `iqm-sampler`/`iqm-estimator` CLI scripts.
+- [Qiskit Integration](qiskit.md) for writing and running circuits directly
+  against {py:class}`~iqm.qdmi.qiskit.IQMBackend`.
+- The [SPANK Plugin Guide](spank_plugin.md#for-users)'s user-facing section for
+  the `--iqm-*` `srun`/`sbatch`/`salloc` flags themselves.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,15 +16,17 @@ alongside a Python wrapper for straightforward installation via `pip` or `uv`.
 
 ## Where to Start
 
-| I want to…                                                       | Start here                            |
-| :--------------------------------------------------------------- | :------------------------------------ |
-| Run quantum circuits on IQM hardware from **Python / Qiskit**    | [Qiskit Integration](qiskit.md)       |
-| Run end-to-end example workloads (benchmarks, quantum chemistry) | [Examples](examples.md)               |
-| Integrate the C++ library directly                               | [Usage Guide](usage.md)               |
-| Integrate with **Slurm** on an HPC cluster                       | [SPANK Plugin Guide](spank_plugin.md) |
-| Install via **Spack** on an HPC cluster                          | [Spack Guide](spack_guide.md)         |
-| Understand the Python package and its entry points               | [Python Package](python_package.md)   |
-| Contribute to the project                                        | [Contributing](contributing.md)       |
+| I want to…                                                       | Start here                                                 |
+| :--------------------------------------------------------------- | :--------------------------------------------------------- |
+| Run quantum circuits on IQM hardware from **Python / Qiskit**    | [Qiskit Integration](qiskit.md)                            |
+| Run end-to-end example workloads (benchmarks, quantum chemistry) | [Examples](examples.md)                                    |
+| Integrate the C++ library directly                               | [Usage Guide](usage.md)                                    |
+| Integrate with **Slurm** on an HPC cluster                       | [SPANK Plugin Guide](spank_plugin.md)                      |
+| Install via **Spack** on an HPC cluster                          | [Spack Guide](spack_guide.md)                              |
+| Understand the Python package and its entry points               | [Python Package](python_package.md)                        |
+| Compare integration options for my HPC site                      | [Integration Scenarios Analysis](integration_scenarios.md) |
+| Stand up IQM access on a Slurm cluster as an administrator       | [Administrator Guide](admin_guide.md)                      |
+| Contribute to the project                                        | [Contributing](contributing.md)                            |
 
 ## API Reference
 
@@ -47,6 +49,14 @@ spank_plugin
 spack_guide
 
 CHANGELOG
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Administrator Guide
+
+integration_scenarios
+admin_guide
 ```
 
 ```{toctree}

--- a/docs/integration_scenarios.md
+++ b/docs/integration_scenarios.md
@@ -1,0 +1,148 @@
+# Integration Scenarios Analysis
+
+This page compares the ways an HPC center or downstream project can integrate
+IQM quantum computers (QCs) through QDMI-on-IQM. Each scenario links to the
+guide that covers its mechanics; this page focuses on when to pick it, what it
+costs to set up, and what isolation and multi-tenancy properties it gives you. A
+recommendation matrix at the end maps site profiles to scenarios.
+
+:::{note}
+Scenarios 1-6 describe integration paths this repository implements today.
+Scenario 7 is forward-looking: it discusses schedulers this repository does not
+yet support, to help sites evaluating IQM integration outside Slurm.
+:::
+
+## 1. Direct C++ QDMI Device Usage
+
+Link a downstream C++ application directly against the QDMI device library and
+drive a session yourself — see the [Usage Guide](usage.md). No scheduler is
+involved: the calling process owns the session lifecycle, authentication, and
+calibration/job queries end to end.
+
+- **Setup complexity**: low — link the library, call the C API.
+- **Isolation**: whatever the host process provides; QDMI-on-IQM itself enforces
+  no isolation between callers.
+- **Multi-tenancy**: none built in. Concurrent callers targeting the same QC
+  contend at the IQM service's own queue, with no cluster-side arbitration.
+- **Resource brokering**: none — the QC's own queue is the only broker.
+
+## 2. Direct Python/Qiskit Usage
+
+Use {py:class}`~iqm.qdmi.qiskit.IQMBackend` directly from a Python process, as
+shown in [Qiskit Integration](qiskit.md). Same properties as Scenario 1, but at
+the Qiskit/Python layer: no scheduler, no cluster-side isolation, transpilation
+handled by Qiskit's standard tools before the circuit reaches the QC.
+
+- **Setup complexity**: low — `uv pip install iqm-qdmi[qiskit]`.
+- **Isolation / multi-tenancy / resource brokering**: same as Scenario 1.
+- **Fits**: single-researcher workstations, notebooks with direct network access
+  to the IQM service, CI jobs that don't run on a cluster.
+
+## 3. Slurm + SPANK Env-Injection with Synchronous `srun` Offloading
+
+The production integration path today: the [SPANK plugin](spank_plugin.md)
+injects `IQM_*` environment variables into job steps, and the
+{py:mod}`~iqm.qdmi.offloader` module (see
+[Python Package](python_package.md#programmatic-offloading-with-the-offloader-module))
+submits `srun iqm-sampler`/`srun iqm-estimator` jobs from a login-node process
+such as a Jupyter notebook.
+
+- **Setup complexity**: moderate — compile and deploy the SPANK plugin on login
+  and compute nodes, configure `plugstack.conf`, provision a `quantum` partition
+  (see the [Administrator Guide](admin_guide.md)).
+- **Isolation**: partition-gated — the plugin only activates on
+  administrator-listed partitions, and per-node launch-time validation rejects a
+  job step before any task starts if the target QC or credentials are invalid.
+- **Multi-tenancy**: Slurm's own scheduler arbitrates access to the `quantum`
+  partition; optionally, administrators can additionally model each QC as a
+  Slurm license (see
+  [Limiting Concurrent Access with Slurm Licenses](spank_plugin.md#limiting-concurrent-access-with-slurm-licenses))
+  so Slurm itself caps concurrent QC access ahead of the QC's own queue — most
+  useful for on-premise, effectively single-tenant hardware.
+- **Resource brokering**: deliberately shallow. The plugin injects environment
+  variables and validates reachability; it does not lock or schedule the QC
+  itself. Precedence when the same setting is given multiple ways: `srun`
+  command-line flags override user-set environment variables, which override
+  `plugstack.conf` administrator defaults.
+
+## 4. Spack-Based Install
+
+Layer a Spack package definition (see the [Spack Guide](spack_guide.md)) on top
+of any of the above scenarios as the install mechanism, instead of a manual
+CMake build.
+
+- **Setup complexity**: low once a package repository exists; concretization and
+  reproducible pinning (via commit SHA) are handled by Spack.
+- **Fits**: HPC centers that already manage their software stack through Spack
+  environments/modules rather than ad hoc builds.
+- Does not change the isolation, multi-tenancy, or resource-brokering properties
+  of the underlying scenario (3 or 1) — it only changes how the binaries get
+  onto the cluster.
+
+## 5. Docker-Based Test/Dev Topology vs. Bare-Metal Production Deployment
+
+The SPANK plugin's test suite runs inside Docker (`spank/Dockerfile`,
+`.github/workflows/spank-tests.yml`) without requiring a real Slurm installation
+or credentials, as described in
+[Testing with Docker](spank_plugin.md#testing-with-docker).
+Production deployment instead installs the compiled plugin directly onto real
+login and compute nodes running `slurmd`/`slurmstepd`.
+
+- **Fits**: use the Docker topology for plugin development and CI; use the
+  bare-metal topology for any environment where jobs actually reach IQM
+  hardware, since the plugin is tied to the target cluster's Slurm daemon ABI
+  and must be rebuilt against it (see
+  [Compatibility and Requirements](spank_plugin.md#compatibility-and-requirements)).
+- These two topologies are not alternatives for the same purpose — treat Docker
+  as a pre-production verification step, not a deployment option.
+
+## 6. Shared Multi-Tenant Cluster vs. Dedicated/Single-User Access
+
+Orthogonal to Scenarios 1-5: the same integration mechanism behaves differently
+depending on who else is on the cluster.
+
+- **Shared multi-tenant cluster**: partition gating (Scenario 3) and,
+  optionally, Slurm licenses become load-bearing — without them, any user on any
+  partition could target the QC, and concurrent jobs could overwhelm an
+  on-premise QC's own queue.
+- **Dedicated/single-user cluster**: partition gating and license limits are
+  still supported but less critical, since there is no competing tenant to
+  isolate from.
+- Direct usage (Scenarios 1-2) has no partition/license concept at all — choose
+  Scenario 3 instead as soon as more than one user or job needs regulated access
+  to the same QC.
+
+## 7. Forward-Looking: Non-Slurm Schedulers (Not Implemented)
+
+QDMI-on-IQM only supports Slurm today. Sites running other schedulers would need
+an equivalent env-injection mechanism, and the SPANK plugin's "shallow, no
+resource brokering" design is itself Slurm-specific — it would not port to
+another scheduler unchanged:
+
+- **PBS/OpenPBS**: would need a PBS hook (`qmgr` server/queue hooks) written
+  against PBS's own hook API to inject `IQM_*` variables into the job
+  environment at launch — a different lifecycle and API from SPANK's.
+- **LSF**: would need an `esub`/`eexec` job submission wrapper or an LSF
+  external scheduler plugin; LSF has no direct SPANK equivalent, so environment
+  injection and any launch-time validation would need to be reimplemented
+  against LSF's job-control hooks.
+- **Kubernetes**: would look structurally different from all of the above —
+  likely a mutating admission webhook or device-plugin-style resource
+  advertisement, since Kubernetes has no per-job-step CLI flag-parsing hook
+  comparable to SPANK; partition gating's closest analogue would be namespace-
+  or `ResourceQuota`-scoped access.
+
+None of these are implemented in this repository. Treat this section as scoping
+input for a site evaluating IQM integration outside Slurm, not as supported
+functionality.
+
+## Recommendation Matrix
+
+| Site profile | Recommended scenario |
+| :--- | :--- |
+| Single researcher, workstation or notebook, direct network access to the IQM service | 1 (C++) or 2 (Python/Qiskit) |
+| Shared academic HPC center, multiple users/groups, on-premise or capacity-limited QC | 3 (Slurm + SPANK), with Slurm licenses enabled |
+| Dedicated production cluster, single tenant, still scheduler-managed | 3 (Slurm + SPANK), partition gating optional, licenses optional |
+| Site already standardized on Spack for software management | 4, layered on top of 1-3 |
+| Plugin development or CI, no access to real Slurm | 5's Docker topology only — not a deployment target |
+| Site running PBS, LSF, or Kubernetes instead of Slurm | 7 — no supported path today; would require new integration work |

--- a/docs/integration_scenarios.md
+++ b/docs/integration_scenarios.md
@@ -126,11 +126,23 @@ another scheduler unchanged:
   external scheduler plugin; LSF has no direct SPANK equivalent, so environment
   injection and any launch-time validation would need to be reimplemented
   against LSF's job-control hooks.
-- **Kubernetes**: would look structurally different from all of the above —
-  likely a mutating admission webhook or device-plugin-style resource
-  advertisement, since Kubernetes has no per-job-step CLI flag-parsing hook
-  comparable to SPANK; partition gating's closest analogue would be namespace-
-  or `ResourceQuota`-scoped access.
+- **Grid Engine**: would need a prolog/epilog script pair (or a JSV — Job
+  Submission Verifier — script) configured cluster-wide to inject `IQM_*`
+  variables before the job starts, since Grid Engine has no SPANK-equivalent
+  plugin API; partition gating's closest analogue is queue-based access control
+  via `qconf`.
+- **Kubernetes (CRD-based)**: would look structurally different from all of the
+  above — a Custom Resource Definition (e.g. an `IQMJob` CRD) reconciled by a
+  custom controller/operator, which injects `IQM_*` variables into the pod spec
+  it creates, rather than a mutating admission webhook intercepting arbitrary
+  pods; Kubernetes has no per-job-step CLI flag-parsing hook comparable to
+  SPANK, and partition gating's closest analogue would be namespace- or
+  `ResourceQuota`-scoped access.
+- **Flux**: would need a Flux plugin against its job execution API (e.g. a
+  `flux-shell` plugin or jobtap plugin) to inject `IQM_*` variables at job shell
+  launch — architecturally closer to SPANK's shell-launch hook than the others
+  here, but a distinct plugin API and ABI that would need its own
+  implementation.
 
 None of these are implemented in this repository. Treat this section as scoping
 input for a site evaluating IQM integration outside Slurm, not as supported
@@ -145,4 +157,4 @@ functionality.
 | Dedicated production cluster, single tenant, still scheduler-managed | 3 (Slurm + SPANK), partition gating optional, licenses optional |
 | Site already standardized on Spack for software management | 4, layered on top of 1-3 |
 | Plugin development or CI, no access to real Slurm | 5's Docker topology only — not a deployment target |
-| Site running PBS, LSF, or Kubernetes instead of Slurm | 7 — no supported path today; would require new integration work |
+| Site running PBS, LSF, Grid Engine, Kubernetes (CRD-based), or Flux instead of Slurm | 7 — no supported path today; would require new integration work |


### PR DESCRIPTION
Adds an analysis report on various integration scenarios and an integration documentation, plus tutorials for system admins.

`docs/integration_scenarios.md` compares the ways an HPC center can integrate IQM QCs: direct C++/Python usage, Slurm + SPANK env-injection offloading, Spack-based install, Docker-test vs. bare-metal deployment, shared multi-tenant vs. dedicated clusters, and a forward-looking (explicitly not-implemented) look at PBS/LSF/Kubernetes, ending in a recommendation matrix by site profile.

`docs/admin_guide.md` is a step-by-step tutorial for a sysadmin standing up IQM access on a Slurm cluster from scratch — install path, SPANK plugin build/deploy, `plugstack.conf` configuration, authentication setup, verification, and a troubleshooting table keyed off the plugin's diagnostic log line.

Both pages are wired into `docs/index.md`'s nav table and a new "Administrator Guide" toctree caption, cross-linking rather than duplicating `spank_plugin.md` and `spack_guide.md`.