### PR TITLE
🐛 Preserve QDMI job program bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🩹 Preserve exact program bytes across QDMI job parameter updates and property
-  queries ([**@burgholzer**])
+  queries ([#159]) ([**@burgholzer**])
 
 ## [1.3.0] - 2026-07-31
 
@@ -140,6 +140,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#159]: https://github.com/iqm-finland/QDMI-on-IQM/pull/159
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#140]: https://github.com/iqm-finland/QDMI-on-IQM/pull/140
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🩹 Preserve exact program bytes across QDMI job parameter updates and property
+  queries ([**@burgholzer**])
+
 ## [1.3.0] - 2026-07-31
 
 ### Added

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1091,8 +1091,8 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
       iqm::API_ENDPOINT::SUBMIT_CALIBRATION_JOB);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      job->session_->connection_pool_, program,
-      {{"Expect", "100-continue"}}, job->session_->request_timeout_);
+      job->session_->connection_pool_, program, {{"Expect", "100-continue"}},
+      job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -151,6 +151,8 @@ struct IQM_QDMI_Device_Job_impl_d {
   QDMI_Program_Format program_format_ = QDMI_PROGRAM_FORMAT_IQMJSON;
   /// The program to be executed.
   std::string program_;
+  /// Whether a program has been set.
+  bool program_set_ = false;
   /// The number of shots to execute for a quantum circuit job.
   size_t num_shots_ = 0;
   /// @brief Heralding mode for the job.
@@ -861,6 +863,7 @@ int IQM_QDMI_device_job_set_parameter(IQM_QDMI_Device_Job job,
   case QDMI_DEVICE_JOB_PARAMETER_PROGRAM:
     if (value != nullptr) {
       job->program_.assign(static_cast<const char *>(value), size);
+      job->program_set_ = true;
     }
     return QDMI_SUCCESS;
   case QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM:
@@ -979,6 +982,9 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAMFORMAT,
                             QDMI_Program_Format, job->program_format_, prop,
                             size, value, size_ret)
+  if (prop == QDMI_DEVICE_JOB_PROPERTY_PROGRAM && !job->program_set_) {
+    return QDMI_ERROR_BADSTATE;
+  }
   ADD_LIST_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAM, char, job->program_, prop,
                     size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM, size_t,
@@ -1117,7 +1123,7 @@ int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
   if (job->session_ == nullptr) {
     return QDMI_ERROR_BADSTATE;
   }
-  if (job->program_.empty()) {
+  if (!job->program_set_) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   job->session_->device_status_ = QDMI_DEVICE_STATUS_BUSY;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -45,6 +45,7 @@
 #include <optional>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -149,7 +150,7 @@ struct IQM_QDMI_Device_Job_impl_d {
   /// The program format used for this job.
   QDMI_Program_Format program_format_ = QDMI_PROGRAM_FORMAT_IQMJSON;
   /// The program to be executed.
-  void *program_ = nullptr;
+  std::string program_;
   /// The number of shots to execute for a quantum circuit job.
   size_t num_shots_ = 0;
   /// @brief Heralding mode for the job.
@@ -813,7 +814,6 @@ int IQM_QDMI_device_session_create_device_job(IQM_QDMI_Device_Session session,
 
 void IQM_QDMI_device_job_free(IQM_QDMI_Device_Job job) {
   LOG_INFO("Freeing device job");
-  delete[] static_cast<char *>(job->program_);
   delete job;
 }
 
@@ -860,8 +860,7 @@ int IQM_QDMI_device_job_set_parameter(IQM_QDMI_Device_Job job,
     return QDMI_SUCCESS;
   case QDMI_DEVICE_JOB_PARAMETER_PROGRAM:
     if (value != nullptr) {
-      job->program_ = new char[size];
-      memcpy(job->program_, value, size);
+      job->program_.assign(static_cast<const char *>(value), size);
     }
     return QDMI_SUCCESS;
   case QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM:
@@ -980,24 +979,32 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAMFORMAT,
                             QDMI_Program_Format, job->program_format_, prop,
                             size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAM, void *,
-                            job->program_, prop, size, value, size_ret)
+  ADD_LIST_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAM, char, job->program_, prop,
+                    size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM, size_t,
                             job->num_shots_, prop, size, value, size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 }
 
 namespace {
+std::string_view Program_contents(const std::string &stored_program) {
+  auto program = std::string_view{stored_program};
+  if (program.ends_with('\0')) {
+    program.remove_suffix(1);
+  }
+  return program;
+}
+
 int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
   LOG_INFO("Submitting circuit job");
   auto json_program = nlohmann::json();
   json_program["circuits"] = nlohmann::json::array();
+  const auto program = Program_contents(job->program_);
   if (job->program_format_ == QDMI_PROGRAM_FORMAT_IQMJSON) {
     json_program["circuits"].emplace_back(
-        nlohmann::json::parse(static_cast<const char *>(job->program_)));
+        nlohmann::json::parse(program.begin(), program.end()));
   } else {
-    json_program["circuits"].emplace_back(
-        std::string{static_cast<const char *>(job->program_)});
+    json_program["circuits"].emplace_back(std::string{program});
   }
   json_program["calibration_set_id"] = job->session_->calibration_set_id_;
   json_program["shots"] = job->num_shots_;
@@ -1066,12 +1073,12 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
     return QDMI_ERROR_NOTSUPPORTED;
   }
   LOG_INFO("Submitting calibration job");
+  const auto program = std::string{Program_contents(job->program_)};
   const auto job_submission_url = job->session_->api_config_->url(
       iqm::API_ENDPOINT::SUBMIT_CALIBRATION_JOB);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      static_cast<const char *>(job->program_), {{"Expect", "100-continue"}},
-      job->session_->request_timeout_);
+      program, {{"Expect", "100-continue"}}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1110,7 +1117,7 @@ int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
   if (job->session_ == nullptr) {
     return QDMI_ERROR_BADSTATE;
   }
-  if (job->program_ == nullptr) {
+  if (job->program_.empty()) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   job->session_->device_status_ = QDMI_DEVICE_STATUS_BUSY;

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1190,6 +1190,40 @@ TEST_F(DeviceJobMockTest, JobParameterValidation) {
             QDMI_SUCCESS);
 }
 
+TEST_F(DeviceJobMockTest, ProgramPropertyReturnsLatestCopiedBytes) {
+  auto first_program = std::to_array("first");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM, first_program.size(),
+                first_program.data()),
+            QDMI_SUCCESS);
+  first_program.front() = 'X';
+
+  constexpr auto latest_program = std::to_array("latest program");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM, latest_program.size(),
+                latest_program.data()),
+            QDMI_SUCCESS);
+
+  size_t size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, 0, nullptr, &size),
+            QDMI_SUCCESS);
+  ASSERT_EQ(size, latest_program.size());
+
+  std::vector<char> too_small(size - 1);
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, too_small.size(),
+                too_small.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+
+  std::vector<char> retrieved_program(size);
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, retrieved_program.size(),
+                retrieved_program.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_TRUE(std::ranges::equal(retrieved_program, latest_program));
+}
+
 TEST_F(DeviceJobMockTest, JobSubmissionWithoutRequiredParameters) {
   // Test submitting job without required parameters
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_INVALIDARGUMENT);

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1191,12 +1191,29 @@ TEST_F(DeviceJobMockTest, JobParameterValidation) {
 }
 
 TEST_F(DeviceJobMockTest, ProgramPropertyReturnsLatestCopiedBytes) {
-  auto first_program = std::to_array("first");
+  size_t size = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, 0, nullptr, &size),
+            QDMI_ERROR_BADSTATE);
+
+  constexpr auto first_program_expected = std::to_array("first");
+  auto first_program = first_program_expected;
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM, first_program.size(),
                 first_program.data()),
             QDMI_SUCCESS);
   first_program.front() = 'X';
+
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, 0, nullptr, &size),
+            QDMI_SUCCESS);
+  ASSERT_EQ(size, first_program_expected.size());
+  std::vector<char> retrieved_program(size);
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, retrieved_program.size(),
+                retrieved_program.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_TRUE(std::ranges::equal(retrieved_program, first_program_expected));
 
   constexpr auto latest_program = std::to_array("latest program");
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
@@ -1204,7 +1221,6 @@ TEST_F(DeviceJobMockTest, ProgramPropertyReturnsLatestCopiedBytes) {
                 latest_program.data()),
             QDMI_SUCCESS);
 
-  size_t size = 0;
   ASSERT_EQ(IQM_QDMI_device_job_query_property(
                 job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, 0, nullptr, &size),
             QDMI_SUCCESS);
@@ -1216,7 +1232,7 @@ TEST_F(DeviceJobMockTest, ProgramPropertyReturnsLatestCopiedBytes) {
                 too_small.data(), nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
 
-  std::vector<char> retrieved_program(size);
+  retrieved_program.resize(size);
   ASSERT_EQ(IQM_QDMI_device_job_query_property(
                 job, QDMI_DEVICE_JOB_PROPERTY_PROGRAM, retrieved_program.size(),
                 retrieved_program.data(), nullptr),


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Preserve the exact copied byte sequence supplied through `QDMI_DEVICE_JOB_PARAMETER_PROGRAM` and return it through the corresponding program property.

The previous raw-pointer storage lost the payload size, leaked the old allocation when the parameter was set repeatedly, and made `QDMI_DEVICE_JOB_PROPERTY_PROGRAM` return an internal pointer-sized value instead of the stored program bytes. This conflicted with the QDMI setter and property contracts and with consumers that first query the payload size and then retrieve the payload.

This change:

- owns the complete, size-aware program payload;
- replaces an existing payload without leaking it;
- returns the actual bytes and byte count from the program property;
- reports `QDMI_ERROR_BADSTATE` when that property is queried before initialization; and
- keeps submission compatible with the conventional trailing NUL on text payloads.

The regression test verifies that the provider owns the first submitted value after the caller mutates its buffer, then verifies that a subsequent value replaces it and is returned exactly.

## Validation

- Release build
- Focused job program and submission lifecycle tests
- All 68 hermetic C++ unit tests
- `uvx nox -s lint`
- `git diff --check`