### PR TITLE
🐛 Preserve IQM measurement result order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🩹 Keep IQM shot and histogram bitstrings in the result order specified by
+  IQM's measurement-count metadata ([#158]) ([**@burgholzer**])
+
 ## [1.3.0] - 2026-07-31
 
 ### Added
@@ -135,6 +140,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#158]: https://github.com/iqm-finland/QDMI-on-IQM/pull/158
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#140]: https://github.com/iqm-finland/QDMI-on-IQM/pull/140
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🩹 Keep IQM shot and histogram bitstrings in the result order specified by
-  IQM's measurement-count metadata ([#158]) ([**@burgholzer**])
+- 🩹 Keep IQM shot and histogram bitstrings in the measurement-key and qubit
+  order specified by IQM's result metadata ([#158]) ([**@burgholzer**])
 
 ## [1.3.0] - 2026-07-31
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -545,13 +545,16 @@ The implementation expects JSON responses in specific formats:
   `value`, and `invalid` fields.
 - **Job Status**: Object with job status, errors, and messages.
 - **Measurement Counts Artifact**: Array with a single object containing
-  `counts` (object mapping bitstrings to count integers).
+  `measurement_keys` (the concatenation order for result bitstrings) and
+  `counts` (an object mapping bitstrings to count integers).
 - **Measurements Artifact**: Array typically containing a single object where
-  each measurement key maps to an array of all shot results. Each shot result is
-  a single-element array containing an integer (0 or 1). For example:
-  `[{"meas_2_0_0": [[0], [1], [0], [1]], "meas_2_0_1": [[1], [0], [1], [0]]}]`
-  represents 4 shots measuring two qubits, where each measurement key contains
-  all results for that qubit across all shots.
+  results have the shape `results[measurement_key][shot][qubit_index]`. A
+  measurement key may cover one or more qubits; its result arrays have a
+  constant width across shots and contain integer bits (0 or 1). For example,
+  `[{"m_pair": [[0, 1], [1, 0]], "m_single": [[0], [1]]}]` represents two shots,
+  with `m_pair` measuring two qubits and `m_single` one qubit. The
+  `measurement_keys` metadata from the corresponding counts artifact determines
+  how these per-key arrays are concatenated into each result bitstring.
 
 For more details, see the implementation in `iqm_device.cpp` and the API
 configuration in `iqm_api_config.hpp`/`.cpp`.

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1481,7 +1481,7 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
     // API returns array format: [{"meas_key": [[0], [1], ...], ...}, ...]
     // The outer array typically contains a single object.
     // Each measurement key maps to an array of shot results.
-    // Each shot result is itself an array containing a single integer (0 or 1).
+    // Each shot result contains one bit per measured qubit.
     if (!job_measurements_json_response.is_array()) {
       LOG_ERROR("Expected array of measurement objects for job " +
                 job->job_id_);
@@ -1580,28 +1580,28 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
               return QDMI_ERROR_FATAL;
             }
 
-            // Each qubit result array must contain exactly one integer outcome
-            if (qubit_result.size() != 1 ||
-                !qubit_result[0].is_number_integer()) {
-              LOG_ERROR("Invalid qubit result value format for measurement "
-                        "key '" +
-                        key + "', shot " + std::to_string(shot_idx) +
-                        " in job " + job->job_id_);
-              job->status_ = QDMI_JOB_STATUS_FAILED;
-              return QDMI_ERROR_FATAL;
-            }
+            for (const auto &bit : qubit_result) {
+              if (!bit.is_number_integer()) {
+                LOG_ERROR("Invalid qubit result value format for measurement "
+                          "key '" +
+                          key + "', shot " + std::to_string(shot_idx) +
+                          " in job " + job->job_id_);
+                job->status_ = QDMI_JOB_STATUS_FAILED;
+                return QDMI_ERROR_FATAL;
+              }
 
-            const auto value = qubit_result[0].get<int>();
-            if (value < 0 || value > 1) {
-              LOG_ERROR("Invalid qubit value " + std::to_string(value) +
-                        " for measurement key '" + key + "', shot " +
-                        std::to_string(shot_idx) + " in job " + job->job_id_);
-              job->status_ = QDMI_JOB_STATUS_FAILED;
-              return QDMI_ERROR_FATAL;
-            }
+              const auto value = bit.get<int>();
+              if (value < 0 || value > 1) {
+                LOG_ERROR("Invalid qubit value " + std::to_string(value) +
+                          " for measurement key '" + key + "', shot " +
+                          std::to_string(shot_idx) + " in job " + job->job_id_);
+                job->status_ = QDMI_JOB_STATUS_FAILED;
+                return QDMI_ERROR_FATAL;
+              }
 
-            // Append to the bitstring for this shot
-            (*job->shots_)[shot_idx] += std::to_string(value);
+              // Preserve the qubit order within each measurement key.
+              (*job->shots_)[shot_idx] += std::to_string(value);
+            }
           }
         }
       }

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -38,6 +38,7 @@
 #include <cstring>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -1569,6 +1570,8 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
             return QDMI_ERROR_FATAL;
           }
 
+          std::optional<size_t> key_result_width;
+
           // Process each shot for this measurement key
           for (size_t shot_idx = 0; shot_idx < num_shots; ++shot_idx) {
             const auto &qubit_result = key_results[shot_idx];
@@ -1576,6 +1579,19 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
               LOG_ERROR("Invalid qubit result format for measurement key '" +
                         key + "', shot " + std::to_string(shot_idx) +
                         " in job " + job->job_id_);
+              job->status_ = QDMI_JOB_STATUS_FAILED;
+              return QDMI_ERROR_FATAL;
+            }
+
+            if (!key_result_width.has_value()) {
+              key_result_width = qubit_result.size();
+            } else if (qubit_result.size() != *key_result_width) {
+              LOG_ERROR(
+                  "Inconsistent qubit-result width for measurement key '" +
+                  key + "': expected " + std::to_string(*key_result_width) +
+                  ", got " + std::to_string(qubit_result.size()) +
+                  " for shot " + std::to_string(shot_idx) + " in job " +
+                  job->job_id_);
               job->status_ = QDMI_JOB_STATUS_FAILED;
               return QDMI_ERROR_FATAL;
             }
@@ -1624,13 +1640,21 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
     return QDMI_SUCCESS;
   }
 
-  // Calculate required size: bitstring lengths + commas + null terminator
-  // All shots have the same bitstring length (number of qubits measured)
-  const size_t bitstring_length = (*job->shots_)[0].length();
-  const size_t total_bitstring_length = bitstring_length * job->shots_->size();
-  // For N shots, we need (N - 1) commas and 1 null terminator => N extra
-  // characters.
-  const size_t req_size = total_bitstring_length + job->shots_->size();
+  // Calculate the exact serialized size, including separators and terminator.
+  size_t req_size = 1;
+  for (size_t shot_idx = 0; shot_idx < job->shots_->size(); ++shot_idx) {
+    const auto &shot = (*job->shots_)[shot_idx];
+    const size_t separator_size = shot_idx == 0 ? 0 : 1;
+    if (separator_size > std::numeric_limits<size_t>::max() - req_size ||
+        shot.size() >
+            std::numeric_limits<size_t>::max() - req_size - separator_size) {
+      LOG_ERROR("Serialized shot results exceed the supported size for job " +
+                job->job_id_);
+      job->status_ = QDMI_JOB_STATUS_FAILED;
+      return QDMI_ERROR_FATAL;
+    }
+    req_size += separator_size + shot.size();
+  }
 
   if (size_ret != nullptr) {
     *size_ret = req_size;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -191,6 +191,8 @@ struct IQM_QDMI_Device_Job_impl_d {
   std::optional<std::string> dd_strategy_ = std::nullopt;
   /// The dictionary of results (histogram counts).
   std::map<std::string, size_t> counts_;
+  /// Measurement keys in the order used by IQM's histogram bitstrings.
+  std::optional<std::vector<std::string>> measurement_keys_;
   /// Individual shot measurement results as bitstrings. std::nullopt means not
   /// yet fetched, empty vector means fetched but no shots.
   std::optional<std::vector<std::string>> shots_;
@@ -1314,7 +1316,9 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
           nlohmann::json::parse(job_results_response.text);
       LOG_DEBUG("Job results response:\n" + job_results_json_response.dump());
 
-      // Response is an array with a single object containing counts
+      // Response is an array with one result for the submitted circuit.
+      job->measurement_keys_ = job_results_json_response[0]["measurement_keys"]
+                                   .get<std::vector<std::string>>();
       for (const auto &counts = job_results_json_response[0]["counts"];
            const auto &[bitstring, count] : counts.items()) {
         job->counts_[bitstring] = count.get<size_t>();
@@ -1443,6 +1447,16 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
                                           size_t *size_ret) {
   // Fetch the remote results, if not already fetched
   if (!job->shots_.has_value()) {
+    // IQM defines this metadata as the concatenation order of measurement
+    // results in histogram bitstrings. Use the same order for individual shots.
+    if (!job->measurement_keys_.has_value()) {
+      if (const auto status = IQM_QDMI_device_job_get_results_hist(
+              job, QDMI_JOB_RESULT_HIST_KEYS, 0, nullptr, nullptr);
+          status != QDMI_SUCCESS) {
+        return status;
+      }
+    }
+
     LOG_INFO("Fetching shot measurements for job " + job->job_id_);
     const auto job_measurements_url = job->session_->api_config_->url(
         iqm::API_ENDPOINT::GET_JOB_ARTIFACT_MEASUREMENTS, job->job_id_);
@@ -1496,14 +1510,17 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
           return QDMI_ERROR_FATAL;
         }
 
-        // Collect and sort measurement keys for consistent bitstring ordering
-        std::vector<std::string> keys;
-        keys.reserve(measurement_obj.size());
-        for (auto it = measurement_obj.begin(); it != measurement_obj.end();
-             ++it) {
-          keys.emplace_back(it.key());
+        const auto &keys = *job->measurement_keys_;
+        if (measurement_obj.size() != keys.size() ||
+            !std::ranges::all_of(keys, [&](const auto &key) {
+              return measurement_obj.contains(key);
+            })) {
+          LOG_ERROR(
+              "Measurement keys do not match histogram metadata for job " +
+              job->job_id_);
+          job->status_ = QDMI_JOB_STATUS_FAILED;
+          return QDMI_ERROR_FATAL;
         }
-        std::ranges::sort(keys);
 
         // Determine the number of shots from the first key
         size_t num_shots = 0;

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -710,7 +710,7 @@ TEST_F(DeviceJobMockTest, FullLifecycle) {
   const std::string job_submission_response = R"({"id": "job-123"})";
   const std::string job_status_response = R"({"status": "ready"})";
   const std::string job_results_response =
-      R"([{"counts": {"0": 100, "1": 0}}])";
+      R"([{"measurement_keys": ["meas_2_0_0"], "counts": {"0": 100, "1": 0}}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
@@ -755,11 +755,14 @@ TEST_F(DeviceJobMockTest, FullLifecycle) {
 TEST_F(DeviceJobMockTest, RetrieveShotMeasurements) {
   const std::string job_submission_response = R"({"id": "job-456"})";
   const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["meas_2_0_0", "meas_2_0_1"], "counts": {"00": 1, "01": 1, "10": 1, "11": 1}}])";
   const std::string job_measurements_response =
       R"([{"meas_2_0_0": [[0], [1], [0], [1]], "meas_2_0_1": [[0], [0], [1], [1]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
   http_stub.queue_get(200, job_measurements_response);
 
   // Job submission
@@ -800,7 +803,7 @@ TEST_F(DeviceJobMockTest, RetrieveShotMeasurements) {
                                             small_buffer.data(), nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
 
-  // This should NOT trigger another API call (only 2 GET responses were
+  // This should NOT trigger another API call (only 3 GET responses were
   // queued above; an unscripted call would fail the test).
   size_t hist_keys_size{};
   ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
@@ -909,10 +912,13 @@ TEST_F(DeviceJobMockTest, RetrieveShotsBeforeCompletion) {
 TEST_F(DeviceJobMockTest, RejectInvalidMeasurementFormat) {
   const std::string job_submission_response = R"({"id": "job-789"})";
   const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["m"], "counts": {"0": 1}}])";
   const std::string job_measurements_response = R"([{"m": [[0], [0]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
   http_stub.queue_get(200, job_measurements_response);
 
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
@@ -954,11 +960,14 @@ TEST_F(DeviceJobMockTest, HandleInvalidQueuePositionTypes) {
 TEST_F(DeviceJobMockTest, RejectNonIntegerMeasurementValues) {
   const std::string job_submission_response = R"({"id": "job-999"})";
   const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["meas_2_0_0"], "counts": {"0": 1}}])";
   // Invalid: qubit result value is a string instead of an integer
   const std::string job_measurements_response = R"([{"meas_2_0_0": [["0"]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
   http_stub.queue_get(200, job_measurements_response);
 
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
@@ -982,11 +991,14 @@ TEST_F(DeviceJobMockTest, RejectNonIntegerMeasurementValues) {
 TEST_F(DeviceJobMockTest, EmptyShotsReturnsNullTerminator) {
   const std::string job_submission_response = R"({"id": "job-empty"})";
   const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": [], "counts": {}}])";
   // Empty measurements array - no shots
   const std::string job_measurements_response = R"([])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
   http_stub.queue_get(200, job_measurements_response);
 
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1018,6 +1018,41 @@ TEST_F(DeviceJobMockTest, RejectNonBitMeasurementValues) {
             QDMI_ERROR_FATAL);
 }
 
+TEST_F(DeviceJobMockTest, RejectInconsistentMeasurementWidths) {
+  const std::string job_submission_response = R"({"id": "job-width"})";
+  const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["m"], "counts": {"0": 1, "01": 1}}])";
+  const std::string job_measurements_response = R"([{"m": [[0], [0, 1]]}])";
+
+  http_stub.queue_post(200, job_submission_response);
+  http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
+  http_stub.queue_get(200, job_measurements_response);
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 2;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  std::array<char, 8> buffer{};
+  buffer.fill('x');
+  const auto original_buffer = buffer;
+  size_t shots_size = 123;
+  EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS,
+                                            buffer.size(), buffer.data(),
+                                            &shots_size),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(shots_size, 123);
+  EXPECT_EQ(buffer, original_buffer);
+}
+
 TEST_F(DeviceJobMockTest, EmptyShotsReturnsNullTerminator) {
   const std::string job_submission_response = R"({"id": "job-empty"})";
   const std::string job_status_response = R"({"status": "ready"})";

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -849,9 +849,9 @@ TEST_F(DeviceJobMockTest, ShotOrderMatchesIQMMeasurementCounts) {
   const std::string job_submission_response = R"({"id": "job-ordered"})";
   const std::string job_status_response = R"({"status": "ready"})";
   const std::string job_counts_response =
-      R"([{"measurement_keys": ["z_result", "a_result"], "counts": {"01": 1, "10": 1}}])";
+      R"([{"measurement_keys": ["z_result", "a_result"], "counts": {"010": 1, "101": 1}}])";
   const std::string job_measurements_response =
-      R"([{"a_result": [[1], [0]], "z_result": [[0], [1]]}])";
+      R"([{"a_result": [[0], [1]], "z_result": [[0, 1], [1, 0]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
@@ -883,7 +883,7 @@ TEST_F(DeviceJobMockTest, ShotOrderMatchesIQMMeasurementCounts) {
                                             shots_size, shots_buffer.data(),
                                             nullptr),
             QDMI_SUCCESS);
-  EXPECT_STREQ(shots_buffer.data(), "01,10");
+  EXPECT_STREQ(shots_buffer.data(), "010,101");
 }
 
 TEST_F(DeviceJobMockTest, RetrieveShotsBeforeCompletion) {
@@ -914,7 +914,7 @@ TEST_F(DeviceJobMockTest, RejectInvalidMeasurementFormat) {
   const std::string job_status_response = R"({"status": "ready"})";
   const std::string job_counts_response =
       R"([{"measurement_keys": ["m"], "counts": {"0": 1}}])";
-  const std::string job_measurements_response = R"([{"m": [[0], [0]]}])";
+  const std::string job_measurements_response = R"([{"m": [[]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
@@ -961,9 +961,10 @@ TEST_F(DeviceJobMockTest, RejectNonIntegerMeasurementValues) {
   const std::string job_submission_response = R"({"id": "job-999"})";
   const std::string job_status_response = R"({"status": "ready"})";
   const std::string job_counts_response =
-      R"([{"measurement_keys": ["meas_2_0_0"], "counts": {"0": 1}}])";
-  // Invalid: qubit result value is a string instead of an integer
-  const std::string job_measurements_response = R"([{"meas_2_0_0": [["0"]]}])";
+      R"([{"measurement_keys": ["meas_2_0_0"], "counts": {"00": 1}}])";
+  // Invalid: the second value is a string instead of an integer.
+  const std::string job_measurements_response =
+      R"([{"meas_2_0_0": [[0, "1"]]}])";
 
   http_stub.queue_post(200, job_submission_response);
   http_stub.queue_get(200, job_status_response);
@@ -982,6 +983,35 @@ TEST_F(DeviceJobMockTest, RejectNonIntegerMeasurementValues) {
   ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
 
   // Should fail when trying to retrieve results due to non-integer value
+  size_t shots_size{};
+  EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS, 0,
+                                            nullptr, &shots_size),
+            QDMI_ERROR_FATAL);
+}
+
+TEST_F(DeviceJobMockTest, RejectNonBitMeasurementValues) {
+  const std::string job_submission_response = R"({"id": "job-999"})";
+  const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["meas_2_0_0"], "counts": {"00": 1}}])";
+  const std::string job_measurements_response = R"([{"meas_2_0_0": [[0, 2]]}])";
+
+  http_stub.queue_post(200, job_submission_response);
+  http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
+  http_stub.queue_get(200, job_measurements_response);
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 1;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
   size_t shots_size{};
   EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS, 0,
                                             nullptr, &shots_size),

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -842,6 +842,47 @@ TEST_F(DeviceJobMockTest, RetrieveShotMeasurements) {
   EXPECT_EQ(total_count, 4); // 4 shots total
 }
 
+TEST_F(DeviceJobMockTest, ShotOrderMatchesIQMMeasurementCounts) {
+  const std::string job_submission_response = R"({"id": "job-ordered"})";
+  const std::string job_status_response = R"({"status": "ready"})";
+  const std::string job_counts_response =
+      R"([{"measurement_keys": ["z_result", "a_result"], "counts": {"01": 1, "10": 1}}])";
+  const std::string job_measurements_response =
+      R"([{"a_result": [[1], [0]], "z_result": [[0], [1]]}])";
+
+  http_stub.queue_post(200, job_submission_response);
+  http_stub.queue_get(200, job_status_response);
+  http_stub.queue_get(200, job_counts_response);
+  http_stub.queue_get(200, job_measurements_response);
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 2;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  size_t hist_keys_size{};
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                            nullptr, &hist_keys_size),
+            QDMI_SUCCESS);
+
+  size_t shots_size{};
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS, 0,
+                                            nullptr, &shots_size),
+            QDMI_SUCCESS);
+  std::vector<char> shots_buffer(shots_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS,
+                                            shots_size, shots_buffer.data(),
+                                            nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(shots_buffer.data(), "01,10");
+}
+
 TEST_F(DeviceJobMockTest, RetrieveShotsBeforeCompletion) {
   const std::string job_submission_response = R"({"id": "job-789"})";
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- add a regression test showing that shot bitstrings can use a different measurement-key order than IQM histogram results
- follow IQM `measurement_keys` metadata when flattening individual shot results
- preserve every bit, including multi-qubit measurement results, in IQM array order
- validate that every measurement result is a non-empty array of integer bits with a constant per-key width across shots
- calculate the serialized SHOTS size from the constructed results with overflow protection
- document IQM measurement-result dimensions and ordering

## Motivation

IQM measurement counts carry a `measurement_keys` list that defines how measurement results are concatenated into histogram bitstrings. Individual measurements are structured as `results[key][shot][qubit_index]`. The QDMI device previously discarded the key-order metadata, lexicographically sorted keys, and accepted only one bit per measurement key. Non-lexicographic or multi-qubit result layouts could therefore make SHOTS disagree with histogram bitstrings or reject valid IQM results.

Multi-qubit support also requires validating that a measurement key has the same result width in every shot. Otherwise malformed data such as `[[0], [0, 1]]` could make a size derived from the first shot smaller than the subsequent serialization. The implementation now rejects that response before writing output and computes the exact serialized length defensively.

The first commit intentionally contains only the ordering regression. CI on `7456eeff68885f0558ac4523a8afcac81b994670` confirmed that the regression failed as intended. Independently, the live `QDMIIntegrationTest.JobCycleQIR` also failed because IQM Station Control returned an internal-server error; that failure occurred before result retrieval and is unrelated to this change. The following commits apply the key-order, multi-qubit, and validation fixes.

## Testing

- focused unit tests for non-lexicographic multi-qubit ordering, inconsistent widths, and malformed values
- `ctest -C Release --test-dir build/test/unit --output-on-failure`
- `uvx nox -s lint`
- `git diff --check`

## Checklist

- [x] The change is narrowly scoped to IQM measurement-result ordering and validation.
- [x] No live IQM hardware or credentials were used locally.
- [x] The full unit-test suite passes locally.
- [x] Repository lint passes locally.
