### PR TITLE
:bug: Guard missing VQE optimal parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   Slurm job step before launching tasks ([#136]) ([**@burgholzer**])
 - ✨ Add `iqm.qdmi.offloader` module exposing programmatic `sample` and
   `estimate` functions (including `qc_id`/`qc_alias` SPANK device-selection
-  parameters) for Slurm job submissions ([#104], [#130], [#133])
+  parameters) for Slurm job submissions ([#104], [#130], [#133], [#148])
   ([**@marcelwa**])
 - ✨ Validate Slurm `--licenses` alignment with the targeted QC alias in the
   SPANK plugin, enabling admins to enforce Slurm-native concurrency limits on
@@ -125,6 +125,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#148]: https://github.com/iqm-finland/QDMI-on-IQM/pull/148
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136
 [#134]: https://github.com/iqm-finland/QDMI-on-IQM/pull/134

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -108,8 +108,10 @@ The module provides two primary functions:
   pickled result back to a python dictionary of counts.
 - {py:func}`~iqm.qdmi.offloader.estimate`: Serializes the ansatz and observable,
   submits a Slurm job using `srun iqm-estimator`, and parses the base64-encoded
-  pickled `VQEResult` to return it, matching the semantics of running `VQE`
-  directly against the regular (non-offloaded) estimator.
+  pickled `VQEResult` to return it. For both local and Slurm execution, it
+  raises a `RuntimeError` if VQE does not return optimal parameters; successful
+  results otherwise match running `VQE` directly against the regular
+  (non-offloaded) estimator.
 
 Both functions support a `local=True` argument for running simulation/hardware
 compilation locally (useful for debugging) and a `simulator=True` argument when

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -117,6 +117,21 @@ def _first_pub(primitive_result: Iterable[PubResult]) -> PubResult:
     return first_pub
 
 
+def _validate_vqe_result(result: VQEResult) -> VQEResult:
+    """Ensure that a VQE result contains optimized parameters.
+
+    Returns:
+        The validated VQE result.
+
+    Raises:
+        RuntimeError: If VQE did not return optimal parameters.
+    """
+    if result.optimal_parameters is None:
+        msg = "VQE did not return optimal parameters."
+        raise RuntimeError(msg)
+    return result
+
+
 def _get_jobs_dir() -> Path:
     """Get the jobs directory path.
 
@@ -344,9 +359,10 @@ def estimate(
     When `local=True`, runs the VQE algorithm locally using either the MQT Core
     DDSIM simulator backend or the packaged IQM backend.
 
-    The returned result has the same semantics as calling
-    `VQE(...).compute_minimum_eigenvalue(...)` directly against the regular
-    (non-offloaded) estimator.
+    A successful call returns the same result as
+    `VQE(...).compute_minimum_eigenvalue(...)` against the regular
+    (non-offloaded) estimator. If VQE does not produce optimal parameters, this
+    function raises a `RuntimeError`.
 
     Args:
         ansatz: The ansatz circuit to run.
@@ -371,7 +387,8 @@ def estimate(
 
     Raises:
         ImportError: If Qiskit or the QDMI backend plugins are not installed.
-        RuntimeError: If there is an error while submitting the job to Slurm or parsing the output.
+        RuntimeError: If VQE does not return optimal parameters or there is an
+            error while submitting the job to Slurm or parsing the output.
     """  # ruff:ignore[docstring-extraneous-exception]
     if _IMPORT_ERROR is not None:
         msg = (
@@ -382,7 +399,8 @@ def estimate(
     if local:
         _, estimator = build_estimator(simulator=simulator)
         vqe = VQE(estimator, ansatz, L_BFGS_B(maxiter=maxiter))
-        return vqe.compute_minimum_eigenvalue(operator=operator)
+        result = vqe.compute_minimum_eigenvalue(operator=operator)
+        return _validate_vqe_result(result)
 
     # Make sure the `jobs` directory exists on the shared filesystem
     job_dir = _new_job_dir()
@@ -423,4 +441,5 @@ def estimate(
         job_dir.rmdir()
 
     payload = _decode_payload(process)
-    return cast("VQEResult", _load_pickled_result(payload))
+    result = cast("VQEResult", _load_pickled_result(payload))
+    return _validate_vqe_result(result)

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -58,7 +58,7 @@ class FakePubResult:
 class FakeVQEResult:
     """Mock for VQEResult."""
 
-    def __init__(self, optimal_parameters: dict[str, float]) -> None:
+    def __init__(self, optimal_parameters: dict[str, float] | None) -> None:
         """Initialize optimal parameters."""
         self.optimal_parameters = optimal_parameters
 
@@ -89,6 +89,36 @@ def test_estimate_local_simulator() -> None:
     params = list(optimal_parameters.values())
     assert len(params) == 1
     assert math.isfinite(float(params[0]))
+
+
+def test_estimate_local_raises_without_optimal_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A local VQE result without optimal parameters should raise a clear error."""
+
+    class FakeVQE:
+        """Mock VQE that returns no optimal parameters."""
+
+        def __init__(self, *args: object) -> None:
+            """Accept the VQE constructor arguments."""
+            assert args
+
+        @staticmethod
+        def compute_minimum_eigenvalue(*, operator: SparsePauliOp) -> FakeVQEResult:
+            """Return an unsuccessful VQE result."""
+            assert operator
+            return FakeVQEResult(None)
+
+    def fake_build_estimator(*, simulator: bool) -> tuple[object, object]:
+        assert simulator
+        return object(), object()
+
+    monkeypatch.setattr(offloader, "VQE", FakeVQE)
+    monkeypatch.setattr(offloader, "build_estimator", fake_build_estimator)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    with pytest.raises(RuntimeError, match="VQE did not return optimal parameters"):
+        offloader.estimate(ansatz, operator, local=True, simulator=True)
 
 
 def test_sample_slurm_mock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -161,6 +191,33 @@ def test_estimate_slurm_mock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     # Backend configuration (base URL, tokens, etc.) is not passed explicitly:
     # it is inherited by the job's environment (e.g. via the Slurm SPANK plugin).
     assert "--base-url" not in captured_command
+
+
+def test_estimate_slurm_raises_without_optimal_parameters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An offloaded VQE result without optimal parameters should raise a clear error."""
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps(FakeVQEResult(None)))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        assert command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    with pytest.raises(RuntimeError, match="VQE did not return optimal parameters"):
+        offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True)
 
 
 def test_sample_slurm_uses_spank_qc_alias_and_no_cli_credentials(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- validate VQE results returned by both local and Slurm estimation paths
- raise a clear RuntimeError when no optimal parameters are available
- cover both failure paths with hermetic regression tests and document the behavior

Closes #135

## Verification

- `uvx nox -s tests-3.14` (30 passed, 3 credential-gated live tests skipped)
- `uvx nox -s lint`
- `uvx nox -s docs -- -D nb_execution_mode=off` (passes with 19 existing-style warnings)

The regular documentation build reached the changed guide, then attempted an unrelated live IQM example in `docs/qiskit.md` and failed with HTTP 401 because no hardware credentials were provided.