### PR TITLE
✨ Retrieve existing IQM circuit jobs by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ releases may include breaking changes.
   `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
+- ✨ Support retrieving existing IQM jobs by ID ([#160])
+  ([**@burgholzer**])
 
 ### Fixed
 
@@ -159,6 +161,7 @@ Compatible with QDMI `v1.3.0`.
 [#163]: https://github.com/iqm-finland/QDMI-on-IQM/pull/163
 [#162]: https://github.com/iqm-finland/QDMI-on-IQM/pull/162
 [#158]: https://github.com/iqm-finland/QDMI-on-IQM/pull/158
+[#160]: https://github.com/iqm-finland/QDMI-on-IQM/pull/160
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#140]: https://github.com/iqm-finland/QDMI-on-IQM/pull/140
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
-- ✨ Support opening existing IQM circuit jobs by ID ([#160])
+- ✨ Support retrieving existing IQM circuit jobs by ID ([#160])
   ([**@burgholzer**])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
-- ✨ Support retrieving existing IQM circuit jobs by ID ([#160])
+- ✨ Support opening existing IQM circuit jobs by ID ([#160])
   ([**@burgholzer**])
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ releases may include breaking changes.
   `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
-- ✨ Support retrieving existing IQM jobs by ID ([#160])
+- ✨ Support retrieving existing IQM circuit jobs by ID ([#160])
   ([**@burgholzer**])
 
 ### Fixed

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -23,11 +23,11 @@ if(TARGET qdmi::qdmi)
 else()
   message(STATUS "QDMI will be included via FetchContent")
   # cmake-format: off
-  set(QDMI_MINIMUM_VERSION 1.3.0
+  set(QDMI_MINIMUM_VERSION 1.3.3
       CACHE STRING "Minimum QDMI version")
-  set(QDMI_VERSION 1.3.2
+  set(QDMI_VERSION 1.3.3
       CACHE STRING "QDMI version")
-  set(QDMI_REV "d05a0b418f42e54e9585d2e00af8ce23e745fd83" # v1.3.2
+  set(QDMI_REV "3716948044e23aa50c084732aae2cc3ee913014e" # QDMI PR #485
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -27,7 +27,7 @@ else()
       CACHE STRING "Minimum QDMI version")
   set(QDMI_VERSION 1.3.3
       CACHE STRING "QDMI version")
-  set(QDMI_REV "3716948044e23aa50c084732aae2cc3ee913014e" # QDMI PR #485
+  set(QDMI_REV "a884facd38a551086eef00c3116f1c8e9a09b9c2" # QDMI PR #485
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -27,7 +27,7 @@ else()
       CACHE STRING "Minimum QDMI version")
   set(QDMI_VERSION 1.3.3
       CACHE STRING "QDMI version")
-  set(QDMI_REV "a884facd38a551086eef00c3116f1c8e9a09b9c2" # QDMI PR #485
+  set(QDMI_REV "e80020f7ace5c0a716142378c812f30f86263c4e" # QDMI PR #485
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -11,7 +11,7 @@ These dependencies are linked into the shared library and
 
 | Dependency      | Version | License                        | Purpose                                                    |
 | :-------------- | :------ | :----------------------------- | :--------------------------------------------------------- |
-| [QDMI]          | 1.3.2   | Apache-2.0 with LLVM-exception | QDMI specification and interface headers                   |
+| [QDMI]          | 1.3.3   | Apache-2.0 with LLVM-exception | QDMI specification and interface headers                   |
 | [nlohmann/json] | 3.12.0  | MIT License                    | JSON parsing and serialization                             |
 | [CPR]           | 1.14.2  | MIT License                    | C++ Requests HTTP client library for backend communication |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -468,6 +468,28 @@ For QIR and JSON formats, the program should be provided as a string via the
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_PROGRAM`
 parameter.
 
+## Reopening jobs
+
+Use {cpp:func}`IQM_QDMI_device_session_open_device_job` with the opaque job ID
+returned by
+{cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_ID` to
+obtain a new local handle for an existing IQM job:
+
+```cpp
+IQM_QDMI_Device_Job opened_job = nullptr;
+const int ret = IQM_QDMI_device_session_open_device_job(
+    session, job_id.c_str(), &opened_job);
+```
+
+The device validates the ID with the IQM Server using the current session
+credentials and initializes the handle with the remote job's current status.
+Opening does not clone or submit the job. Parameters cannot be changed and the
+opened handle cannot be submitted again. Freeing it only releases the local
+handle; it does not cancel or delete the remote job. Check or wait for
+completion before retrieving results. Since the original submission payload is
+not reconstructed, only the job ID is exposed as a job property on an opened
+handle.
+
 ## Retrieving Job Results
 
 After a job completes execution, you can retrieve the measurement results in

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -470,24 +470,24 @@ parameter.
 
 ## Retrieving jobs by ID
 
-Use {cpp:func}`IQM_QDMI_device_session_open_device_job` with the job ID returned
-for an IQM circuit job by
+Use {cpp:func}`IQM_QDMI_device_session_retrieve_device_job_by_id` with the job
+ID returned for an IQM circuit job by
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_ID` to
 obtain a new local handle for an existing IQM circuit job:
 
 ```cpp
 IQM_QDMI_Device_Job retrieved_job = nullptr;
-const int ret = IQM_QDMI_device_session_open_device_job(
+const int ret = IQM_QDMI_device_session_retrieve_device_job_by_id(
     session, job_id.c_str(), &retrieved_job);
 ```
 
 The device validates the ID with the IQM Server using the current session
 credentials and initializes the handle with the remote job's current status.
-Opening does not clone or submit the job. Parameters cannot be changed and the
-opened handle cannot be submitted again. Freeing it only releases the local
-handle; it does not cancel or delete the remote job. Check or wait for
+Retrieving does not clone or submit the job. Parameters cannot be changed and
+the retrieved handle cannot be submitted again. Freeing it only releases the
+local handle; it does not cancel or delete the remote job. Check or wait for
 completion before retrieving results. Since the original submission payload is
-not reconstructed, only the job ID is exposed as a job property on an opened
+not reconstructed, only the job ID is exposed as a job property on a retrieved
 handle.
 
 ## Retrieving Job Results

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -468,17 +468,17 @@ For QIR and JSON formats, the program should be provided as a string via the
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_PROGRAM`
 parameter.
 
-## Reopening jobs
+## Retrieving jobs by ID
 
-Use {cpp:func}`IQM_QDMI_device_session_open_device_job` with the opaque job ID
-returned for an IQM circuit job by
+Use {cpp:func}`IQM_QDMI_device_session_retrieve_device_job_by_id` with the job
+ID returned for an IQM circuit job by
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_ID` to
 obtain a new local handle for an existing IQM circuit job:
 
 ```cpp
-IQM_QDMI_Device_Job opened_job = nullptr;
-const int ret = IQM_QDMI_device_session_open_device_job(
-    session, job_id.c_str(), &opened_job);
+IQM_QDMI_Device_Job retrieved_job = nullptr;
+const int ret = IQM_QDMI_device_session_retrieve_device_job_by_id(
+    session, job_id.c_str(), &retrieved_job);
 ```
 
 The device validates the ID with the IQM Server using the current session

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -470,14 +470,14 @@ parameter.
 
 ## Retrieving jobs by ID
 
-Use {cpp:func}`IQM_QDMI_device_session_retrieve_device_job_by_id` with the job
-ID returned for an IQM circuit job by
+Use {cpp:func}`IQM_QDMI_device_session_open_device_job` with the job ID returned
+for an IQM circuit job by
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_ID` to
 obtain a new local handle for an existing IQM circuit job:
 
 ```cpp
 IQM_QDMI_Device_Job retrieved_job = nullptr;
-const int ret = IQM_QDMI_device_session_retrieve_device_job_by_id(
+const int ret = IQM_QDMI_device_session_open_device_job(
     session, job_id.c_str(), &retrieved_job);
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -471,9 +471,9 @@ parameter.
 ## Reopening jobs
 
 Use {cpp:func}`IQM_QDMI_device_session_open_device_job` with the opaque job ID
-returned by
+returned for an IQM circuit job by
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_ID` to
-obtain a new local handle for an existing IQM job:
+obtain a new local handle for an existing IQM circuit job:
 
 ```cpp
 IQM_QDMI_Device_Job opened_job = nullptr;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1276,7 +1276,8 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (job->job_id_.empty() || job->status_ == QDMI_JOB_STATUS_DONE ||
-      job->status_ == QDMI_JOB_STATUS_CANCELED) {
+      job->status_ == QDMI_JOB_STATUS_CANCELED ||
+      job->status_ == QDMI_JOB_STATUS_FAILED) {
     *status = job->status_;
     return QDMI_SUCCESS;
   }

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -892,12 +892,7 @@ int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
   opened_job->job_id_ = job_id;
   opened_job->opened_ = true;
   const auto job_type = job_status_json.value("type", "circuit");
-  if (job_type == "calibration") {
-    if (!session->supports_calibration_jobs_) {
-      return QDMI_ERROR_NOTSUPPORTED;
-    }
-    opened_job->program_format_ = QDMI_PROGRAM_FORMAT_CALIBRATION;
-  } else if (job_type != "circuit") {
+  if (job_type != "circuit") {
     return QDMI_ERROR_NOTSUPPORTED;
   }
   if (const auto status = Set_job_status(
@@ -1248,6 +1243,9 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
       job->session_->connection_pool_, "", {}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_abortion_response);
   if (status != QDMI_SUCCESS) {
+    if (status == QDMI_ERROR_PERMISSIONDENIED) {
+      return status;
+    }
     job->status_ = QDMI_JOB_STATUS_FAILED;
     return QDMI_ERROR_FATAL;
   }
@@ -1279,6 +1277,9 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
       job->session_->connection_pool_, job->session_->request_timeout_);
   const auto status_code = iqm::http::Handle_response(job_status_response);
   if (status_code != QDMI_SUCCESS) {
+    if (status_code == QDMI_ERROR_PERMISSIONDENIED) {
+      return status_code;
+    }
     job->status_ = QDMI_JOB_STATUS_FAILED;
     return QDMI_ERROR_FATAL;
   }

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -867,9 +867,9 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
 }
 } // namespace
 
-int IQM_QDMI_device_session_retrieve_device_job_by_id(
-    IQM_QDMI_Device_Session session, const char *job_id,
-    IQM_QDMI_Device_Job *job) {
+int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
+                                            const char *job_id,
+                                            IQM_QDMI_Device_Job *job) {
   if (session == nullptr || job_id == nullptr || job_id[0] == '\0' ||
       job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -867,9 +867,9 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
 }
 } // namespace
 
-int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
-                                            const char *job_id,
-                                            IQM_QDMI_Device_Job *job) {
+int IQM_QDMI_device_session_retrieve_device_job_by_id(
+    IQM_QDMI_Device_Session session, const char *job_id,
+    IQM_QDMI_Device_Job *job) {
   if (session == nullptr || job_id == nullptr || job_id[0] == '\0' ||
       job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -37,11 +37,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
+#include <new>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
@@ -876,17 +878,17 @@ int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
     return QDMI_ERROR_BADSTATE;
   }
 
-  const auto job_status_url =
-      session->api_config_->url(iqm::API_ENDPOINT::GET_JOB_STATUS, job_id);
-  const auto job_status_response = iqm::http::Get(
-      job_status_url, session->token_manager_->get_bearer_token(),
-      session->request_timeout_);
-  if (const auto status = iqm::http::Handle_response(job_status_response);
-      status != QDMI_SUCCESS) {
-    return status;
-  }
-
   try {
+    const auto job_status_url =
+        session->api_config_->url(iqm::API_ENDPOINT::GET_JOB_STATUS, job_id);
+    const auto job_status_response = iqm::http::Get(
+        job_status_url, session->token_manager_->get_bearer_token(),
+        session->request_timeout_);
+    if (const auto status = iqm::http::Handle_response(job_status_response);
+        status != QDMI_SUCCESS) {
+      return status;
+    }
+
     const auto job_status_json =
         nlohmann::json::parse(job_status_response.text);
     if (job_status_json.value("type", "circuit") != "circuit") {
@@ -903,9 +905,21 @@ int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
       return status;
     }
     *job = opened_job.release();
+  } catch (const iqm::ClientAuthenticationError &error) {
+    LOG_ERROR("Authentication failed while opening job: " +
+              std::string{error.what()});
+    return QDMI_ERROR_PERMISSIONDENIED;
+  } catch (const std::bad_alloc &) {
+    return QDMI_ERROR_OUTOFMEM;
   } catch (const nlohmann::json::exception &error) {
     LOG_ERROR("Failed to parse opened job response: " +
               std::string{error.what()});
+    return QDMI_ERROR_FATAL;
+  } catch (const std::exception &error) {
+    LOG_ERROR("Failed to open job: " + std::string{error.what()});
+    return QDMI_ERROR_FATAL;
+  } catch (...) {
+    LOG_ERROR("Failed to open job with an unknown error");
     return QDMI_ERROR_FATAL;
   }
   LOG_INFO("Opened device job with ID: " + std::string{job_id});
@@ -1616,7 +1630,7 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
         }
 
         // Validate that the number of shots matches what was requested
-        if (num_shots != job->num_shots_) {
+        if (!job->opened_ && num_shots != job->num_shots_) {
           LOG_ERROR(
               "Number of shots in measurement response (" +
               std::to_string(num_shots) + ") does not match requested shots (" +

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -154,7 +154,7 @@ struct IQM_QDMI_Device_Job_impl_d {
   /// The job ID as returned by the API.
   std::string job_id_;
   /// Whether this handle was opened for an existing remote job.
-  bool opened_ = false;
+  bool retrieved_ = false;
   /// The program format used for this job.
   QDMI_Program_Format program_format_ = QDMI_PROGRAM_FORMAT_IQMJSON;
   /// The program to be executed.
@@ -867,9 +867,9 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
 }
 } // namespace
 
-int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
-                                            const char *job_id,
-                                            IQM_QDMI_Device_Job *job) {
+int IQM_QDMI_device_session_retrieve_device_job_by_id(
+    IQM_QDMI_Device_Session session, const char *job_id,
+    IQM_QDMI_Device_Job *job) {
   if (session == nullptr || job_id == nullptr || job_id[0] == '\0' ||
       job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
@@ -895,34 +895,35 @@ int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
       return QDMI_ERROR_NOTSUPPORTED;
     }
 
-    auto opened_job = std::make_unique<IQM_QDMI_Device_Job_impl_d>();
-    opened_job->session_ = session;
-    opened_job->job_id_ = job_id;
-    opened_job->opened_ = true;
-    if (const auto status = Set_job_status(
-            opened_job.get(), job_status_json.at("status").get<std::string>());
+    auto retrieved_job = std::make_unique<IQM_QDMI_Device_Job_impl_d>();
+    retrieved_job->session_ = session;
+    retrieved_job->job_id_ = job_id;
+    retrieved_job->retrieved_ = true;
+    if (const auto status =
+            Set_job_status(retrieved_job.get(),
+                           job_status_json.at("status").get<std::string>());
         status != QDMI_SUCCESS) {
       return status;
     }
-    *job = opened_job.release();
+    *job = retrieved_job.release();
   } catch (const iqm::ClientAuthenticationError &error) {
-    LOG_ERROR("Authentication failed while opening job: " +
+    LOG_ERROR("Authentication failed while retrieving job: " +
               std::string{error.what()});
     return QDMI_ERROR_PERMISSIONDENIED;
   } catch (const std::bad_alloc &) {
     return QDMI_ERROR_OUTOFMEM;
   } catch (const nlohmann::json::exception &error) {
-    LOG_ERROR("Failed to parse opened job response: " +
+    LOG_ERROR("Failed to parse retrieved job response: " +
               std::string{error.what()});
     return QDMI_ERROR_FATAL;
   } catch (const std::exception &error) {
-    LOG_ERROR("Failed to open job: " + std::string{error.what()});
+    LOG_ERROR("Failed to retrieve job: " + std::string{error.what()});
     return QDMI_ERROR_FATAL;
   } catch (...) {
-    LOG_ERROR("Failed to open job with an unknown error");
+    LOG_ERROR("Failed to retrieve job with an unknown error");
     return QDMI_ERROR_FATAL;
   }
-  LOG_INFO("Opened device job with ID: " + std::string{job_id});
+  LOG_INFO("Retrieved device job with ID: " + std::string{job_id});
   return QDMI_SUCCESS;
 }
 
@@ -1092,7 +1093,7 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   }
   ADD_STRING_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_ID, job->job_id_.c_str(), prop,
                       size, value, size_ret)
-  if (job->opened_) {
+  if (job->retrieved_) {
     return QDMI_ERROR_NOTSUPPORTED;
   }
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAMFORMAT,
@@ -1630,7 +1631,7 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
         }
 
         // Validate that the number of shots matches what was requested
-        if (!job->opened_ && num_shots != job->num_shots_) {
+        if (!job->retrieved_ && num_shots != job->num_shots_) {
           LOG_ERROR(
               "Number of shots in measurement response (" +
               std::to_string(num_shots) + ") does not match requested shots (" +

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -886,21 +886,28 @@ int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
     return status;
   }
 
-  const auto job_status_json = nlohmann::json::parse(job_status_response.text);
-  auto opened_job = std::make_unique<IQM_QDMI_Device_Job_impl_d>();
-  opened_job->session_ = session;
-  opened_job->job_id_ = job_id;
-  opened_job->opened_ = true;
-  const auto job_type = job_status_json.value("type", "circuit");
-  if (job_type != "circuit") {
-    return QDMI_ERROR_NOTSUPPORTED;
+  try {
+    const auto job_status_json =
+        nlohmann::json::parse(job_status_response.text);
+    if (job_status_json.value("type", "circuit") != "circuit") {
+      return QDMI_ERROR_NOTSUPPORTED;
+    }
+
+    auto opened_job = std::make_unique<IQM_QDMI_Device_Job_impl_d>();
+    opened_job->session_ = session;
+    opened_job->job_id_ = job_id;
+    opened_job->opened_ = true;
+    if (const auto status = Set_job_status(
+            opened_job.get(), job_status_json.at("status").get<std::string>());
+        status != QDMI_SUCCESS) {
+      return status;
+    }
+    *job = opened_job.release();
+  } catch (const nlohmann::json::exception &error) {
+    LOG_ERROR("Failed to parse opened job response: " +
+              std::string{error.what()});
+    return QDMI_ERROR_FATAL;
   }
-  if (const auto status = Set_job_status(
-          opened_job.get(), job_status_json.at("status").get<std::string>());
-      status != QDMI_SUCCESS) {
-    return status;
-  }
-  *job = opened_job.release();
   LOG_INFO("Opened device job with ID: " + std::string{job_id});
   return QDMI_SUCCESS;
 }

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -883,7 +883,7 @@ int IQM_QDMI_device_session_retrieve_device_job_by_id(
         session->api_config_->url(iqm::API_ENDPOINT::GET_JOB_STATUS, job_id);
     const auto job_status_response = iqm::http::Get(
         job_status_url, session->token_manager_->get_bearer_token(),
-        session->request_timeout_);
+        session->connection_pool_, session->request_timeout_);
     if (const auto status = iqm::http::Handle_response(job_status_response);
         status != QDMI_SUCCESS) {
       return status;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -151,6 +151,8 @@ struct IQM_QDMI_Device_Job_impl_d {
   IQM_QDMI_Device_Session session_ = nullptr;
   /// The job ID as returned by the API.
   std::string job_id_;
+  /// Whether this handle was opened for an existing remote job.
+  bool opened_ = false;
   /// The program format used for this job.
   QDMI_Program_Format program_format_ = QDMI_PROGRAM_FORMAT_IQMJSON;
   /// The program to be executed.
@@ -822,6 +824,92 @@ int IQM_QDMI_device_session_create_device_job(IQM_QDMI_Device_Session session,
   return QDMI_SUCCESS;
 }
 
+namespace {
+int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
+  if (native_status == "received") {
+    job->status_ = QDMI_JOB_STATUS_SUBMITTED;
+  } else if (native_status == "queued" || native_status == "waiting") {
+    job->status_ = QDMI_JOB_STATUS_QUEUED;
+  } else if (native_status == "validation_started" ||
+             native_status == "validation_ended" ||
+             native_status == "fetch_calibration_started" ||
+             native_status == "fetch_calibration_ended" ||
+             native_status == "compilation_started" ||
+             native_status == "compilation_ended" ||
+             native_status == "save_sweep_metadata_started" ||
+             native_status == "save_sweep_metadata_ended" ||
+             native_status == "pending execution" ||
+             native_status == "pending_execution" ||
+             native_status == "execution_started" ||
+             native_status == "execution_ended" ||
+             native_status == "post_processing_pending" ||
+             native_status == "post_processing_started" ||
+             native_status == "post_processing_ended" ||
+             // Legacy job statuses
+             native_status == "running" || native_status == "processing" ||
+             native_status == "accepted" ||
+             native_status == "pending compilation" ||
+             native_status == "compiled") {
+    job->status_ = QDMI_JOB_STATUS_RUNNING;
+  } else if (native_status == "ready" || native_status == "completed") {
+    job->status_ = QDMI_JOB_STATUS_DONE;
+  } else if (native_status == "aborted" || native_status == "cancelled") {
+    job->status_ = QDMI_JOB_STATUS_CANCELED;
+  } else if (native_status == "failed") {
+    job->status_ = QDMI_JOB_STATUS_FAILED;
+  } else {
+    LOG_ERROR("Unknown job status: " + native_status);
+    return QDMI_ERROR_FATAL;
+  }
+  return QDMI_SUCCESS;
+}
+} // namespace
+
+int IQM_QDMI_device_session_open_device_job(IQM_QDMI_Device_Session session,
+                                            const char *job_id,
+                                            IQM_QDMI_Device_Job *job) {
+  if (session == nullptr || job_id == nullptr || job_id[0] == '\0' ||
+      job == nullptr) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
+  if (session->session_status_ != IQM_QDMI_DEVICE_SESSION_STATUS::INITIALIZED) {
+    return QDMI_ERROR_BADSTATE;
+  }
+
+  const auto job_status_url =
+      session->api_config_->url(iqm::API_ENDPOINT::GET_JOB_STATUS, job_id);
+  const auto job_status_response = iqm::http::Get(
+      job_status_url, session->token_manager_->get_bearer_token(),
+      session->request_timeout_);
+  if (const auto status = iqm::http::Handle_response(job_status_response);
+      status != QDMI_SUCCESS) {
+    return status;
+  }
+
+  const auto job_status_json = nlohmann::json::parse(job_status_response.text);
+  auto opened_job = std::make_unique<IQM_QDMI_Device_Job_impl_d>();
+  opened_job->session_ = session;
+  opened_job->job_id_ = job_id;
+  opened_job->opened_ = true;
+  const auto job_type = job_status_json.value("type", "circuit");
+  if (job_type == "calibration") {
+    if (!session->supports_calibration_jobs_) {
+      return QDMI_ERROR_NOTSUPPORTED;
+    }
+    opened_job->program_format_ = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  } else if (job_type != "circuit") {
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
+  if (const auto status = Set_job_status(
+          opened_job.get(), job_status_json.at("status").get<std::string>());
+      status != QDMI_SUCCESS) {
+    return status;
+  }
+  *job = opened_job.release();
+  LOG_INFO("Opened device job with ID: " + std::string{job_id});
+  return QDMI_SUCCESS;
+}
+
 void IQM_QDMI_device_job_free(IQM_QDMI_Device_Job job) {
   LOG_INFO("Freeing device job");
   delete[] static_cast<char *>(job->program_);
@@ -988,6 +1076,9 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   }
   ADD_STRING_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_ID, job->job_id_.c_str(), prop,
                       size, value, size_ret)
+  if (job->opened_) {
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAMFORMAT,
                             QDMI_Program_Format, job->program_format_, prop,
                             size, value, size_ret)
@@ -1114,8 +1205,11 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
 } // namespace
 
 int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
-  if (job == nullptr || job->status_ != QDMI_JOB_STATUS_CREATED) {
+  if (job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
+  }
+  if (job->status_ != QDMI_JOB_STATUS_CREATED) {
+    return QDMI_ERROR_BADSTATE;
   }
   if (job->session_ == nullptr) {
     return QDMI_ERROR_BADSTATE;
@@ -1193,39 +1287,9 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
   LOG_DEBUG("Job status response:\n" + job_status_json_response.dump());
 
   const auto job_status = job_status_json_response["status"].get<std::string>();
-  if (job_status == "received") {
-    job->status_ = QDMI_JOB_STATUS_SUBMITTED;
-  } else if (job_status == "queued" || job_status == "waiting") {
-    job->status_ = QDMI_JOB_STATUS_QUEUED;
-  } else if (job_status == "validation_started" ||
-             job_status == "validation_ended" ||
-             job_status == "fetch_calibration_started" ||
-             job_status == "fetch_calibration_ended" ||
-             job_status == "compilation_started" ||
-             job_status == "compilation_ended" ||
-             job_status == "save_sweep_metadata_started" ||
-             job_status == "save_sweep_metadata_ended" ||
-             job_status == "pending execution" ||
-             job_status == "pending_execution" ||
-             job_status == "execution_started" ||
-             job_status == "execution_ended" ||
-             job_status == "post_processing_pending" ||
-             job_status == "post_processing_started" ||
-             job_status == "post_processing_ended" ||
-             // Legacy job statuses
-             job_status == "running" || job_status == "processing" ||
-             job_status == "accepted" || job_status == "pending compilation" ||
-             job_status == "compiled") {
-    job->status_ = QDMI_JOB_STATUS_RUNNING;
-  } else if (job_status == "ready" || job_status == "completed") {
-    job->status_ = QDMI_JOB_STATUS_DONE;
-  } else if (job_status == "aborted" || job_status == "cancelled") {
-    job->status_ = QDMI_JOB_STATUS_CANCELED;
-  } else if (job_status == "failed") {
-    job->status_ = QDMI_JOB_STATUS_FAILED;
-  } else {
-    LOG_ERROR("Unknown job status: " + job_status);
-    return QDMI_ERROR_FATAL;
+  if (const auto update_status = Set_job_status(job, job_status);
+      update_status != QDMI_SUCCESS) {
+    return update_status;
   }
   *status = job->status_;
   LOG_DEBUG("Job status: " + std::to_string(job->status_) +

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -874,6 +874,7 @@ int IQM_QDMI_device_session_retrieve_device_job_by_id(
       job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
+  *job = nullptr;
   if (session->session_status_ != IQM_QDMI_DEVICE_SESSION_STATUS::INITIALIZED) {
     return QDMI_ERROR_BADSTATE;
   }
@@ -905,26 +906,18 @@ int IQM_QDMI_device_session_retrieve_device_job_by_id(
         status != QDMI_SUCCESS) {
       return status;
     }
+    LOG_INFO("Retrieved device job with ID: " + std::string{job_id});
     *job = retrieved_job.release();
-  } catch (const iqm::ClientAuthenticationError &error) {
-    LOG_ERROR("Authentication failed while retrieving job: " +
-              std::string{error.what()});
+    return QDMI_SUCCESS;
+  } catch (const iqm::ClientAuthenticationError &) {
     return QDMI_ERROR_PERMISSIONDENIED;
   } catch (const std::bad_alloc &) {
     return QDMI_ERROR_OUTOFMEM;
-  } catch (const nlohmann::json::exception &error) {
-    LOG_ERROR("Failed to parse retrieved job response: " +
-              std::string{error.what()});
-    return QDMI_ERROR_FATAL;
-  } catch (const std::exception &error) {
-    LOG_ERROR("Failed to retrieve job: " + std::string{error.what()});
+  } catch (const std::exception &) {
     return QDMI_ERROR_FATAL;
   } catch (...) {
-    LOG_ERROR("Failed to retrieve job with an unknown error");
     return QDMI_ERROR_FATAL;
   }
-  LOG_INFO("Retrieved device job with ID: " + std::string{job_id});
-  return QDMI_SUCCESS;
 }
 
 void IQM_QDMI_device_job_free(IQM_QDMI_Device_Job job) {

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -802,6 +802,19 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
                         return total + entry.second;
                       });
   EXPECT_EQ(reopened_sum, shots_num);
+
+  size_t reopened_shots_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
+                                            0, nullptr, &reopened_shots_size),
+            QDMI_SUCCESS);
+  ASSERT_GT(reopened_shots_size, 1U);
+  std::vector<char> reopened_shots(reopened_shots_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
+                                            reopened_shots.size(),
+                                            reopened_shots.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(static_cast<size_t>(std::ranges::count(reopened_shots, ',')) + 1,
+            shots_num);
   IQM_QDMI_device_job_free(opened_job);
 }
 

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -789,8 +789,8 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
   IQM_QDMI_device_job_free(job);
 
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, job_id.c_str(),
-                                                    &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, job_id.c_str(), &retrieved_job),
             QDMI_SUCCESS);
   EXPECT_EQ(FoMaC::get_job_id(retrieved_job), job_id);
   EXPECT_EQ(IQM_QDMI_device_job_submit(retrieved_job), QDMI_ERROR_BADSTATE);

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -789,8 +789,8 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
   IQM_QDMI_device_job_free(job);
 
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, job_id.c_str(), &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, job_id.c_str(),
+                                                    &retrieved_job),
             QDMI_SUCCESS);
   EXPECT_EQ(FoMaC::get_job_id(retrieved_job), job_id);
   EXPECT_EQ(IQM_QDMI_device_job_submit(retrieved_job), QDMI_ERROR_BADSTATE);

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -29,6 +29,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <map>
+#include <numeric>
 #include <optional>
 #include <random>
 #include <ranges>
@@ -690,6 +691,7 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
   constexpr size_t shots_num = 64;
   const auto circuit = build_iqm_json_test_circuit();
   auto *job = fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
+  const auto job_id = FoMaC::get_job_id(job);
   const auto status = wait_for_done(job);
   if (should_skip_for_expected_mock_failure(status)) {
     IQM_QDMI_device_job_free(job);
@@ -785,6 +787,22 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
             QDMI_ERROR_NOTSUPPORTED);
 
   IQM_QDMI_device_job_free(job);
+
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, job_id.c_str(),
+                                                    &opened_job),
+            QDMI_SUCCESS);
+  EXPECT_EQ(FoMaC::get_job_id(opened_job), job_id);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(opened_job), QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(wait_for_done(opened_job), QDMI_JOB_STATUS_DONE);
+  const auto reopened_counts = FoMaC::get_histogram(opened_job);
+  const auto reopened_sum =
+      std::accumulate(reopened_counts.begin(), reopened_counts.end(), size_t{0},
+                      [](const size_t total, const auto &entry) {
+                        return total + entry.second;
+                      });
+  EXPECT_EQ(reopened_sum, shots_num);
+  IQM_QDMI_device_job_free(opened_job);
 }
 
 TEST_F(QDMIIntegrationTest, JobCancellation) {

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -788,34 +788,35 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
 
   IQM_QDMI_device_job_free(job);
 
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, job_id.c_str(),
-                                                    &opened_job),
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, job_id.c_str(), &retrieved_job),
             QDMI_SUCCESS);
-  EXPECT_EQ(FoMaC::get_job_id(opened_job), job_id);
-  EXPECT_EQ(IQM_QDMI_device_job_submit(opened_job), QDMI_ERROR_BADSTATE);
-  EXPECT_EQ(wait_for_done(opened_job), QDMI_JOB_STATUS_DONE);
-  const auto reopened_counts = FoMaC::get_histogram(opened_job);
-  const auto reopened_sum =
-      std::accumulate(reopened_counts.begin(), reopened_counts.end(), size_t{0},
-                      [](const size_t total, const auto &entry) {
+  EXPECT_EQ(FoMaC::get_job_id(retrieved_job), job_id);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(retrieved_job), QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(wait_for_done(retrieved_job), QDMI_JOB_STATUS_DONE);
+  const auto retrieved_counts = FoMaC::get_histogram(retrieved_job);
+  const auto retrieved_sum =
+      std::accumulate(retrieved_counts.begin(), retrieved_counts.end(),
+                      size_t{0}, [](const size_t total, const auto &entry) {
                         return total + entry.second;
                       });
-  EXPECT_EQ(reopened_sum, shots_num);
+  EXPECT_EQ(retrieved_sum, shots_num);
 
-  size_t reopened_shots_size = 0;
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
-                                            0, nullptr, &reopened_shots_size),
+  size_t retrieved_shots_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(retrieved_job,
+                                            QDMI_JOB_RESULT_SHOTS, 0, nullptr,
+                                            &retrieved_shots_size),
             QDMI_SUCCESS);
-  ASSERT_GT(reopened_shots_size, 1U);
-  std::vector<char> reopened_shots(reopened_shots_size);
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
-                                            reopened_shots.size(),
-                                            reopened_shots.data(), nullptr),
+  ASSERT_GT(retrieved_shots_size, 1U);
+  std::vector<char> retrieved_shots(retrieved_shots_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(
+                retrieved_job, QDMI_JOB_RESULT_SHOTS, retrieved_shots.size(),
+                retrieved_shots.data(), nullptr),
             QDMI_SUCCESS);
-  EXPECT_EQ(static_cast<size_t>(std::ranges::count(reopened_shots, ',')) + 1,
+  EXPECT_EQ(static_cast<size_t>(std::ranges::count(retrieved_shots, ',')) + 1,
             shots_num);
-  IQM_QDMI_device_job_free(opened_job);
+  IQM_QDMI_device_job_free(retrieved_job);
 }
 
 TEST_F(QDMIIntegrationTest, JobCancellation) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -732,9 +732,83 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
             QDMI_ERROR_BADSTATE);
 }
 
+TEST_F(DeviceTest, JobOpeningValidatesArgumentsAndSessionState) {
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(nullptr, "job-123", &opened_job),
+      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, nullptr, &opened_job),
+      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "", &opened_job),
+            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", nullptr),
+      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_BADSTATE);
+}
+
 // ============================================================================
 // INTEGRATION MOCK TESTS - Full lifecycle with mocked dependencies
 // ============================================================================
+
+TEST_F(DeviceJobMockTest, OpenExistingJob) {
+  const std::string job_status_response =
+      R"({"id": "job-123", "status": "ready", "type": "circuit"})";
+  http_stub.queue_get(200, job_status_response);
+
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  ASSERT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_SUCCESS);
+
+  size_t id_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(
+                opened_job, QDMI_DEVICE_JOB_PROPERTY_ID, 0, nullptr, &id_size),
+            QDMI_SUCCESS);
+  std::string id(id_size, '\0');
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(opened_job,
+                                               QDMI_DEVICE_JOB_PROPERTY_ID,
+                                               id.size(), id.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(id.c_str(), "job-123");
+
+  EXPECT_EQ(IQM_QDMI_device_job_set_parameter(
+                opened_job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, 0, nullptr),
+            QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(opened_job), QDMI_ERROR_BADSTATE);
+
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
+  IQM_QDMI_device_job_free(opened_job);
+}
+
+TEST_F(DeviceJobMockTest, OpenExistingJobPropagatesAccessErrors) {
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  http_stub.queue_get(404, R"({"message": "Job not found"})");
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "unknown", &opened_job),
+      QDMI_ERROR_NOTFOUND);
+
+  http_stub.queue_get(403, R"({"message": "Access denied"})");
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "private", &opened_job),
+      QDMI_ERROR_PERMISSIONDENIED);
+}
+
+TEST_F(DeviceJobMockTest, OpenExistingCalibrationJob) {
+  http_stub.queue_get(
+      200,
+      R"({"id": "calibration-123", "status": "ready", "type": "calibration"})");
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
+                                                    &opened_job),
+            QDMI_SUCCESS);
+  IQM_QDMI_device_job_free(opened_job);
+}
 
 TEST_F(DeviceJobMockTest, FullLifecycle) {
   const std::string job_submission_response = R"({"id": "job-123"})";

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <array>
-#include <bit>
 #include <chrono>
 #include <cpr/response.h>
 #include <cstddef>
@@ -738,25 +737,27 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
             QDMI_ERROR_BADSTATE);
 }
 
-TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
-  IQM_QDMI_Device_Job const sentinel =
-      std::bit_cast<IQM_QDMI_Device_Job>(session);
-  IQM_QDMI_Device_Job retrieved_job = sentinel;
+TEST_F(DeviceJobMockTest, JobRetrievalValidatesArguments) {
+  IQM_QDMI_Device_Job retrieved_job = job;
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 nullptr, "job-123", &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(retrieved_job, sentinel);
+  EXPECT_EQ(retrieved_job, job);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, nullptr,
                                                               &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(retrieved_job, sentinel);
+  EXPECT_EQ(retrieved_job, job);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, "",
                                                               &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(retrieved_job, sentinel);
+  EXPECT_EQ(retrieved_job, job);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
+}
+
+TEST_F(DeviceTest, JobRetrievalRequiresInitializedSession) {
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_BADSTATE);
@@ -789,6 +790,12 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
             QDMI_SUCCESS);
   EXPECT_STREQ(id.c_str(), "job-123");
 
+  QDMI_Program_Format program_format = QDMI_PROGRAM_FORMAT_IQMJSON;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                retrieved_job, QDMI_DEVICE_JOB_PROPERTY_PROGRAMFORMAT,
+                sizeof(program_format), &program_format, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+
   EXPECT_EQ(IQM_QDMI_device_job_set_parameter(
                 retrieved_job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, 0, nullptr),
             QDMI_ERROR_BADSTATE);
@@ -798,6 +805,44 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
   EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
   EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
   IQM_QDMI_device_job_free(retrieved_job);
+}
+
+TEST_F(DeviceJobMockTest, RetrieveExistingJobRestoresRemoteStatus) {
+  struct StatusCase {
+    const char *native_status;
+    QDMI_Job_Status qdmi_status;
+  };
+  constexpr std::array status_cases{
+      StatusCase{"received", QDMI_JOB_STATUS_SUBMITTED},
+      StatusCase{"aborted", QDMI_JOB_STATUS_CANCELED},
+      StatusCase{"failed", QDMI_JOB_STATUS_FAILED},
+  };
+
+  for (const auto &[native_status, qdmi_status] : status_cases) {
+    const auto response = std::string{R"({"id":"job-123","status":")"} +
+                          native_status + R"(","type":"circuit"})";
+    http_stub.queue_get(200, response);
+    IQM_QDMI_Device_Job retrieved_job = nullptr;
+    ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                  session, "job-123", &retrieved_job),
+              QDMI_SUCCESS);
+
+    if (qdmi_status == QDMI_JOB_STATUS_SUBMITTED) {
+      http_stub.queue_get(200, response);
+    }
+    QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+    ASSERT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
+    EXPECT_EQ(status, qdmi_status);
+    IQM_QDMI_device_job_free(retrieved_job);
+  }
+
+  http_stub.queue_get(
+      200, R"({"id":"job-123","status":"unknown","type":"circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = job;
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(retrieved_job, nullptr);
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
@@ -814,16 +859,14 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
-  IQM_QDMI_Device_Job const sentinel =
-      std::bit_cast<IQM_QDMI_Device_Job>(session);
-  IQM_QDMI_Device_Job retrieved_job = sentinel;
+  IQM_QDMI_Device_Job retrieved_job = job;
   http_stub.queue_get(200, "invalid json");
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  retrieved_job = sentinel;
+  retrieved_job = job;
   http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
@@ -832,9 +875,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
-  IQM_QDMI_Device_Job const sentinel =
-      std::bit_cast<IQM_QDMI_Device_Job>(session);
-  IQM_QDMI_Device_Job retrieved_job = sentinel;
+  IQM_QDMI_Device_Job retrieved_job = job;
   auto &get_hook = iqm::http::internal::Get_hooks().get;
 
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
@@ -846,7 +887,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_PERMISSIONDENIED);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  retrieved_job = sentinel;
+  retrieved_job = job;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -854,7 +895,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_OUTOFMEM);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  retrieved_job = sentinel;
+  retrieved_job = job;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
@@ -864,7 +905,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  retrieved_job = sentinel;
+  retrieved_job = job;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw 42; };
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -740,23 +740,23 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
 TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
   const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(nullptr, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                nullptr, "job-123", &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, nullptr, &retrieved_job),
-      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, nullptr,
+                                                              &retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "", &retrieved_job),
-      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, "",
+                                                              &retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", nullptr),
-      QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_BADSTATE);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -771,8 +771,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
   http_stub.queue_get(200, job_status_response);
 
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_SUCCESS);
 
   size_t id_size = 0;
@@ -801,13 +801,13 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
 TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
   IQM_QDMI_Device_Job retrieved_job = nullptr;
   http_stub.queue_get(404, R"({"message": "Job not found"})");
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "unknown",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "unknown", &retrieved_job),
             QDMI_ERROR_NOTFOUND);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "private",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "private", &retrieved_job),
             QDMI_ERROR_PERMISSIONDENIED);
 }
 
@@ -815,15 +815,15 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
   const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
   http_stub.queue_get(200, "invalid json");
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -837,16 +837,16 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
                 const auto) -> cpr::Response {
     throw iqm::ClientAuthenticationError{"expired token"};
   };
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_PERMISSIONDENIED);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_OUTOFMEM);
   EXPECT_EQ(retrieved_job, nullptr);
 
@@ -855,16 +855,16 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
   };
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw 42; };
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -874,8 +874,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsUnsupportedJobTypes) {
       200,
       R"({"id": "calibration-123", "status": "ready", "type": "calibration"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
-                                                    &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "calibration-123", &retrieved_job),
             QDMI_ERROR_NOTSUPPORTED);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -884,8 +884,8 @@ TEST_F(DeviceJobMockTest, RetrievedJobReturnsShotsWithoutSubmissionMetadata) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "ready", "type": "circuit"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_SUCCESS);
 
   http_stub.queue_get(
@@ -908,8 +908,8 @@ TEST_F(DeviceJobMockTest, RetrievedJobPreservesPermissionFailures) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
-                                                    &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
             QDMI_SUCCESS);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -814,6 +814,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRestoresRemoteStatus) {
   };
   constexpr std::array status_cases{
       StatusCase{"received", QDMI_JOB_STATUS_SUBMITTED},
+      StatusCase{"queued", QDMI_JOB_STATUS_QUEUED},
       StatusCase{"aborted", QDMI_JOB_STATUS_CANCELED},
       StatusCase{"failed", QDMI_JOB_STATUS_FAILED},
   };
@@ -827,12 +828,20 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRestoresRemoteStatus) {
                   session, "job-123", &retrieved_job),
               QDMI_SUCCESS);
 
-    if (qdmi_status == QDMI_JOB_STATUS_SUBMITTED) {
+    if (qdmi_status == QDMI_JOB_STATUS_SUBMITTED ||
+        qdmi_status == QDMI_JOB_STATUS_QUEUED) {
       http_stub.queue_get(200, response);
     }
     QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
     ASSERT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
     EXPECT_EQ(status, qdmi_status);
+
+    if (qdmi_status == QDMI_JOB_STATUS_SUBMITTED) {
+      http_stub.queue_get(
+          200, R"({"id":"job-123","status":"unknown","type":"circuit"})");
+      EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status),
+                QDMI_ERROR_FATAL);
+    }
     IQM_QDMI_device_job_free(retrieved_job);
   }
 
@@ -1615,6 +1624,8 @@ TEST_F(DeviceJobMockTest, JobParameterValidation) {
 }
 
 TEST_F(DeviceJobMockTest, JobSubmissionWithoutRequiredParameters) {
+  EXPECT_EQ(IQM_QDMI_device_job_submit(nullptr), QDMI_ERROR_INVALIDARGUMENT);
+
   // Test submitting job without required parameters
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_INVALIDARGUMENT);
 }

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <chrono>
 #include <cpr/response.h>
 #include <cstddef>
@@ -738,7 +739,8 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
 }
 
 TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
-  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job const sentinel =
+      std::bit_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 nullptr, "job-123", &retrieved_job),
@@ -812,7 +814,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
-  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job const sentinel =
+      std::bit_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
   http_stub.queue_get(200, "invalid json");
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -829,7 +832,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
-  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job const sentinel =
+      std::bit_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
   auto &get_hook = iqm::http::internal::Get_hooks().get;
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -738,22 +738,27 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
 }
 
 TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
-  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job retrieved_job = sentinel;
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 nullptr, "job-123", &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(retrieved_job, sentinel);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, nullptr,
                                                               &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(retrieved_job, sentinel);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, "",
                                                               &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(retrieved_job, sentinel);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(retrieved_job, nullptr);
 }
 
 // ============================================================================
@@ -807,13 +812,15 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
-  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job retrieved_job = sentinel;
   http_stub.queue_get(200, "invalid json");
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
+  retrieved_job = sentinel;
   http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
@@ -822,7 +829,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
-  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
+  IQM_QDMI_Device_Job retrieved_job = sentinel;
   auto &get_hook = iqm::http::internal::Get_hooks().get;
 
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
@@ -834,6 +842,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_PERMISSIONDENIED);
   EXPECT_EQ(retrieved_job, nullptr);
 
+  retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -841,10 +850,19 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_OUTOFMEM);
   EXPECT_EQ(retrieved_job, nullptr);
 
+  retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
   };
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(retrieved_job, nullptr);
+
+  retrieved_job = sentinel;
+  get_hook = [](const auto &, const auto &, const auto &, const auto &,
+                const auto) -> cpr::Response { throw 42; };
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_FATAL);

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -17,7 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include "http_client.hpp"
 #include "http_stub.hpp"
+#include "iqm_auth.hpp"
 #include "iqm_qdmi/device.h"
 #include "logging.hpp"
 
@@ -32,7 +34,9 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <new>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -814,6 +818,36 @@ TEST_F(DeviceJobMockTest, OpenExistingJobRejectsMalformedResponses) {
   EXPECT_EQ(opened_job, nullptr);
 }
 
+TEST_F(DeviceJobMockTest, OpenExistingJobContainsBoundaryExceptions) {
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  auto &get_hook = iqm::http::internal::Get_hooks().get;
+
+  get_hook = [](const auto &, const auto &, const auto &,
+                const auto) -> cpr::Response {
+    throw iqm::ClientAuthenticationError{"expired token"};
+  };
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_PERMISSIONDENIED);
+  EXPECT_EQ(opened_job, nullptr);
+
+  get_hook = [](const auto &, const auto &, const auto &,
+                const auto) -> cpr::Response { throw std::bad_alloc{}; };
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_OUTOFMEM);
+  EXPECT_EQ(opened_job, nullptr);
+
+  get_hook = [](const auto &, const auto &, const auto &,
+                const auto) -> cpr::Response {
+    throw std::runtime_error{"transport hook failed"};
+  };
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_FATAL);
+  EXPECT_EQ(opened_job, nullptr);
+}
+
 TEST_F(DeviceJobMockTest, OpenExistingJobRejectsUnsupportedJobTypes) {
   http_stub.queue_get(
       200,
@@ -823,6 +857,30 @@ TEST_F(DeviceJobMockTest, OpenExistingJobRejectsUnsupportedJobTypes) {
                                                     &opened_job),
             QDMI_ERROR_NOTSUPPORTED);
   EXPECT_EQ(opened_job, nullptr);
+}
+
+TEST_F(DeviceJobMockTest, OpenedJobRetrievesShotsWithoutSubmissionMetadata) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "ready", "type": "circuit"})");
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  ASSERT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_SUCCESS);
+
+  http_stub.queue_get(
+      200,
+      R"([{"meas_2_0_0": [[0], [1], [0]], "meas_2_0_1": [[1], [0], [1]]}])");
+  size_t shots_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
+                                            0, nullptr, &shots_size),
+            QDMI_SUCCESS);
+  std::vector<char> shots(shots_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
+                                            shots.size(), shots.data(),
+                                            nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(shots.data(), "01,10,01");
+  IQM_QDMI_device_job_free(opened_job);
 }
 
 TEST_F(DeviceJobMockTest, OpenedJobPreservesPermissionFailures) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -799,14 +799,38 @@ TEST_F(DeviceJobMockTest, OpenExistingJobPropagatesAccessErrors) {
       QDMI_ERROR_PERMISSIONDENIED);
 }
 
-TEST_F(DeviceJobMockTest, OpenExistingCalibrationJob) {
+TEST_F(DeviceJobMockTest, OpenExistingJobRejectsUnsupportedJobTypes) {
   http_stub.queue_get(
       200,
       R"({"id": "calibration-123", "status": "ready", "type": "calibration"})");
   IQM_QDMI_Device_Job opened_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
                                                     &opened_job),
-            QDMI_SUCCESS);
+            QDMI_ERROR_NOTSUPPORTED);
+  EXPECT_EQ(opened_job, nullptr);
+}
+
+TEST_F(DeviceJobMockTest, OpenedJobPreservesPermissionFailures) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  ASSERT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_SUCCESS);
+
+  http_stub.queue_get(403, R"({"message": "Access denied"})");
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status),
+            QDMI_ERROR_PERMISSIONDENIED);
+
+  http_stub.queue_post(403, R"({"message": "Access denied"})");
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(opened_job),
+            QDMI_ERROR_PERMISSIONDENIED);
+
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_RUNNING);
   IQM_QDMI_device_job_free(opened_job);
 }
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -740,23 +740,23 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
 TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
   const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                nullptr, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(nullptr, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, nullptr,
-                                                              &retrieved_job),
-            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, nullptr, &retrieved_job),
+      QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, "",
-                                                              &retrieved_job),
-            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "", &retrieved_job),
+      QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(retrieved_job, sentinel);
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", nullptr),
-            QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", nullptr),
+      QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_BADSTATE);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -771,8 +771,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
   http_stub.queue_get(200, job_status_response);
 
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_SUCCESS);
 
   size_t id_size = 0;
@@ -801,13 +801,13 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
 TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
   IQM_QDMI_Device_Job retrieved_job = nullptr;
   http_stub.queue_get(404, R"({"message": "Job not found"})");
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "unknown", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "unknown",
+                                                    &retrieved_job),
             QDMI_ERROR_NOTFOUND);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "private", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "private",
+                                                    &retrieved_job),
             QDMI_ERROR_PERMISSIONDENIED);
 }
 
@@ -815,15 +815,15 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
   const auto sentinel = reinterpret_cast<IQM_QDMI_Device_Job>(session);
   IQM_QDMI_Device_Job retrieved_job = sentinel;
   http_stub.queue_get(200, "invalid json");
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -837,16 +837,16 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
                 const auto) -> cpr::Response {
     throw iqm::ClientAuthenticationError{"expired token"};
   };
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_PERMISSIONDENIED);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_OUTOFMEM);
   EXPECT_EQ(retrieved_job, nullptr);
 
@@ -855,16 +855,16 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
   };
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 
   retrieved_job = sentinel;
   get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw 42; };
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_ERROR_FATAL);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -874,8 +874,8 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsUnsupportedJobTypes) {
       200,
       R"({"id": "calibration-123", "status": "ready", "type": "calibration"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "calibration-123", &retrieved_job),
+  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
+                                                    &retrieved_job),
             QDMI_ERROR_NOTSUPPORTED);
   EXPECT_EQ(retrieved_job, nullptr);
 }
@@ -884,8 +884,8 @@ TEST_F(DeviceJobMockTest, RetrievedJobReturnsShotsWithoutSubmissionMetadata) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "ready", "type": "circuit"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_SUCCESS);
 
   http_stub.queue_get(
@@ -908,8 +908,8 @@ TEST_F(DeviceJobMockTest, RetrievedJobPreservesPermissionFailures) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
   IQM_QDMI_Device_Job retrieved_job = nullptr;
-  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
-                session, "job-123", &retrieved_job),
+  ASSERT_EQ(IQM_QDMI_device_session_open_device_job(session, "job-123",
+                                                    &retrieved_job),
             QDMI_SUCCESS);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -737,175 +737,177 @@ TEST_F(DeviceTest, JobCreationWithoutInitialization) {
             QDMI_ERROR_BADSTATE);
 }
 
-TEST_F(DeviceTest, JobOpeningValidatesArgumentsAndSessionState) {
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(nullptr, "job-123", &opened_job),
-      QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, nullptr, &opened_job),
-      QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "", &opened_job),
+TEST_F(DeviceTest, JobRetrievalValidatesArgumentsAndSessionState) {
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                nullptr, "job-123", &retrieved_job),
             QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", nullptr),
-      QDMI_ERROR_INVALIDARGUMENT);
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, nullptr,
+                                                              &retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(session, "",
+                                                              &retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_BADSTATE);
 }
 
 // ============================================================================
 // INTEGRATION MOCK TESTS - Full lifecycle with mocked dependencies
 // ============================================================================
 
-TEST_F(DeviceJobMockTest, OpenExistingJob) {
+TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
   const std::string job_status_response =
       R"({"id": "job-123", "status": "ready", "type": "circuit"})";
   http_stub.queue_get(200, job_status_response);
 
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  ASSERT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_SUCCESS);
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
 
   size_t id_size = 0;
-  ASSERT_EQ(IQM_QDMI_device_job_query_property(
-                opened_job, QDMI_DEVICE_JOB_PROPERTY_ID, 0, nullptr, &id_size),
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(retrieved_job,
+                                               QDMI_DEVICE_JOB_PROPERTY_ID, 0,
+                                               nullptr, &id_size),
             QDMI_SUCCESS);
   std::string id(id_size, '\0');
-  ASSERT_EQ(IQM_QDMI_device_job_query_property(opened_job,
+  ASSERT_EQ(IQM_QDMI_device_job_query_property(retrieved_job,
                                                QDMI_DEVICE_JOB_PROPERTY_ID,
                                                id.size(), id.data(), nullptr),
             QDMI_SUCCESS);
   EXPECT_STREQ(id.c_str(), "job-123");
 
   EXPECT_EQ(IQM_QDMI_device_job_set_parameter(
-                opened_job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, 0, nullptr),
+                retrieved_job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, 0, nullptr),
             QDMI_ERROR_BADSTATE);
-  EXPECT_EQ(IQM_QDMI_device_job_submit(opened_job), QDMI_ERROR_BADSTATE);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(retrieved_job), QDMI_ERROR_BADSTATE);
 
   QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
-  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
   EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
-  IQM_QDMI_device_job_free(opened_job);
+  IQM_QDMI_device_job_free(retrieved_job);
 }
 
-TEST_F(DeviceJobMockTest, OpenExistingJobPropagatesAccessErrors) {
-  IQM_QDMI_Device_Job opened_job = nullptr;
+TEST_F(DeviceJobMockTest, RetrieveExistingJobPropagatesAccessErrors) {
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
   http_stub.queue_get(404, R"({"message": "Job not found"})");
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "unknown", &opened_job),
-      QDMI_ERROR_NOTFOUND);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "unknown", &retrieved_job),
+            QDMI_ERROR_NOTFOUND);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "private", &opened_job),
-      QDMI_ERROR_PERMISSIONDENIED);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "private", &retrieved_job),
+            QDMI_ERROR_PERMISSIONDENIED);
 }
 
-TEST_F(DeviceJobMockTest, OpenExistingJobRejectsMalformedResponses) {
-  IQM_QDMI_Device_Job opened_job = nullptr;
+TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsMalformedResponses) {
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
   http_stub.queue_get(200, "invalid json");
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_FATAL);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(retrieved_job, nullptr);
 
   http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_FATAL);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(retrieved_job, nullptr);
 }
 
-TEST_F(DeviceJobMockTest, OpenExistingJobContainsBoundaryExceptions) {
-  IQM_QDMI_Device_Job opened_job = nullptr;
+TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
   auto &get_hook = iqm::http::internal::Get_hooks().get;
 
   get_hook = [](const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw iqm::ClientAuthenticationError{"expired token"};
   };
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_PERMISSIONDENIED);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_PERMISSIONDENIED);
+  EXPECT_EQ(retrieved_job, nullptr);
 
   get_hook = [](const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_OUTOFMEM);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_OUTOFMEM);
+  EXPECT_EQ(retrieved_job, nullptr);
 
   get_hook = [](const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
   };
-  EXPECT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_ERROR_FATAL);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_ERROR_FATAL);
+  EXPECT_EQ(retrieved_job, nullptr);
 }
 
-TEST_F(DeviceJobMockTest, OpenExistingJobRejectsUnsupportedJobTypes) {
+TEST_F(DeviceJobMockTest, RetrieveExistingJobRejectsUnsupportedJobTypes) {
   http_stub.queue_get(
       200,
       R"({"id": "calibration-123", "status": "ready", "type": "calibration"})");
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  EXPECT_EQ(IQM_QDMI_device_session_open_device_job(session, "calibration-123",
-                                                    &opened_job),
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "calibration-123", &retrieved_job),
             QDMI_ERROR_NOTSUPPORTED);
-  EXPECT_EQ(opened_job, nullptr);
+  EXPECT_EQ(retrieved_job, nullptr);
 }
 
-TEST_F(DeviceJobMockTest, OpenedJobRetrievesShotsWithoutSubmissionMetadata) {
+TEST_F(DeviceJobMockTest, RetrievedJobReturnsShotsWithoutSubmissionMetadata) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "ready", "type": "circuit"})");
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  ASSERT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_SUCCESS);
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
 
   http_stub.queue_get(
       200,
       R"([{"meas_2_0_0": [[0], [1], [0]], "meas_2_0_1": [[1], [0], [1]]}])");
   size_t shots_size = 0;
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
-                                            0, nullptr, &shots_size),
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(
+                retrieved_job, QDMI_JOB_RESULT_SHOTS, 0, nullptr, &shots_size),
             QDMI_SUCCESS);
   std::vector<char> shots(shots_size);
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(opened_job, QDMI_JOB_RESULT_SHOTS,
-                                            shots.size(), shots.data(),
-                                            nullptr),
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(retrieved_job,
+                                            QDMI_JOB_RESULT_SHOTS, shots.size(),
+                                            shots.data(), nullptr),
             QDMI_SUCCESS);
   EXPECT_STREQ(shots.data(), "01,10,01");
-  IQM_QDMI_device_job_free(opened_job);
+  IQM_QDMI_device_job_free(retrieved_job);
 }
 
-TEST_F(DeviceJobMockTest, OpenedJobPreservesPermissionFailures) {
+TEST_F(DeviceJobMockTest, RetrievedJobPreservesPermissionFailures) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
-  IQM_QDMI_Device_Job opened_job = nullptr;
-  ASSERT_EQ(
-      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
-      QDMI_SUCCESS);
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
 
   http_stub.queue_get(403, R"({"message": "Access denied"})");
   QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
-  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status),
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status),
             QDMI_ERROR_PERMISSIONDENIED);
 
   http_stub.queue_post(403, R"({"message": "Access denied"})");
-  EXPECT_EQ(IQM_QDMI_device_job_cancel(opened_job),
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(retrieved_job),
             QDMI_ERROR_PERMISSIONDENIED);
 
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
-  EXPECT_EQ(IQM_QDMI_device_job_check(opened_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
   EXPECT_EQ(status, QDMI_JOB_STATUS_RUNNING);
-  IQM_QDMI_device_job_free(opened_job);
+  IQM_QDMI_device_job_free(retrieved_job);
 }
 
 TEST_F(DeviceJobMockTest, FullLifecycle) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -799,6 +799,21 @@ TEST_F(DeviceJobMockTest, OpenExistingJobPropagatesAccessErrors) {
       QDMI_ERROR_PERMISSIONDENIED);
 }
 
+TEST_F(DeviceJobMockTest, OpenExistingJobRejectsMalformedResponses) {
+  IQM_QDMI_Device_Job opened_job = nullptr;
+  http_stub.queue_get(200, "invalid json");
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_FATAL);
+  EXPECT_EQ(opened_job, nullptr);
+
+  http_stub.queue_get(200, R"({"id": "job-123", "type": "circuit"})");
+  EXPECT_EQ(
+      IQM_QDMI_device_session_open_device_job(session, "job-123", &opened_job),
+      QDMI_ERROR_FATAL);
+  EXPECT_EQ(opened_job, nullptr);
+}
+
 TEST_F(DeviceJobMockTest, OpenExistingJobRejectsUnsupportedJobTypes) {
   http_stub.queue_get(
       200,

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cpr/response.h>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -825,7 +825,7 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
   IQM_QDMI_Device_Job retrieved_job = nullptr;
   auto &get_hook = iqm::http::internal::Get_hooks().get;
 
-  get_hook = [](const auto &, const auto &, const auto &,
+  get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw iqm::ClientAuthenticationError{"expired token"};
   };
@@ -834,14 +834,14 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobContainsBoundaryExceptions) {
             QDMI_ERROR_PERMISSIONDENIED);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  get_hook = [](const auto &, const auto &, const auto &,
+  get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response { throw std::bad_alloc{}; };
   EXPECT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, "job-123", &retrieved_job),
             QDMI_ERROR_OUTOFMEM);
   EXPECT_EQ(retrieved_job, nullptr);
 
-  get_hook = [](const auto &, const auto &, const auto &,
+  get_hook = [](const auto &, const auto &, const auto &, const auto &,
                 const auto) -> cpr::Response {
     throw std::runtime_error{"transport hook failed"};
   };

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -34,8 +34,8 @@
 #include <exception>
 #include <gtest/gtest.h>
 #include <iostream>
-#include <nlohmann/json.hpp>
 #include <new>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -938,6 +938,9 @@ TEST_F(DeviceJobMockTest, RetrievedJobReturnsShotsWithoutSubmissionMetadata) {
                 session, "job-123", &retrieved_job),
             QDMI_SUCCESS);
 
+  http_stub.queue_get(
+      200,
+      R"([{"measurement_keys": ["meas_2_0_0", "meas_2_0_1"], "counts": {"01": 2, "10": 1}}])");
   http_stub.queue_get(
       200,
       R"([{"meas_2_0_0": [[0], [1], [0]], "meas_2_0_1": [[1], [0], [1]]}])");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -808,15 +808,11 @@ TEST_F(DeviceJobMockTest, RetrieveExistingJobById) {
 }
 
 TEST_F(DeviceJobMockTest, RetrieveExistingJobRestoresRemoteStatus) {
-  struct StatusCase {
-    const char *native_status;
-    QDMI_Job_Status qdmi_status;
-  };
   constexpr std::array status_cases{
-      StatusCase{"received", QDMI_JOB_STATUS_SUBMITTED},
-      StatusCase{"queued", QDMI_JOB_STATUS_QUEUED},
-      StatusCase{"aborted", QDMI_JOB_STATUS_CANCELED},
-      StatusCase{"failed", QDMI_JOB_STATUS_FAILED},
+      std::pair{"received", QDMI_JOB_STATUS_SUBMITTED},
+      std::pair{"queued", QDMI_JOB_STATUS_QUEUED},
+      std::pair{"aborted", QDMI_JOB_STATUS_CANCELED},
+      std::pair{"failed", QDMI_JOB_STATUS_FAILED},
   };
 
   for (const auto &[native_status, qdmi_status] : status_cases) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- implement `IQM_QDMI_device_session_retrieve_device_job_by_id` from Munich-Quantum-Software-Stack/QDMI#485 for circuit jobs managed by the unified IQM API
- validate the job ID with the current session credentials and return a fresh local handle initialized from the remote status
- keep retrieved jobs immutable and non-resubmittable, while allowing status checks, waiting, cancellation, and result retrieval
- preserve permission failures from subsequent status and cancellation requests without corrupting the remote job status
- contain authentication, allocation, transport, and malformed-response failures inside the C entry point, map them to QDMI errors, and never publish a partial handle
- expose only the remote job ID on retrieved handles because the original submission payload is not reconstructed
- retrieve both histograms and raw shots without depending on unavailable local submission metadata
- reuse the device session connection pool for job-retrieval requests
- document the lifecycle and cover it with unit and live integration tests

Calibration jobs remain on the separate legacy COCOS API and are deliberately not claimed as retrievable by this implementation.

## Dependency

This draft temporarily pins the merged QDMI #485 revision `e80020f7ace5c0a716142378c812f30f86263c4e`. The pin should be replaced with the QDMI v1.3.3 tag once the next patch release is available.

## Validation

- `uvx nox --non-interactive -s lint`
- fresh debug build against current main and the merged QDMI revision above
- 78/78 credential-independent tests
- `QDMIIntegrationTest.JobCycle` against `emerald:mock`, including freeing the original handle, retrieving by ID, rejecting resubmission, waiting, and retrieving the same 64-shot result as both a histogram and raw shots
- `QDMIIntegrationTest.JobCycleQIR` is explicitly disabled and tracked by #170

## Known external QIR failure

Resonance currently rejects valid QIR programs during Station Control compilation with `unknown: Internal server error occurred`. This is independent of the job-retrieval change. The live QIR test is temporarily disabled, with its re-enablement tracked in #170.

The exact QCCSW 4.6 package set parses malformed QIR on Resonance and returns a precise `pyqir` diagnostic, proving that the QIR dependencies are installed. However, both the original fixture and a minimal valid measurement-only QIR module pass validation, enter compilation, and then fail with the generic server error. The same valid modules convert and compile locally with the exact package set and live `emerald:mock` calibration.

The strongest remaining integration hypothesis is a stale call site for `iqm.pulla.utils_qir.qir_to_pulla`. Its first parameter changed from `Pulla` in 9.0.0 to `Compiler` in 9.1.0; 14.0.0 still requires and returns a `Compiler`. Passing the old `Pulla` object explains the observed discriminator: malformed input fails during parsing before the first parameter is used, while every valid module reaches component mapping or subsequent compilation and collapses into the generic server error. The server-side fix is to pass an existing `Compiler`, or `pulla.get_standard_compiler()`, into `qir_to_pulla` and continue with the returned compiler. This needs confirmation against the private Station Control call site.
