### PR TITLE
⚡️ Cache QDMI-on-IQM HTTP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ releases may include breaking changes.
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
 
+### Changed
+
+- ⚡️ Reuse HTTP connections within each QDMI device session to reduce TCP/TLS
+  setup during initialization and subsequent requests ([**@burgholzer**])
+
 ## [1.3.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ releases may include breaking changes.
 ### Changed
 
 - ⚡️ Reuse HTTP connections within each QDMI device session to reduce TCP/TLS
-  setup during initialization and subsequent requests ([**@burgholzer**])
+  setup during initialization and subsequent requests ([#163])
+  ([**@burgholzer**])
 
 ## [1.3.0] - 2026-07-31
 
@@ -147,6 +148,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#163]: https://github.com/iqm-finland/QDMI-on-IQM/pull/163
 [#162]: https://github.com/iqm-finland/QDMI-on-IQM/pull/162
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147
 [#140]: https://github.com/iqm-finland/QDMI-on-IQM/pull/140

--- a/include/http_client.hpp
+++ b/include/http_client.hpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/body.h>
+#include <cpr/connection_pool.h>
 #include <cpr/cprtypes.h>
 #include <cpr/response.h>
 #include <cstdint>
@@ -57,11 +58,13 @@ enum class ERROR_LOG_POLICY : uint8_t {
  *
  * @param url The target URL for the GET request.
  * @param bearer_token Bearer token used for authentication, if configured.
+ * @param connection_pool Connection pool shared by the owning device session.
  * @param timeout Overall timeout for the request and any rate-limit retries.
  * @return CPR response object.
  */
 cpr::Response Get(const cpr::Url &url,
                   const std::optional<cpr::Bearer> &bearer_token,
+                  const cpr::ConnectionPool &connection_pool,
                   std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
@@ -72,12 +75,14 @@ cpr::Response Get(const cpr::Url &url,
  *
  * @param url The target URL for the GET request.
  * @param bearer_token Bearer token used for authentication, if configured.
+ * @param connection_pool Connection pool shared by the owning device session.
  * @param timeout Overall timeout for the request and any rate-limit retries.
  * @return CPR response object.
  */
 cpr::Response
 Get_optional(const cpr::Url &url,
              const std::optional<cpr::Bearer> &bearer_token,
+             const cpr::ConnectionPool &connection_pool,
              std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
@@ -90,6 +95,7 @@ Get_optional(const cpr::Url &url,
  *
  * @param url The target URL for the POST request.
  * @param bearer_token Bearer token used for authentication, if configured.
+ * @param connection_pool Connection pool shared by the owning device session.
  * @param data The request body data.
  * @param additional_headers Additional HTTP headers to include.
  * @param timeout Overall timeout for the request and any rate-limit retries.
@@ -97,6 +103,7 @@ Get_optional(const cpr::Url &url,
  */
 cpr::Response Post(const cpr::Url &url,
                    const std::optional<cpr::Bearer> &bearer_token,
+                   const cpr::ConnectionPool &connection_pool,
                    const cpr::Body &data,
                    const cpr::Header &additional_headers = {},
                    std::chrono::milliseconds timeout = std::chrono::hours{1});
@@ -149,13 +156,14 @@ struct Hooks {
   /// Hook for GET requests.
   std::function<cpr::Response(
       const cpr::Url &url, const std::optional<cpr::Bearer> &bearer_token,
-      const cpr::Header &headers, std::chrono::milliseconds timeout)>
+      const cpr::ConnectionPool &connection_pool, const cpr::Header &headers,
+      std::chrono::milliseconds timeout)>
       get;
   /// Hook for POST requests.
-  std::function<cpr::Response(const cpr::Url &url,
-                              const std::optional<cpr::Bearer> &bearer_token,
-                              const cpr::Header &headers, const cpr::Body &body,
-                              std::chrono::milliseconds timeout)>
+  std::function<cpr::Response(
+      const cpr::Url &url, const std::optional<cpr::Bearer> &bearer_token,
+      const cpr::ConnectionPool &connection_pool, const cpr::Header &headers,
+      const cpr::Body &body, std::chrono::milliseconds timeout)>
       post;
   /// Hook for the retry backoff delay, given a delay in seconds.
   std::function<void(int)> sleep;

--- a/src/internal/http_client.cpp
+++ b/src/internal/http_client.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/body.h>
+#include <cpr/connection_pool.h>
 #include <cpr/cprtypes.h>
 #include <cpr/error.h>
 #include <cpr/redirect.h>
@@ -67,8 +68,10 @@ cpr::Header Make_json_headers(const cpr::Header &additional_headers) {
 
 void Apply_common_options(cpr::Session &session, const cpr::Url &url,
                           const std::optional<cpr::Bearer> &bearer_token,
+                          const cpr::ConnectionPool &connection_pool,
                           const cpr::Header &headers,
                           const std::chrono::milliseconds timeout) {
+  session.SetConnectionPool(connection_pool);
   session.SetUrl(url);
   session.SetHeader(headers);
   session.SetUserAgent(cpr::UserAgent{"QDMI-on-IQM"});
@@ -84,19 +87,23 @@ void Apply_common_options(cpr::Session &session, const cpr::Url &url,
 
 cpr::Response Default_get(const cpr::Url &url,
                           const std::optional<cpr::Bearer> &bearer_token,
+                          const cpr::ConnectionPool &connection_pool,
                           const cpr::Header &headers,
                           const std::chrono::milliseconds timeout) {
   cpr::Session session;
-  Apply_common_options(session, url, bearer_token, headers, timeout);
+  Apply_common_options(session, url, bearer_token, connection_pool, headers,
+                       timeout);
   return session.Get();
 }
 
 cpr::Response Default_post(const cpr::Url &url,
                            const std::optional<cpr::Bearer> &bearer_token,
+                           const cpr::ConnectionPool &connection_pool,
                            const cpr::Header &headers, const cpr::Body &body,
                            const std::chrono::milliseconds timeout) {
   cpr::Session session;
-  Apply_common_options(session, url, bearer_token, headers, timeout);
+  Apply_common_options(session, url, bearer_token, connection_pool, headers,
+                       timeout);
   session.SetBody(body);
   return session.Post();
 }
@@ -370,30 +377,35 @@ QDMI_STATUS Handle_response(const cpr::Response &response,
 
 cpr::Response Get(const cpr::Url &url,
                   const std::optional<cpr::Bearer> &bearer_token,
+                  const cpr::ConnectionPool &connection_pool,
                   const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing GET request to " + url.str());
   const auto &hooks = internal::Get_hooks();
   const auto headers = internal::Make_headers();
   return internal::Perform_with_retries(
       url, timeout, [&](const auto remaining) {
-        return hooks.get(url, bearer_token, headers, remaining);
+        return hooks.get(url, bearer_token, connection_pool, headers,
+                         remaining);
       });
 }
 
 cpr::Response Get_optional(const cpr::Url &url,
                            const std::optional<cpr::Bearer> &bearer_token,
+                           const cpr::ConnectionPool &connection_pool,
                            const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing GET request to " + url.str());
   const auto &hooks = internal::Get_hooks();
   const auto headers = internal::Make_headers();
   return internal::Perform_with_retries(
       url, timeout, [&](const auto remaining) {
-        return hooks.get(url, bearer_token, headers, remaining);
+        return hooks.get(url, bearer_token, connection_pool, headers,
+                         remaining);
       });
 }
 
 cpr::Response Post(const cpr::Url &url,
                    const std::optional<cpr::Bearer> &bearer_token,
+                   const cpr::ConnectionPool &connection_pool,
                    const cpr::Body &data, const cpr::Header &additional_headers,
                    const std::chrono::milliseconds timeout) {
   LOG_INFO("Performing POST request to " + url.str());
@@ -404,7 +416,8 @@ cpr::Response Post(const cpr::Url &url,
   const auto headers = internal::Make_json_headers(additional_headers);
   return internal::Perform_with_retries(
       url, timeout, [&](const auto remaining) {
-        return hooks.post(url, bearer_token, headers, data, remaining);
+        return hooks.post(url, bearer_token, connection_pool, headers, data,
+                          remaining);
       });
 }
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <cpr/connection_pool.h>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -82,6 +83,9 @@ struct IQM_QDMI_Device_Session_impl_d {
 
   /// Timeout applied to each HTTP request made by this session.
   std::chrono::milliseconds request_timeout_ = std::chrono::hours{1};
+
+  /// HTTP connection cache shared by requests belonging to this session.
+  cpr::ConnectionPool connection_pool_;
 
   /// Session status
   IQM_QDMI_DEVICE_SESSION_STATUS session_status_ =
@@ -327,7 +331,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
       session->api_config_->url(iqm::API_ENDPOINT::GET_QUANTUM_COMPUTERS);
   const auto bearer_token = session->token_manager_->get_bearer_token();
   const auto qc_list_response =
-      iqm::http::Get(qc_list_url, bearer_token, session->request_timeout_);
+      iqm::http::Get(qc_list_url, bearer_token, session->connection_pool_,
+                     session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(qc_list_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -392,7 +397,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
       iqm::API_ENDPOINT::GET_STATIC_QUANTUM_ARCHITECTURE,
       *session->quantum_computer_alias_);
   const auto arch_response =
-      iqm::http::Get(arch_url, bearer_token, session->request_timeout_);
+      iqm::http::Get(arch_url, bearer_token, session->connection_pool_,
+                     session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(arch_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -476,7 +482,8 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
       iqm::API_ENDPOINT::GET_DYNAMIC_QUANTUM_ARCHITECTURE,
       *session->quantum_computer_alias_, session->calibration_set_id_);
   const auto dyn_arch_response =
-      iqm::http::Get(dyn_arch_url, bearer_token, session->request_timeout_);
+      iqm::http::Get(dyn_arch_url, bearer_token, session->connection_pool_,
+                     session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(dyn_arch_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -544,7 +551,8 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
       *session->quantum_computer_alias_, session->calibration_set_id_);
   const auto bearer_token = session->token_manager_->get_bearer_token();
   const auto calibration_response =
-      iqm::http::Get(calibration_url, bearer_token, session->request_timeout_);
+      iqm::http::Get(calibration_url, bearer_token, session->connection_pool_,
+                     session->request_timeout_);
   if (const auto status = iqm::http::Handle_response(calibration_response);
       status != QDMI_SUCCESS) {
     return status;
@@ -709,7 +717,7 @@ int IQM_QDMI_device_session_init(IQM_QDMI_Device_Session session) {
       session->api_config_->url(iqm::API_ENDPOINT::COCOS_HEALTH);
   const auto cocos_health_response = iqm::http::Get_optional(
       cocos_health_url, session->token_manager_->get_bearer_token(),
-      session->request_timeout_);
+      session->connection_pool_, session->request_timeout_);
   const auto status = iqm::http::Handle_response(
       cocos_health_response, iqm::http::ERROR_LOG_POLICY::LOG_AS_DEBUG);
   session->supports_calibration_jobs_ = (status == QDMI_SUCCESS);
@@ -1030,8 +1038,8 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
                                       *job->session_->quantum_computer_alias_);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      json_program.dump(), {{"Expect", "100-continue"}},
-      job->session_->request_timeout_);
+      job->session_->connection_pool_, json_program.dump(),
+      {{"Expect", "100-continue"}}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1070,8 +1078,8 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
       iqm::API_ENDPOINT::SUBMIT_CALIBRATION_JOB);
   const auto job_submission_response = iqm::http::Post(
       job_submission_url, job->session_->token_manager_->get_bearer_token(),
-      static_cast<const char *>(job->program_), {{"Expect", "100-continue"}},
-      job->session_->request_timeout_);
+      job->session_->connection_pool_, static_cast<const char *>(job->program_),
+      {{"Expect", "100-continue"}}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_submission_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1140,8 +1148,8 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
           : job->session_->api_config_->url(iqm::API_ENDPOINT::CANCEL_JOB,
                                             job->job_id_);
   const auto job_abortion_response = iqm::http::Post(
-      job_abortion_url, job->session_->token_manager_->get_bearer_token(), "",
-      {}, job->session_->request_timeout_);
+      job_abortion_url, job->session_->token_manager_->get_bearer_token(),
+      job->session_->connection_pool_, "", {}, job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_abortion_response);
   if (status != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1172,7 +1180,7 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
                                             job->job_id_);
   const auto job_status_response = iqm::http::Get(
       job_status_url, job->session_->token_manager_->get_bearer_token(),
-      job->session_->request_timeout_);
+      job->session_->connection_pool_, job->session_->request_timeout_);
   const auto status_code = iqm::http::Handle_response(job_status_response);
   if (status_code != QDMI_SUCCESS) {
     job->status_ = QDMI_JOB_STATUS_FAILED;
@@ -1300,7 +1308,7 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
           iqm::API_ENDPOINT::GET_JOB_ARTIFACT_MEASUREMENT_COUNTS, job->job_id_);
       const auto job_results_response = iqm::http::Get(
           job_results_url, job->session_->token_manager_->get_bearer_token(),
-          job->session_->request_timeout_);
+          job->session_->connection_pool_, job->session_->request_timeout_);
       const auto status = iqm::http::Handle_response(job_results_response);
       if (status != QDMI_SUCCESS) {
         // Only mark the job as failed for truly fatal errors, but always
@@ -1383,7 +1391,7 @@ int IQM_QDMI_device_job_get_results_calibration_id(IQM_QDMI_Device_Job job,
         iqm::API_ENDPOINT::GET_CALIBRATION_JOB_STATUS, job->job_id_);
     const auto job_calibration_response = iqm::http::Get(
         job_calibration_url, job->session_->token_manager_->get_bearer_token(),
-        job->session_->request_timeout_);
+        job->session_->connection_pool_, job->session_->request_timeout_);
     const auto status = iqm::http::Handle_response(job_calibration_response);
     if (status != QDMI_SUCCESS) {
       // Only mark the job as failed for truly fatal errors, but always
@@ -1448,7 +1456,7 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
         iqm::API_ENDPOINT::GET_JOB_ARTIFACT_MEASUREMENTS, job->job_id_);
     const auto job_measurements_response = iqm::http::Get(
         job_measurements_url, job->session_->token_manager_->get_bearer_token(),
-        job->session_->request_timeout_);
+        job->session_->connection_pool_, job->session_->request_timeout_);
     const auto status = iqm::http::Handle_response(job_measurements_response);
     if (status != QDMI_SUCCESS) {
       // Only mark the job as failed for truly fatal errors, but always

--- a/test/unit/http_stub.cpp
+++ b/test/unit/http_stub.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cpr/bearer.h>
 #include <cpr/body.h>
+#include <cpr/connection_pool.h>
 #include <cpr/cprtypes.h>
 #include <cpr/error.h>
 #include <cpr/response.h>
@@ -61,11 +62,13 @@ HttpStub::HttpStub() {
 
   hooks.get = [this](const cpr::Url &url,
                      const std::optional<cpr::Bearer> &bearer_token,
+                     const cpr::ConnectionPool &connection_pool,
                      const cpr::Header & /*headers*/,
                      const std::chrono::milliseconds timeout) {
     get_urls_.push_back(url.str());
     get_bearer_tokens_.push_back(bearer_token);
     get_timeouts_.push_back(timeout);
+    get_connection_pools_.push_back(&connection_pool);
     if (get_responses_.empty()) {
       ADD_FAILURE() << "Unexpected GET request to '" << url
                     << "': no scripted response was queued";
@@ -83,12 +86,14 @@ HttpStub::HttpStub() {
 
   hooks.post = [this](const cpr::Url &url,
                       const std::optional<cpr::Bearer> &bearer_token,
+                      const cpr::ConnectionPool &connection_pool,
                       const cpr::Header & /*headers*/,
                       const cpr::Body & /*body*/,
                       const std::chrono::milliseconds timeout) {
     post_urls_.push_back(url.str());
     post_bearer_tokens_.push_back(bearer_token);
     post_timeouts_.push_back(timeout);
+    post_connection_pools_.push_back(&connection_pool);
     if (post_responses_.empty()) {
       ADD_FAILURE() << "Unexpected POST request to '" << url
                     << "': no scripted response was queued";
@@ -152,6 +157,11 @@ const std::vector<std::chrono::milliseconds> &HttpStub::get_timeouts() const {
   return get_timeouts_;
 }
 
+const std::vector<const cpr::ConnectionPool *> &
+HttpStub::get_connection_pools() const {
+  return get_connection_pools_;
+}
+
 const std::vector<std::string> &HttpStub::post_urls() const {
   return post_urls_;
 }
@@ -163,6 +173,11 @@ HttpStub::post_bearer_tokens() const {
 
 const std::vector<std::chrono::milliseconds> &HttpStub::post_timeouts() const {
   return post_timeouts_;
+}
+
+const std::vector<const cpr::ConnectionPool *> &
+HttpStub::post_connection_pools() const {
+  return post_connection_pools_;
 }
 
 size_t HttpStub::sleep_call_count() const { return sleep_durations_.size(); }

--- a/test/unit/http_stub.hpp
+++ b/test/unit/http_stub.hpp
@@ -26,6 +26,7 @@
 
 #include <chrono>
 #include <cpr/bearer.h>
+#include <cpr/connection_pool.h>
 #include <cpr/cprtypes.h>
 #include <cstddef>
 #include <cstdint>
@@ -100,6 +101,9 @@ public:
   /// Timeouts passed to GET requests, in call order.
   [[nodiscard]] const std::vector<std::chrono::milliseconds> &
   get_timeouts() const;
+  /// Connection pools passed to GET requests, in call order.
+  [[nodiscard]] const std::vector<const cpr::ConnectionPool *> &
+  get_connection_pools() const;
   /// URLs requested via POST, in call order.
   [[nodiscard]] const std::vector<std::string> &post_urls() const;
   /// Bearer tokens passed to POST requests, in call order.
@@ -108,6 +112,9 @@ public:
   /// Timeouts passed to POST requests, in call order.
   [[nodiscard]] const std::vector<std::chrono::milliseconds> &
   post_timeouts() const;
+  /// Connection pools passed to POST requests, in call order.
+  [[nodiscard]] const std::vector<const cpr::ConnectionPool *> &
+  post_connection_pools() const;
   /// Number of retry-delay ("sleep") calls triggered by HTTP 429 retries.
   [[nodiscard]] size_t sleep_call_count() const;
   /// Retry-delay durations requested by HTTP 429 handling, in call order.
@@ -119,9 +126,11 @@ private:
   std::vector<std::string> get_urls_;
   std::vector<std::optional<cpr::Bearer>> get_bearer_tokens_;
   std::vector<std::chrono::milliseconds> get_timeouts_;
+  std::vector<const cpr::ConnectionPool *> get_connection_pools_;
   std::vector<std::string> post_urls_;
   std::vector<std::optional<cpr::Bearer>> post_bearer_tokens_;
   std::vector<std::chrono::milliseconds> post_timeouts_;
+  std::vector<const cpr::ConnectionPool *> post_connection_pools_;
   std::vector<int> sleep_durations_;
 };
 

--- a/test/unit/test_http_client.cpp
+++ b/test/unit/test_http_client.cpp
@@ -23,6 +23,7 @@
 #include "logging.hpp"
 
 #include <chrono>
+#include <cpr/connection_pool.h>
 #include <cpr/cprtypes.h>
 #include <cpr/response.h>
 #include <cstdint>
@@ -166,9 +167,10 @@ TEST(HttpClientTest, StructuredErrorsSuppressRawFallback) {
 TEST(HttpClientTest, GetReturnsFatalWhenRequestFails) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get_connection_error();
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
 
   EXPECT_EQ(iqm::http::Handle_response(response), QDMI_ERROR_FATAL);
   EXPECT_NE(
@@ -179,9 +181,10 @@ TEST(HttpClientTest, GetReturnsFatalWhenRequestFails) {
 TEST(HttpClientTest, PostReturnsFatalWhenRequestFails) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_post_connection_error();
-  const auto response =
-      iqm::http::Post("https://example.test/jobs", std::nullopt, "{}");
+  const auto response = iqm::http::Post("https://example.test/jobs",
+                                        std::nullopt, connection_pool, "{}");
 
   EXPECT_EQ(iqm::http::Handle_response(response), QDMI_ERROR_FATAL);
   EXPECT_NE(
@@ -191,18 +194,22 @@ TEST(HttpClientTest, PostReturnsFatalWhenRequestFails) {
 
 TEST(HttpClientTest, BearerTokenIsPassedToHooks) {
   iqm::test_support::HttpStub http_stub;
-  http_stub.queue_get(200).queue_post(200);
+  const cpr::ConnectionPool connection_pool;
+  http_stub.queue_get(200).queue_get(200).queue_post(200);
   const auto bearer_token = cpr::Bearer{"test-token"};
 
-  const auto get_response =
-      iqm::http::Get("https://example.test/jobs", bearer_token);
-  const auto post_response =
-      iqm::http::Post("https://example.test/jobs", bearer_token, "{}");
+  const auto get_response = iqm::http::Get("https://example.test/jobs",
+                                           bearer_token, connection_pool);
+  const auto optional_get_response = iqm::http::Get_optional(
+      "https://example.test/capability", bearer_token, connection_pool);
+  const auto post_response = iqm::http::Post(
+      "https://example.test/jobs", bearer_token, connection_pool, "{}");
 
   EXPECT_EQ(iqm::http::Handle_response(get_response), QDMI_SUCCESS);
+  EXPECT_EQ(iqm::http::Handle_response(optional_get_response), QDMI_SUCCESS);
   EXPECT_EQ(iqm::http::Handle_response(post_response), QDMI_SUCCESS);
 
-  ASSERT_EQ(http_stub.get_bearer_tokens().size(), 1U);
+  ASSERT_EQ(http_stub.get_bearer_tokens().size(), 2U);
   ASSERT_TRUE(http_stub.get_bearer_tokens()[0].has_value());
   EXPECT_EQ(std::string{http_stub.get_bearer_tokens()[0]->GetToken()},
             "test-token");
@@ -210,17 +217,24 @@ TEST(HttpClientTest, BearerTokenIsPassedToHooks) {
   ASSERT_TRUE(http_stub.post_bearer_tokens()[0].has_value());
   EXPECT_EQ(std::string{http_stub.post_bearer_tokens()[0]->GetToken()},
             "test-token");
+  EXPECT_EQ(http_stub.get_connection_pools(),
+            (std::vector<const cpr::ConnectionPool *>{&connection_pool,
+                                                      &connection_pool}));
+  EXPECT_EQ(http_stub.post_connection_pools(),
+            (std::vector<const cpr::ConnectionPool *>{&connection_pool}));
 }
 
 TEST(HttpClientTest, ExplicitTimeoutIsPassedToHooks) {
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(200).queue_post(200);
   constexpr auto timeout = std::chrono::milliseconds{1'234};
 
-  const auto get_response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt, timeout);
-  const auto post_response = iqm::http::Post("https://example.test/jobs",
-                                             std::nullopt, "{}", {}, timeout);
+  const auto get_response = iqm::http::Get(
+      "https://example.test/jobs", std::nullopt, connection_pool, timeout);
+  const auto post_response =
+      iqm::http::Post("https://example.test/jobs", std::nullopt,
+                      connection_pool, "{}", {}, timeout);
 
   EXPECT_EQ(iqm::http::Handle_response(get_response), QDMI_SUCCESS);
   EXPECT_EQ(iqm::http::Handle_response(post_response), QDMI_SUCCESS);
@@ -243,16 +257,20 @@ TEST(HttpClientTest, TimeoutIsClampedToTransportRepresentation) {
 TEST(HttpClientTest, RetriesHttp429UsingRetryAfterUntilSuccess) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429, "", {{"Retry-After", "30"}}).queue_get(200);
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_SUCCESS);
   EXPECT_EQ(response.status_code, 200);
   EXPECT_EQ(http_stub.sleep_call_count(), 1U);
   EXPECT_EQ(http_stub.sleep_durations(), std::vector<int>{30});
+  EXPECT_EQ(http_stub.get_connection_pools(),
+            (std::vector<const cpr::ConnectionPool *>{&connection_pool,
+                                                      &connection_pool}));
 
   const auto logs = logger_capture.str();
   EXPECT_NE(logs.find("hit HTTP 429 rate limiting; retrying after 30 second(s) "
@@ -263,10 +281,11 @@ TEST(HttpClientTest, RetriesHttp429UsingRetryAfterUntilSuccess) {
 
 TEST(HttpClientTest, RetriesHttp429UsingCaseInsensitiveRetryAfterHeader) {
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429, "", {{"retry-after", "7"}}).queue_get(200);
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_SUCCESS);
@@ -276,10 +295,11 @@ TEST(HttpClientTest, RetriesHttp429UsingCaseInsensitiveRetryAfterHeader) {
 TEST(HttpClientTest, RateLimitRetryDoesNotOutliveRequestTimeout) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429, "", {{"Retry-After", "30"}}).queue_get(200);
 
   const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt,
+      iqm::http::Get("https://example.test/jobs", std::nullopt, connection_pool,
                      std::chrono::milliseconds{1'000});
   const auto status = iqm::http::Handle_response(response);
 
@@ -295,11 +315,12 @@ TEST(HttpClientTest, RateLimitRetryDoesNotOutliveRequestTimeout) {
 
 TEST(HttpClientTest, MaximumRequestTimeoutDoesNotOverflowRetryBudget) {
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429, "", {{"Retry-After", "30"}}).queue_get(200);
   constexpr auto timeout = std::chrono::milliseconds::max();
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt, timeout);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool, timeout);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_SUCCESS);
@@ -313,10 +334,11 @@ TEST(HttpClientTest, MaximumRequestTimeoutDoesNotOverflowRetryBudget) {
 TEST(HttpClientTest,
      RetriesHttp429WithConservativeFallbackForMissingRetryAfter) {
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429).queue_get(200);
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_SUCCESS);
@@ -326,10 +348,11 @@ TEST(HttpClientTest,
 TEST(HttpClientTest,
      RetriesHttp429WithConservativeFallbackForMalformedRetryAfter) {
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   http_stub.queue_get(429, "", {{"Retry-After", "soon"}}).queue_get(200);
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_SUCCESS);
@@ -339,12 +362,13 @@ TEST(HttpClientTest,
 TEST(HttpClientTest, RetriesExhaustedForHttp429ReturnsInvalidArgument) {
   const LoggerCapture logger_capture;
   iqm::test_support::HttpStub http_stub;
+  const cpr::ConnectionPool connection_pool;
   for (int i = 0; i < 11; ++i) {
     http_stub.queue_get(429, "", {{"Retry-After", "1"}});
   }
 
-  const auto response =
-      iqm::http::Get("https://example.test/jobs", std::nullopt);
+  const auto response = iqm::http::Get("https://example.test/jobs",
+                                       std::nullopt, connection_pool);
   const auto status = iqm::http::Handle_response(response);
 
   EXPECT_EQ(status, QDMI_ERROR_INVALIDARGUMENT);

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -583,6 +583,35 @@ TEST_F(DeviceIntegrationMockTest,
             "https://localhost/api/v1/quantum-computers");
 }
 
+TEST_F(DeviceIntegrationMockTest,
+       DeviceSessionsReuseDistinctConnectionPoolsDuringInitialization) {
+  IQM_QDMI_Device_Session second_session = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_alloc(&second_session), QDMI_SUCCESS);
+  const std::string base_url = "https://localhost";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                second_session, QDMI_DEVICE_SESSION_PARAMETER_BASEURL,
+                base_url.size() + 1, base_url.c_str()),
+            QDMI_SUCCESS);
+
+  queue_successful_initialization();
+  queue_successful_initialization();
+
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_session_init(second_session), QDMI_SUCCESS);
+
+  const auto &connection_pools = http_stub.get_connection_pools();
+  ASSERT_EQ(connection_pools.size(), 10U);
+  EXPECT_TRUE(std::ranges::all_of(
+      connection_pools.begin(), connection_pools.begin() + 5,
+      [&](const auto *pool) { return pool == connection_pools.front(); }));
+  EXPECT_TRUE(std::ranges::all_of(
+      connection_pools.begin() + 5, connection_pools.end(),
+      [&](const auto *pool) { return pool == connection_pools.back(); }));
+  EXPECT_NE(connection_pools.front(), connection_pools.back());
+
+  IQM_QDMI_device_session_free(second_session);
+}
+
 TEST_F(DeviceTest, SessionAllocation) {
   // Session should be allocated in SetUp
   EXPECT_NE(session, nullptr);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- add one CPR connection pool to each opaque QDMI device session
- keep request-local `cpr::Session` objects while sharing the owning device session's connection cache
- reuse the same pool across initialization, architecture refreshes, job submission and polling, result retrieval, cancellation, calibration requests, and rate-limit retries
- preserve existing authentication, headers, bodies, timeout budgets, retry behavior, logging, and response mapping
- cover pool propagation, retry reuse, five-request initialization reuse, and isolation between separately allocated device sessions

## Motivation

QDMI device initialization performs five sequential HTTP requests. Creating and destroying an independent CPR session for every request also discarded libcurl's connection cache, so those requests could each establish a separate TCP/TLS connection. A per-device `cpr::ConnectionPool` allows opportunistic keep-alive reuse without making CPR sessions persistent or introducing cross-device global state.

This follows the connection behavior measured in [openQSE/QFw#34](https://github.com/openQSE/QFw/pull/34).

## Validation

- focused pool and HTTP tests: 17 passed
- `ctest -C Release --test-dir build/test/unit --output-on-failure` (68 passed)
- `uvx nox -s lint`
- `git diff --check`
- fresh independent read-only verification

No live IQM hardware or credential-dependent integration tests were run.
