### PR TITLE
🐛 Serialize canonical IQM run-request fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ releases may include breaking changes.
   Slurm license a site administrator may require via the SPANK plugin's
   `iqm_require_license` option ([#162]) ([**@marcelwa**])
 
+### Fixed
+
+- 🐛 Serialize move-gate and active-reset options using the canonical IQM
+  RunRequest field names ([#169]) ([**@burgholzer**])
+
 ### Changed
 
 - ⚡️ Reuse HTTP connections within each QDMI device session to reduce TCP/TLS
@@ -148,6 +153,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#169]: https://github.com/iqm-finland/QDMI-on-IQM/pull/169
 [#163]: https://github.com/iqm-finland/QDMI-on-IQM/pull/163
 [#162]: https://github.com/iqm-finland/QDMI-on-IQM/pull/162
 [#147]: https://github.com/iqm-finland/QDMI-on-IQM/pull/147

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -160,15 +160,15 @@ struct IQM_QDMI_Device_Job_impl_d {
   /// @details Valid values include "none" and "zeros".
   ///          Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM1 parameter.
   std::string heralding_mode_ = "none";
-  /// @brief Move validation mode for the job.
+  /// @brief Move gate validation mode for the job.
   /// @details Valid values include "strict", "allow_prx", and "none"
   ///          Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM2 parameter.
-  std::string move_validation_mode_ = "strict";
+  std::string move_gate_validation_ = "strict";
   /// @brief Move gate frame tracking mode for the job.
   /// @details Valid values include "full", "no_detuning_correction", and
   ///          "none".
   ///          Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM3 parameter.
-  std::string move_gate_frame_tracking_mode_ = "full";
+  std::string move_gate_frame_tracking_ = "full";
   /// @brief Dynamical decoupling mode for the job.
   /// @details Valid values include "disabled" and "enabled".
   ///          Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM4 parameter.
@@ -186,7 +186,7 @@ struct IQM_QDMI_Device_Job_impl_d {
   std::optional<double> max_circuit_duration_over_t2_ = std::nullopt;
   /// @brief The number of active reset cycles.
   /// @details Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM5+2 parameter.
-  std::optional<size_t> num_active_reset_cycles_ = std::nullopt;
+  std::optional<size_t> active_reset_cycles_ = std::nullopt;
   /// @brief The dynamical decoupling strategy to use for the job.
   /// @details Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM5+3 parameter.
   ///          This is transferred as a JSON string according to the data model
@@ -894,7 +894,7 @@ int IQM_QDMI_device_job_set_parameter(IQM_QDMI_Device_Job job,
           move_validation_mode != "none") {
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      job->move_validation_mode_ = move_validation_mode;
+      job->move_gate_validation_ = move_validation_mode;
     }
     return QDMI_SUCCESS;
   case QDMI_DEVICE_JOB_PARAMETER_CUSTOM3:
@@ -906,7 +906,7 @@ int IQM_QDMI_device_job_set_parameter(IQM_QDMI_Device_Job job,
           move_gate_frame_tracking_mode != "none") {
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      job->move_gate_frame_tracking_mode_ = move_gate_frame_tracking_mode;
+      job->move_gate_frame_tracking_ = move_gate_frame_tracking_mode;
     }
     return QDMI_SUCCESS;
   case QDMI_DEVICE_JOB_PARAMETER_CUSTOM4:
@@ -956,7 +956,7 @@ int IQM_QDMI_device_job_set_parameter(IQM_QDMI_Device_Job job,
     }
     if (static_cast<int>(param) == QDMI_DEVICE_JOB_PARAMETER_CUSTOM5 + 2) {
       if (value != nullptr) {
-        job->num_active_reset_cycles_ = *static_cast<const size_t *>(value);
+        job->active_reset_cycles_ = *static_cast<const size_t *>(value);
       }
       return QDMI_SUCCESS;
     }
@@ -1010,9 +1010,8 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
   json_program["calibration_set_id"] = job->session_->calibration_set_id_;
   json_program["shots"] = job->num_shots_;
   json_program["heralding_mode"] = job->heralding_mode_;
-  json_program["move_gate_validation"] = job->move_validation_mode_;
-  json_program["move_gate_frame_tracking"] =
-      job->move_gate_frame_tracking_mode_;
+  json_program["move_gate_validation"] = job->move_gate_validation_;
+  json_program["move_gate_frame_tracking"] = job->move_gate_frame_tracking_;
   json_program["dd_mode"] = job->dd_mode_;
   if (job->qubit_mapping_) {
     nlohmann::json qubit_mapping_json = nlohmann::json::array();
@@ -1026,8 +1025,8 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
     json_program["max_circuit_duration_over_t2"] =
         *job->max_circuit_duration_over_t2_;
   }
-  if (job->num_active_reset_cycles_) {
-    json_program["active_reset_cycles"] = *job->num_active_reset_cycles_;
+  if (job->active_reset_cycles_) {
+    json_program["active_reset_cycles"] = *job->active_reset_cycles_;
   }
   if (job->dd_strategy_) {
     json_program["dd_strategy"] = nlohmann::json::parse(*job->dd_strategy_);

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1010,8 +1010,8 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
   json_program["calibration_set_id"] = job->session_->calibration_set_id_;
   json_program["shots"] = job->num_shots_;
   json_program["heralding_mode"] = job->heralding_mode_;
-  json_program["move_validation_mode"] = job->move_validation_mode_;
-  json_program["move_gate_frame_tracking_mode"] =
+  json_program["move_gate_validation"] = job->move_validation_mode_;
+  json_program["move_gate_frame_tracking"] =
       job->move_gate_frame_tracking_mode_;
   json_program["dd_mode"] = job->dd_mode_;
   if (job->qubit_mapping_) {
@@ -1027,7 +1027,7 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
         *job->max_circuit_duration_over_t2_;
   }
   if (job->num_active_reset_cycles_) {
-    json_program["num_active_reset_cycles"] = *job->num_active_reset_cycles_;
+    json_program["active_reset_cycles"] = *job->num_active_reset_cycles_;
   }
   if (job->dd_strategy_) {
     json_program["dd_strategy"] = nlohmann::json::parse(*job->dd_strategy_);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,6 @@ add_executable(
 target_compile_features(unit_tests PRIVATE cxx_std_20)
 target_link_libraries(
   unit_tests PRIVATE GTest::gtest_main GTest::gtest qdmi::qdmi_project_warnings
-                     iqm::qdmi_device_internals)
+                     iqm::qdmi_device_internals nlohmann_json::nlohmann_json)
 
 gtest_discover_tests(unit_tests DISCOVERY_TIMEOUT 60)

--- a/test/unit/http_stub.cpp
+++ b/test/unit/http_stub.cpp
@@ -87,10 +87,10 @@ HttpStub::HttpStub() {
   hooks.post = [this](const cpr::Url &url,
                       const std::optional<cpr::Bearer> &bearer_token,
                       const cpr::ConnectionPool &connection_pool,
-                      const cpr::Header & /*headers*/,
-                      const cpr::Body & /*body*/,
+                      const cpr::Header & /*headers*/, const cpr::Body &body,
                       const std::chrono::milliseconds timeout) {
     post_urls_.push_back(url.str());
+    post_bodies_.push_back(body.str());
     post_bearer_tokens_.push_back(bearer_token);
     post_timeouts_.push_back(timeout);
     post_connection_pools_.push_back(&connection_pool);
@@ -164,6 +164,10 @@ HttpStub::get_connection_pools() const {
 
 const std::vector<std::string> &HttpStub::post_urls() const {
   return post_urls_;
+}
+
+const std::vector<std::string> &HttpStub::post_bodies() const {
+  return post_bodies_;
 }
 
 const std::vector<std::optional<cpr::Bearer>> &

--- a/test/unit/http_stub.hpp
+++ b/test/unit/http_stub.hpp
@@ -106,6 +106,8 @@ public:
   get_connection_pools() const;
   /// URLs requested via POST, in call order.
   [[nodiscard]] const std::vector<std::string> &post_urls() const;
+  /// Request bodies passed to POST requests, in call order.
+  [[nodiscard]] const std::vector<std::string> &post_bodies() const;
   /// Bearer tokens passed to POST requests, in call order.
   [[nodiscard]] const std::vector<std::optional<cpr::Bearer>> &
   post_bearer_tokens() const;
@@ -128,6 +130,7 @@ private:
   std::vector<std::chrono::milliseconds> get_timeouts_;
   std::vector<const cpr::ConnectionPool *> get_connection_pools_;
   std::vector<std::string> post_urls_;
+  std::vector<std::string> post_bodies_;
   std::vector<std::optional<cpr::Bearer>> post_bearer_tokens_;
   std::vector<std::chrono::milliseconds> post_timeouts_;
   std::vector<const cpr::ConnectionPool *> post_connection_pools_;

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -31,6 +31,7 @@
 #include <exception>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -779,6 +780,42 @@ TEST_F(DeviceJobMockTest, FullLifecycle) {
                                             hist_values_size,
                                             hist_values.data(), nullptr),
             QDMI_SUCCESS);
+}
+
+TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
+  http_stub.queue_post(200, R"({"id": "job-canonical-fields"})");
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr auto move_validation = "allow_prx";
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_CUSTOM2,
+                strlen(move_validation) + 1, move_validation),
+            QDMI_SUCCESS);
+  constexpr auto frame_tracking = "no_detuning_correction";
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_CUSTOM3,
+                strlen(frame_tracking) + 1, frame_tracking),
+            QDMI_SUCCESS);
+  constexpr size_t active_reset_cycles = 3;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job,
+                static_cast<QDMI_Device_Job_Parameter>(
+                    QDMI_DEVICE_JOB_PARAMETER_CUSTOM5 + 2),
+                sizeof(active_reset_cycles), &active_reset_cycles),
+            QDMI_SUCCESS);
+
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(http_stub.post_bodies().size(), 1U);
+  const auto request = nlohmann::json::parse(http_stub.post_bodies().front());
+  EXPECT_EQ(request.at("move_gate_validation"), move_validation);
+  EXPECT_EQ(request.at("move_gate_frame_tracking"), frame_tracking);
+  EXPECT_EQ(request.at("active_reset_cycles"), active_reset_cycles);
+  EXPECT_FALSE(request.contains("move_validation_mode"));
+  EXPECT_FALSE(request.contains("move_gate_frame_tracking_mode"));
+  EXPECT_FALSE(request.contains("num_active_reset_cycles"));
 }
 
 TEST_F(DeviceJobMockTest, RetrieveShotMeasurements) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -800,6 +800,8 @@ TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
                 strlen(frame_tracking) + 1, frame_tracking),
             QDMI_SUCCESS);
   constexpr size_t active_reset_cycles = 3;
+  // The IQM extension parameters continue past QDMI's last named custom value.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job,
                 static_cast<QDMI_Device_Job_Parameter>(
@@ -809,6 +811,7 @@ TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
 
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
   ASSERT_EQ(http_stub.post_bodies().size(), 1U);
+  // NOLINTNEXTLINE(misc-include-cleaner)
   const auto request = nlohmann::json::parse(http_stub.post_bodies().front());
   EXPECT_EQ(request.at("move_gate_validation"), move_validation);
   EXPECT_EQ(request.at("move_gate_frame_tracking"), frame_tracking);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- serialize move-gate validation as `move_gate_validation`
- serialize move-gate frame tracking as `move_gate_frame_tracking`
- serialize active-reset cycles as `active_reset_cycles`
- name the corresponding internal job members consistently with the canonical IQM fields
- verify the exact submitted JSON and guard against the three obsolete field names

The QDMI parameter surface remains unchanged. This fixes only the IQM RunRequest wire representation expected by current IQM client and Resonance APIs.

## Validation

- `cmake --build build --parallel 8`
- `./build/test/unit/unit_tests` (69/69 passed)
- `uvx nox --non-interactive -s lint`
- `git diff --check`
