### PR TITLE
🚧 Temporarily disable failing Resonance QIR integration test

### DIFF
--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -941,7 +941,10 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
   ASSERT_LE(sum, shots_num);
 }
 
-TEST_F(QDMIIntegrationTest, JobCycleQIR) {
+// Resonance currently rejects valid QIR programs with an internal server error.
+// Track re-enabling this test in
+// https://github.com/iqm-finland/QDMI-on-IQM/issues/170.
+TEST_F(QDMIIntegrationTest, DISABLED_JobCycleQIR) {
   constexpr size_t shots_num = 64;
   const auto qir_program = build_qir_test_circuit();
   auto *job = fomac.submit_job(qir_program, QDMI_PROGRAM_FORMAT_QIRBASESTRING,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Temporarily disable the QIR integration test because Resonance currently accepts the valid QIR input but fails during Station Control compilation with a generic internal server error. The source comment links the tracking issue so re-enabling the test is not lost.

## Validation

- `cmake --build build --target integration_tests --parallel 8`
- `ctest --test-dir build/test/integration -N -R JobCycleQIR` reports `QDMIIntegrationTest.JobCycleQIR (Disabled)`
- `uvx nox --non-interactive -s lint`
- `git diff --check`