### PR TITLE
✨ Forward a `licenses` `kwarg` to `sample()`/`estimate()`'s `srun` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- ✨ Add a `licenses` keyword argument to `iqm.qdmi.offloader`'s `sample`/
+  `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
+  Slurm license a site administrator may require via the SPANK plugin's
+  `iqm_require_license` option ([#PENDING]) ([**@marcelwa**])
+
 ## [1.3.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ releases may include breaking changes.
 - ✨ Add a `licenses` keyword argument to `iqm.qdmi.offloader`'s `sample`/
   `estimate`, forwarded as `--licenses` on `srun`, so callers can request the
   Slurm license a site administrator may require via the SPANK plugin's
-  `iqm_require_license` option ([#PENDING]) ([**@marcelwa**])
+  `iqm_require_license` option ([#162]) ([**@marcelwa**])
 
 ## [1.3.0] - 2026-07-31
 
@@ -142,6 +142,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#162]: https://github.com/iqm-finland/QDMI-on-IQM/pull/162
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#140]: https://github.com/iqm-finland/QDMI-on-IQM/pull/140
 [#136]: https://github.com/iqm-finland/QDMI-on-IQM/pull/136

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -147,6 +147,21 @@ default backend configuration. When set, they are passed as `--iqm-qc-id` and
 [SPANK plugin](spank_plugin.md) resolves into the job's `IQM_QC_ID` and
 `IQM_QC_ALIAS` environment variables. Only used when `local=False`.
 
+### Requesting a Slurm License
+
+Both functions accept an optional `licenses` keyword argument, forwarded
+verbatim as a `--licenses` option on the `srun` command (Slurm's own
+`name[:count][,name[:count]...]` syntax). This is unrelated to QC selection: a
+site administrator can configure a Slurm license per QC to cap concurrent jobs
+against it -- see the SPANK plugin's
+[Limiting Concurrent Access with Slurm Licenses](spank_plugin.md#limiting-concurrent-access-with-slurm-licenses)
+docs -- and `licenses` is how a caller requests it. Only used when
+`local=False`.
+
+```python
+counts = sample(qc, shots=512, simulator=True, qc_alias="emerald:mock", licenses="iqm_qc_emerald_mock:1")
+```
+
 ### Programmatic Sampling Example
 
 ```python

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -159,7 +159,7 @@ docs -- and `licenses` is how a caller requests it. Only used when
 `local=False`.
 
 ```python
-counts = sample(qc, shots=512, simulator=True, qc_alias="emerald:mock", licenses="iqm_qc_emerald_mock:1")
+counts = sample(qc, shots=512, simulator=True, qc_alias="emerald", licenses="iqm_qc_emerald:1")
 ```
 
 ### Programmatic Sampling Example

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -169,6 +169,22 @@ def _spank_qc_selection_args(qc_id: str | None, qc_alias: str | None) -> list[st
     return args
 
 
+def _licenses_arg(licenses: str | None) -> list[str]:
+    """Build `srun` options for an optional Slurm license request.
+
+    Slurm licenses are a cluster admin's own capacity-limiting mechanism (see
+    the SPANK plugin's "Limiting Concurrent Access with Slurm Licenses" docs)
+    and are unrelated to QC selection: the caller passes whatever license
+    name(s)/count(s) their site has configured for the target QC, verbatim,
+    as Slurm's own `name[:count][,name[:count]...]` syntax.
+
+    Returns:
+        List of `srun` options requesting *licenses*, or an empty list if none
+        was given.
+    """
+    return [f"--licenses={licenses}"] if licenses else []
+
+
 def _run_srun(
     command: list[str],
     job_dir: Path,
@@ -241,6 +257,7 @@ def sample(
     timeout: float | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
+    licenses: str | None = None,
 ) -> dict[str, int]:
     """Sample from a quantum circuit.
 
@@ -265,6 +282,12 @@ def sample(
         qc_alias: If given, passed as `--iqm-qc-alias` to `srun`, which the
             QDMI-on-IQM SPANK plugin resolves into the `IQM_QC_ALIAS` job
             environment variable. Only used when `local=False`.
+        licenses: If given, passed as `--licenses` to `srun`, requesting the
+            named Slurm license(s) (Slurm's own `name[:count][,name[:count]
+            ...]` syntax) that a site administrator may have configured to
+            cap concurrent jobs against a QC -- e.g. required by the SPANK
+            plugin's `iqm_require_license` option. Only used when
+            `local=False`.
 
     Returns:
         A dictionary of measurement counts.
@@ -303,6 +326,7 @@ def sample(
         "--nodes=1",
         "--partition=quantum",
         *_spank_qc_selection_args(qc_id, qc_alias),
+        *_licenses_arg(licenses),
         "iqm-sampler",
         str(qc_path.absolute()),
         "--shots",
@@ -334,6 +358,7 @@ def estimate(
     timeout: float | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
+    licenses: str | None = None,
 ) -> VQEResult:
     """Estimate the optimal parameters for a given ansatz circuit and operator.
 
@@ -365,6 +390,12 @@ def estimate(
         qc_alias: If given, passed as `--iqm-qc-alias` to `srun`, which the
             QDMI-on-IQM SPANK plugin resolves into the `IQM_QC_ALIAS` job
             environment variable. Only used when `local=False`.
+        licenses: If given, passed as `--licenses` to `srun`, requesting the
+            named Slurm license(s) (Slurm's own `name[:count][,name[:count]
+            ...]` syntax) that a site administrator may have configured to
+            cap concurrent jobs against a QC -- e.g. required by the SPANK
+            plugin's `iqm_require_license` option. Only used when
+            `local=False`.
 
     Returns:
         The VQE result, including the optimal parameters and eigenvalue.
@@ -405,6 +436,7 @@ def estimate(
         "--nodes=1",
         "--partition=quantum",
         *_spank_qc_selection_args(qc_id, qc_alias),
+        *_licenses_arg(licenses),
         "iqm-estimator",
         str(qc_path.absolute()),
         str(operator_path.absolute()),

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -262,6 +262,109 @@ def test_estimate_slurm_uses_spank_qc_id_and_no_cli_credentials(
     assert worker_command[4] == "3"
 
 
+def test_sample_slurm_forwards_licenses(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The `licenses` kwarg is forwarded verbatim as `--licenses` on `srun`, ahead of the worker command."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    counts = offloader.sample(
+        circuit, shots=7, local=False, simulator=True, qc_alias="emerald:mock", licenses="iqm_qc_emerald_mock:1"
+    )
+
+    worker_index = captured_command.index("iqm-sampler")
+    assert counts == {"0": 1}
+    assert "--licenses=iqm_qc_emerald_mock:1" in captured_command
+    assert captured_command.index("--licenses=iqm_qc_emerald_mock:1") < worker_index
+
+
+def test_sample_slurm_omits_licenses_by_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without a `licenses` kwarg, `--licenses` is not added to the `srun` command."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    offloader.sample(circuit, shots=7, local=False, simulator=True)
+
+    assert not any(arg.startswith("--licenses") for arg in captured_command)
+
+
+def test_estimate_slurm_forwards_licenses(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mirrors `test_sample_slurm_forwards_licenses` for `estimate()`."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    result = offloader.estimate(
+        ansatz,
+        operator,
+        maxiter=3,
+        local=False,
+        simulator=True,
+        qc_alias="emerald:mock",
+        licenses="iqm_qc_emerald_mock:1",
+    )
+
+    worker_index = captured_command.index("iqm-estimator")
+    assert result.optimal_parameters == {"theta": 0.125}
+    assert "--licenses=iqm_qc_emerald_mock:1" in captured_command
+    assert captured_command.index("--licenses=iqm_qc_emerald_mock:1") < worker_index
+
+
 def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A failed Slurm job leaves its input files in place and reports where to find them."""
 


### PR DESCRIPTION
## What this does

Fixes #161.

v1.3.0's SPANK plugin ([#114]) added Slurm license-based capacity limiting: a job can request a QC's license via `srun --licenses=iqm_qc_<alias>:1` alongside `--iqm-qc-alias`, and a site admin can set `iqm_require_license=1` to enforce it — most useful for capping concurrency against single-tenant on-premise hardware.

`iqm.qdmi.offloader`'s `sample()`/`estimate()` build their `srun` command internally and had no way for a caller to add `--licenses` to it. Any downstream consumer that wanted to enable `iqm_require_license=1` while still using the offloader API had no way to satisfy the requirement — every `sample()`/`estimate()` call would fail at job-step launch.

- Adds a `licenses: str | None = None` keyword argument to both `sample()` and `estimate()`, forwarded verbatim as `--licenses=<value>` on the internal `srun` call (Slurm's own `name[:count][,name[:count]...]` syntax), mirroring how `qc_id`/`qc_alias` are already forwarded via `_spank_qc_selection_args`.
- New `_licenses_arg()` helper, same shape as the existing `_spank_qc_selection_args()`.
- Adds tests mirroring the existing SPANK-selection coverage: `licenses` forwarded ahead of the worker command for both `sample()`/`estimate()`, and omitted entirely when not given.
- Documents the new parameter in `docs/python_package.md` under a new "Requesting a Slurm License" subsection, alongside the existing QC-selection one.
- `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

- `uv run pytest test/python/test_offloader.py -q`: 12/12 pass (8 existing + 4 new).
- `uvx nox -s lint` (full `prek` hook set): passes.

[#114]: https://github.com/iqm-finland/QDMI-on-IQM/pull/114
