### PR TITLE
🔖 Prepare release of v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-31
+
 ### Added
 
 - ✨ Validate IQM backend and target-QC availability once per node for each
@@ -123,7 +125,8 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- Version links -->
 
-[Unreleased]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.0.1...v1.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.24...4.2)
 project(
   iqm-qdmi-device
   LANGUAGES C CXX
-  VERSION 1.2.0
+  VERSION 1.3.0
   DESCRIPTION "Implementation of a QDMI device for IQM Quantum Computers")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "iqm-qdmi"
-version = "1.2.0"
+version = "1.3.0"
 requires-python = ">=3.10"
 
 description = "Implementation of a QDMI device for IQM Quantum Computers"
@@ -107,7 +107,6 @@ install.components = ["iqm-qdmi-device_Runtime", "iqm-qdmi-device_Development"]
 sdist.include = ["python/iqm/qdmi/_version.py"]
 sdist.exclude = [
   "**/docs",
-  "**/test",
   "sitecustomize.py",
   ".*",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "iqm-qdmi"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- curate the current Unreleased changelog entries into the 1.3.0 release dated 2026-07-31
- bump the CMake and Python package versions, and synchronize the lockfile
- retain tests in the source distribution so its default CMake configuration is self-contained

## Validation

- `uvx nox -s lint`
- `ctest -C Release --test-dir build-release/test/unit --output-on-failure` (67 passed)
- `uv build`
- `uvx nox -s docs`
- `git diff --check`

No live IQM, Slurm, or Resonance integration tests were run.