### PR TITLE
👷 Run the C++ test suite under AddressSanitizer and UndefinedBehaviorSanitizer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,6 +115,14 @@ jobs:
     secrets:
       IQM_TOKEN: ${{ secrets.RESONANCE_API_KEY }}
 
+  cpp-sanitizers:
+    name: 🇨 Sanitizers
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
+    uses: ./.github/workflows/cpp-sanitizers.yml
+    secrets:
+      IQM_TOKEN: ${{ secrets.RESONANCE_API_KEY }}
+
   cpp-coverage:
     name: 🇨 Coverage
     needs: change-detection
@@ -201,6 +209,7 @@ jobs:
       - cpp-tests-macos
       - cpp-tests-windows
       - cpp-install-tests
+      - cpp-sanitizers
       - cpp-coverage
       - cpp-linter
       - python-linter
@@ -216,7 +225,7 @@ jobs:
           allowed-skips: >-
             ${{
               !fromJSON(needs.change-detection.outputs.run-cpp-tests)
-              && 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,cpp-install-tests,cpp-coverage,' || ''
+              && 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,cpp-install-tests,cpp-sanitizers,cpp-coverage,' || ''
             }}
             ${{
               !fromJSON(needs.change-detection.outputs.run-cpp-linter)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
         .github/workflows/cpp-coverage.yml
         .github/workflows/cpp-linter.yml
         .github/workflows/cpp-install-tests.yml
+        .github/workflows/cpp-sanitizers.yml
       additional-cd-files: |
         spank/**
         .github/workflows/spank-tests.yml

--- a/.github/workflows/cpp-sanitizers.yml
+++ b/.github/workflows/cpp-sanitizers.yml
@@ -17,18 +17,12 @@ permissions:
 
 jobs:
   cpp-sanitizers:
-    name: 🧪 AddressSanitizer + UndefinedBehaviorSanitizer
+    name: 🧪 ASan + UBSan
     runs-on: ubuntu-24.04
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
-      # -fno-sanitize-recover promotes UndefinedBehaviorSanitizer diagnostics
-      # from a printed warning to a non-zero exit. Without it a UBSan finding
-      # leaves the test green and goes unnoticed.
-      SANITIZER_FLAGS: >-
-        -fsanitize=address,undefined -fno-sanitize-recover=all
-        -fno-omit-frame-pointer -g -O1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Dependencies
@@ -48,10 +42,7 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_FLAGS="$SANITIZER_FLAGS" \
-            -DCMAKE_CXX_FLAGS="$SANITIZER_FLAGS" \
-            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
+            -DIQM_QDMI_SANITIZERS="address;undefined"
       - name: Build
         run: cmake --build build
       # No --repeat here, unlike the regular test workflows: a sanitizer

--- a/.github/workflows/cpp-sanitizers.yml
+++ b/.github/workflows/cpp-sanitizers.yml
@@ -1,0 +1,67 @@
+name: 🇨 • Sanitizers
+on:
+  workflow_call:
+    inputs:
+      iqm-qc-alias:
+        description: >
+          The alias of the IQM quantum computer to use for testing. Defaults to 'emerald:mock'.
+          This can be any valid IQM quantum computer alias.
+        default: "emerald:mock"
+        type: string
+    secrets:
+      IQM_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  cpp-sanitizers:
+    name: 🧪 AddressSanitizer + UndefinedBehaviorSanitizer
+    runs-on: ubuntu-24.04
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
+      CTEST_PARALLEL_LEVEL: 4
+      FORCE_COLOR: 3
+      # -fno-sanitize-recover promotes UndefinedBehaviorSanitizer diagnostics
+      # from a printed warning to a non-zero exit. Without it a UBSan finding
+      # leaves the test green and goes unnoticed.
+      SANITIZER_FLAGS: >-
+        -fsanitize=address,undefined -fno-sanitize-recover=all
+        -fno-omit-frame-pointer -g -O1
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+      # Set up ccache for faster C++ builds
+      - name: Setup ccache
+        uses: Chocobo1/setup-ccache-action@802ec72ba1d54bbf75c52f45367253d6abec30f5 # v1.5.8
+        with:
+          prepend_symlinks_to_path: false
+          override_cache_key: c++-sanitizers
+      # Set up mold for faster C++ builds
+      - name: Setup mold
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="$SANITIZER_FLAGS" \
+            -DCMAKE_CXX_FLAGS="$SANITIZER_FLAGS" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
+      - name: Build
+        run: cmake --build build
+      # No --repeat here, unlike the regular test workflows: a sanitizer
+      # diagnostic is deterministic, and retrying until pass would hide it.
+      - name: Test
+        env:
+          IQM_BASE_URL: "https://resonance.iqm.tech"
+          IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
+          IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
+          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          ASAN_OPTIONS: "detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1"
+          UBSAN_OPTIONS: "print_stacktrace=1"
+        run: ctest --output-on-failure --test-dir build --timeout 900

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- 👷 Add an `IQM_QDMI_SANITIZERS` CMake option for building with
+  AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer, or
+  MemorySanitizer, and run the C++ test suite under ASan and UBSan in CI
+  ([#173]) ([**@marcelwa**])
 - 🐍 Start building CPython 3.15 wheels ([#177]) ([**@denialhaag**])
 - ✨ Expose current device queue length and queued job position through QDMI,
   refreshing IQM job status for every position query ([#172])
@@ -171,6 +175,7 @@ Compatible with QDMI `v1.3.0`.
 [#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175
+[#173]: https://github.com/iqm-finland/QDMI-on-IQM/pull/173
 [#172]: https://github.com/iqm-finland/QDMI-on-IQM/pull/172
 [#169]: https://github.com/iqm-finland/QDMI-on-IQM/pull/169
 [#163]: https://github.com/iqm-finland/QDMI-on-IQM/pull/163

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,11 @@ option(BUILD_IQM_SPANK "Build the IQM SPANK plugin" OFF)
 option(BUILD_IQM_QDMI_DOCS "Build documentation for the IQM QDMI device" OFF)
 option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
 
+# Configure runtime sanitizers. This has to happen before the external
+# dependencies are declared so that they are instrumented as well.
+include(cmake/Sanitizers.cmake)
+iqm_qdmi_apply_sanitizers()
+
 # Manage external dependencies
 include(cmake/ExternalDependencies.cmake)
 

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,0 +1,111 @@
+# Copyright (c) 2025 - 2026 IQM Finland Oy
+# All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Runtime sanitizer support. Enable with, for example,
+# -DIQM_QDMI_SANITIZERS="address;undefined" on a Debug build.
+#
+# The flags are applied globally, before the external dependencies are declared,
+# so that the dependencies are instrumented too. That matters for
+# AddressSanitizer: an allocation made in uninstrumented code and freed in
+# instrumented code (or the reverse) is a common source of false reports.
+
+set(IQM_QDMI_SANITIZERS
+    ""
+    CACHE STRING
+          "Semicolon-separated runtime sanitizers to build with. Supported \
+values are 'address', 'undefined', 'thread', and 'memory'. Empty disables \
+sanitizers.")
+
+option(
+  IQM_QDMI_SANITIZER_HALT_ON_ERROR
+  "Make sanitizer diagnostics abort the process instead of only printing. \
+Without this, an UndefinedBehaviorSanitizer finding leaves the test suite green."
+  ON)
+
+# Apply the requested sanitizers to every target defined from here on.
+function(iqm_qdmi_apply_sanitizers)
+  if(NOT IQM_QDMI_SANITIZERS)
+    return()
+  endif()
+
+  set(supported_sanitizers address undefined thread memory)
+  foreach(sanitizer IN LISTS IQM_QDMI_SANITIZERS)
+    if(NOT sanitizer IN_LIST supported_sanitizers)
+      message(
+        FATAL_ERROR
+          "Unknown sanitizer '${sanitizer}'. Supported values are: ${supported_sanitizers}"
+      )
+    endif()
+  endforeach()
+
+  # ThreadSanitizer and MemorySanitizer both shadow the whole address space and
+  # cannot coexist with AddressSanitizer in one binary.
+  if("thread" IN_LIST IQM_QDMI_SANITIZERS AND "address" IN_LIST
+                                              IQM_QDMI_SANITIZERS)
+    message(FATAL_ERROR "ThreadSanitizer cannot be combined with "
+                        "AddressSanitizer; configure them in separate builds")
+  endif()
+  if("memory" IN_LIST IQM_QDMI_SANITIZERS AND "address" IN_LIST
+                                              IQM_QDMI_SANITIZERS)
+    message(FATAL_ERROR "MemorySanitizer cannot be combined with "
+                        "AddressSanitizer; configure them in separate builds")
+  endif()
+
+  if(MSVC)
+    # MSVC only ships AddressSanitizer, spelled with its own flag, and it is
+    # incompatible with the runtime checks that the Debug configuration enables
+    # by default.
+    foreach(sanitizer IN LISTS IQM_QDMI_SANITIZERS)
+      if(NOT sanitizer STREQUAL "address")
+        message(
+          FATAL_ERROR
+            "MSVC supports only the 'address' sanitizer, but '${sanitizer}' was requested"
+        )
+      endif()
+    endforeach()
+    add_compile_options(/fsanitize=address)
+    # /RTC1 is injected by CMake's default Debug flags and rejected by ASan.
+    string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    set(CMAKE_C_FLAGS_DEBUG
+        "${CMAKE_C_FLAGS_DEBUG}"
+        PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS_DEBUG
+        "${CMAKE_CXX_FLAGS_DEBUG}"
+        PARENT_SCOPE)
+    message(STATUS "Sanitizers enabled: address (MSVC)")
+    return()
+  endif()
+
+  if(APPLE AND "memory" IN_LIST IQM_QDMI_SANITIZERS)
+    message(FATAL_ERROR "MemorySanitizer is not available on macOS")
+  endif()
+
+  list(JOIN IQM_QDMI_SANITIZERS "," sanitizer_list)
+  set(sanitizer_flags -fsanitize=${sanitizer_list} -fno-omit-frame-pointer)
+
+  if(IQM_QDMI_SANITIZER_HALT_ON_ERROR)
+    list(APPEND sanitizer_flags -fno-sanitize-recover=all)
+  endif()
+
+  add_compile_options(${sanitizer_flags})
+  # The runtime has to be on the link line as well, or the instrumented objects
+  # fail to resolve their interceptors.
+  add_link_options(-fsanitize=${sanitizer_list})
+
+  message(STATUS "Sanitizers enabled: ${sanitizer_list}")
+endfunction()

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -284,6 +284,38 @@ lcov --remove coverage.info '/usr/*' '*/test/*' '*/build/_deps/*' --output-file 
 lcov --list coverage.info
 ```
 
+**Running the tests under sanitizers:**
+
+The device does a fair amount of manual memory work — raw allocations for the
+job program and caller-supplied output buffers sized by hand — so it is worth
+running the suite under
+[AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) and
+[UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
+when touching those paths. Pass the sanitizers you want as a semicolon-separated
+list:
+
+```console
+cmake -S . -B build-sanitizers -DCMAKE_BUILD_TYPE=Debug -DIQM_QDMI_SANITIZERS="address;undefined"
+cmake --build build-sanitizers
+ctest --test-dir build-sanitizers --output-on-failure
+```
+
+Use a build directory separate from your regular one: the flags apply to the
+external dependencies as well, so switching sanitizers on and off rebuilds
+everything.
+
+Supported values are `address`, `undefined`, `thread`, and `memory`. `thread`
+and `memory` each need their own build, as neither can be combined with
+`address`. On Windows only `address` is available, since MSVC ships no other
+sanitizer.
+
+Sanitizer findings abort the process by default, which is what makes them fail
+the test suite — an UndefinedBehaviorSanitizer diagnostic otherwise only prints
+and leaves the run green. Set `-DIQM_QDMI_SANITIZER_HALT_ON_ERROR=OFF` to
+collect every diagnostic in one run instead of stopping at the first.
+
+The same configuration runs in CI for every pull request that touches C++ code.
+
 ### C++ Code Formatting and Linting
 
 This project mostly follows the

--- a/test/fomac/fomac.cpp
+++ b/test/fomac/fomac.cpp
@@ -425,20 +425,20 @@ namespace {
  *          throw_if_error(), so without this the job allocated up front is
  *          leaked whenever any of those checks throws.
  */
-class Job_guard final {
+class JobGuard final {
 public:
-  explicit Job_guard(const IQM_QDMI_Device_Job job) : job_(job) {}
+  explicit JobGuard(IQM_QDMI_Device_Job job) : job_(job) {}
 
-  ~Job_guard() {
+  ~JobGuard() {
     if (job_ != nullptr) {
       IQM_QDMI_device_job_free(job_);
     }
   }
 
-  Job_guard(const Job_guard &) = delete;
-  Job_guard &operator=(const Job_guard &) = delete;
-  Job_guard(Job_guard &&) = delete;
-  Job_guard &operator=(Job_guard &&) = delete;
+  JobGuard(const JobGuard &) = delete;
+  JobGuard &operator=(const JobGuard &) = delete;
+  JobGuard(JobGuard &&) = delete;
+  JobGuard &operator=(JobGuard &&) = delete;
 
   /// Hand ownership to the caller.
   [[nodiscard]] auto release() -> IQM_QDMI_Device_Job {
@@ -464,7 +464,7 @@ auto FoMaC::submit_job(
   IQM_QDMI_Device_Job job = nullptr;
   int ret = IQM_QDMI_device_session_create_device_job(session_, &job);
   throw_if_error(ret, "Failed to create a job");
-  Job_guard guard{job};
+  JobGuard guard{job};
   ret = IQM_QDMI_device_job_set_parameter(
       job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(QDMI_Program_Format),
       &format);

--- a/test/fomac/fomac.cpp
+++ b/test/fomac/fomac.cpp
@@ -418,6 +418,38 @@ auto FoMaC::get_supported_program_formats() const
   return formats;
 }
 
+namespace {
+/**
+ * @brief Owns a device job until it is handed to the caller.
+ * @details Every parameter that submit_job() sets is followed by a
+ *          throw_if_error(), so without this the job allocated up front is
+ *          leaked whenever any of those checks throws.
+ */
+class Job_guard final {
+public:
+  explicit Job_guard(const IQM_QDMI_Device_Job job) : job_(job) {}
+
+  ~Job_guard() {
+    if (job_ != nullptr) {
+      IQM_QDMI_device_job_free(job_);
+    }
+  }
+
+  Job_guard(const Job_guard &) = delete;
+  Job_guard &operator=(const Job_guard &) = delete;
+  Job_guard(Job_guard &&) = delete;
+  Job_guard &operator=(Job_guard &&) = delete;
+
+  /// Hand ownership to the caller.
+  [[nodiscard]] auto release() -> IQM_QDMI_Device_Job {
+    return std::exchange(job_, nullptr);
+  }
+
+private:
+  IQM_QDMI_Device_Job job_;
+};
+} // namespace
+
 auto FoMaC::submit_job(
     const std::string &program, const QDMI_Program_Format format,
     const size_t num_shots, const std::string &heralding_mode,
@@ -432,6 +464,7 @@ auto FoMaC::submit_job(
   IQM_QDMI_Device_Job job = nullptr;
   int ret = IQM_QDMI_device_session_create_device_job(session_, &job);
   throw_if_error(ret, "Failed to create a job");
+  Job_guard guard{job};
   ret = IQM_QDMI_device_job_set_parameter(
       job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(QDMI_Program_Format),
       &format);
@@ -502,7 +535,7 @@ auto FoMaC::submit_job(
   }
   ret = IQM_QDMI_device_job_submit(job);
   throw_if_error(ret, "Failed to submit the job");
-  return job;
+  return guard.release();
 }
 
 auto FoMaC::get_status(IQM_QDMI_Device_Job job) -> QDMI_Job_Status {

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -886,6 +886,7 @@ TEST_F(QDMIIntegrationTest, JobCancellation) {
   QDMI_Job_Status status{};
   EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
   EXPECT_EQ(status, QDMI_JOB_STATUS_CANCELED);
+  IQM_QDMI_device_job_free(job);
 }
 
 TEST_F(QDMIIntegrationTest, JobCycleCornerCases) {
@@ -1022,6 +1023,7 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
   ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
 
   const auto counts = FoMaC::get_histogram(job);
+  IQM_QDMI_device_job_free(job);
   size_t sum = 0;
   std::cout << "Counts: {\n";
   for (const auto &[key, count] : counts) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

The C++ device does a fair amount of manual memory work — `memcpy`/`strncpy` inside the property macros, and buffer sizes computed by hand in the result getters — but nothing in CI exercises any of it under a sanitizer. Today a memory error on one of those paths first shows up as a crash inside a consumer, a long way from where it was introduced.

This adds an `IQM_QDMI_SANITIZERS` CMake option and a `cpp-sanitizers` job that uses it, wired into `CI.yml` next to the other C++ jobs and included in `required-checks-pass`. A local run is:

```console
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DIQM_QDMI_SANITIZERS="address;undefined"
cmake --build build
ctest --test-dir build --output-on-failure
```

Expressing this in CMake rather than as raw flags in the workflow keeps the toolchain differences in one place: MSVC ships only AddressSanitizer, spells it `/fsanitize=address`, and needs `/RTC1` stripped from its Debug flags; MemorySanitizer does not exist on macOS; ThreadSanitizer and MemorySanitizer each need their own build, since neither can share a binary with AddressSanitizer. Unsupported combinations fail at configure time with an explanation instead of at compile or link time. The flags are applied before the external dependencies are declared so those are instrumented too, which avoids the false reports that come from an allocation crossing between instrumented and uninstrumented code.

Two deliberate departures from the regular test workflows:

- `-fno-sanitize-recover=all` (via `IQM_QDMI_SANITIZER_HALT_ON_ERROR`, on by default), so an UndefinedBehaviorSanitizer finding exits non-zero rather than printing a warning into an otherwise green log.
- No `--repeat until-pass:3`. A sanitizer diagnostic is deterministic, so retrying until pass would only hide it.

## What it found

The job failed on its first run, which was the point of opening it. Three tests, all genuine, all in this repository's own code — no third-party noise, so no suppressions file is needed.

| Test | Leaked | Cause |
| :--- | :----- | :---- |
| `DeviceJobMockTest.MalformedCircuitHandling` | 18 B | setting the job program twice overwrote `program_` without freeing the first buffer |
| `QDMIIntegrationTest.JobCancellation` | 890 B in 3 allocations | job never freed |
| `QDMIIntegrationTest.OptionalJobParameters` | 1333 B in 8 allocations | job never freed |

## Rebased onto `main` (2026-08-10)

This branch was conflicting after #159, #160, #172, and #174 landed. It has been rebased onto `3573bca`, and **two commits were dropped** rather than replayed:

- `13f8f66` (release the previous program buffer) — superseded. #159 replaced the raw `void *program_` with a `std::string`, which fixes that leak structurally, so this branch no longer needs its one-line `delete[]`. This is the outcome the original note here predicted: whichever landed second should take #159's version, and #159 landed first.
- `3977a78` (changelog entry for that leak fix) — dropped with it, since #159 carries its own entry.

The other two leak fixes are still needed and still on the branch. `OptionalJobParameters` gained a free on its `GTEST_SKIP` path on `main` in the meantime; the free this branch adds is on the happy path, after the last use of the job, so the two do not collide.

Verified after the rebase: a fresh `Debug` build with `-DIQM_QDMI_SANITIZERS="address;undefined"` on clang 22 runs the hermetic unit suite **89/89 green**, `MalformedCircuitHandling` included — which is the direct confirmation that dropping `13f8f66` was safe.

## Notes for review

- **`21b13f3` goes slightly beyond what CI reported.** `FoMaC::submit_job` calls `throw_if_error` after every parameter it sets, so an early failure leaked the job regardless of what the caller did. CI never hit it because the happy path was taken, but fixing only the two call sites would have left that path leaking.
- **One hazard left deliberately unfixed.** In `OptionalJobParameters`, `ASSERT_EQ(status, QDMI_JOB_STATUS_DONE)` sits between submission and the release, so a failing run reports a leak on top of the assertion failure. The same shape exists in the tests that already freed their jobs. The release is placed directly after the last use of the job so the trailing assertion cannot skip it, but fixing the class properly means a guard in the tests too — happy to do that separately.
- **Adding the job to `required-checks-pass`** means a future leak blocks merges. That is intentional, but it is a one-line change to drop it from the required list if you would rather it start out advisory.
- **The job runs the full `ctest` suite**, including the live-backend integration tests, matching what the other C++ workflows do.
- **Plain `address,undefined` is deliberate.** A local experiment adding `integer`, `implicit-conversion`, `local-bounds`, and `nullability` produced only libstdc++-internal reports (`basic_string.h` size arithmetic, `ext/atomicity.h` refcount decrements) attributed to project call sites through inlining — no project defects, and it additionally needs `-Wno-pass-failed` to get a cpr translation unit to compile.
- **The change-detection gap noted in the first comment is still open** and still not addressed here.
