### PR TITLE
🐛 Report the device as idle again once its jobs finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Report the device as idle again once its jobs reach a terminal state,
+  instead of leaving it busy for the rest of the session after the first
+  submission ([#180]) ([**@marcelwa**])
 - 🐛 Serialize move-gate and active-reset options using the canonical IQM
   RunRequest field names ([#169]) ([**@burgholzer**])
 - 🩹 Preserve exact program bytes across QDMI job parameter updates and property
@@ -163,6 +166,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#180]: https://github.com/iqm-finland/QDMI-on-IQM/pull/180
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#172]: https://github.com/iqm-finland/QDMI-on-IQM/pull/172
 [#169]: https://github.com/iqm-finland/QDMI-on-IQM/pull/169

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -98,6 +98,12 @@ struct IQM_QDMI_Device_Session_impl_d {
   /// Device status
   QDMI_Device_Status device_status_ = QDMI_DEVICE_STATUS_OFFLINE;
 
+  /// @brief Number of jobs of this session that have not reached a terminal
+  ///        state yet.
+  /// @details The device is reported as busy while this is non-zero and idle
+  ///          once it drops back to zero.
+  size_t outstanding_jobs_ = 0;
+
   /// Quantum computer ID
   std::optional<std::string> quantum_computer_id_ = std::nullopt;
 
@@ -214,6 +220,12 @@ struct IQM_QDMI_Device_Job_impl_d {
   QDMI_Job_Status status_ = QDMI_JOB_STATUS_CREATED;
   /// The number of jobs ahead while this job is queued.
   std::optional<size_t> queue_position_ = std::nullopt;
+  /// @brief Whether this job is currently counted in its session's
+  ///        @c outstanding_jobs_.
+  /// @details Set once the job occupies the device and cleared once it reaches
+  ///          a terminal state or is freed, so that neither transition is
+  ///          counted twice.
+  bool occupies_device_ = false;
 };
 
 /**
@@ -870,6 +882,62 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
   }
   return QDMI_SUCCESS;
 }
+
+/**
+ * @brief Whether a job status means the job will not change state again.
+ * @param status The job status to classify.
+ * @return True if the job has finished, been canceled, or failed.
+ */
+constexpr bool Is_terminal_job_status(const QDMI_Job_Status status) {
+  return status == QDMI_JOB_STATUS_DONE || status == QDMI_JOB_STATUS_CANCELED ||
+         status == QDMI_JOB_STATUS_FAILED;
+}
+
+/**
+ * @brief Count @p job against its session and mark the device busy.
+ * @details Idempotent: a job that already occupies the device is not counted a
+ *          second time.
+ * @param job The job that started occupying the device.
+ */
+void Acquire_device(IQM_QDMI_Device_Job job) {
+  if (job->session_ == nullptr || job->occupies_device_) {
+    return;
+  }
+  job->occupies_device_ = true;
+  ++job->session_->outstanding_jobs_;
+  job->session_->device_status_ = QDMI_DEVICE_STATUS_BUSY;
+}
+
+/**
+ * @brief Stop counting @p job against its session.
+ * @details Returns the device to idle once the last outstanding job of the
+ *          session is released. Idempotent, so repeated terminal-state
+ *          transitions of the same job are harmless.
+ * @param job The job that stopped occupying the device.
+ */
+void Release_device(IQM_QDMI_Device_Job job) {
+  if (job->session_ == nullptr || !job->occupies_device_) {
+    return;
+  }
+  job->occupies_device_ = false;
+  --job->session_->outstanding_jobs_;
+  if (job->session_->outstanding_jobs_ == 0 &&
+      job->session_->device_status_ == QDMI_DEVICE_STATUS_BUSY) {
+    job->session_->device_status_ = QDMI_DEVICE_STATUS_IDLE;
+  }
+}
+
+/**
+ * @brief Synchronize the session's device status with the state of @p job.
+ * @param job The job whose status was just updated.
+ */
+void Track_job_status(IQM_QDMI_Device_Job job) {
+  if (Is_terminal_job_status(job->status_)) {
+    Release_device(job);
+  } else {
+    Acquire_device(job);
+  }
+}
 } // namespace
 
 int IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -911,6 +979,9 @@ int IQM_QDMI_device_session_retrieve_device_job_by_id(
         status != QDMI_SUCCESS) {
       return status;
     }
+    // A reopened job that is still queued or running occupies the device just
+    // as a locally submitted one does.
+    Track_job_status(retrieved_job.get());
     LOG_INFO("Retrieved device job with ID: " + std::string{job_id});
     *job = retrieved_job.release();
     return QDMI_SUCCESS;
@@ -927,6 +998,11 @@ int IQM_QDMI_device_session_retrieve_device_job_by_id(
 
 void IQM_QDMI_device_job_free(IQM_QDMI_Device_Job job) {
   LOG_INFO("Freeing device job");
+  if (job != nullptr) {
+    // A job handle that is dropped while still running can no longer be
+    // observed, so it must not keep the device busy forever.
+    Release_device(job);
+  }
   delete job;
 }
 
@@ -1259,16 +1335,22 @@ int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
   if (!job->program_set_) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
-  job->session_->device_status_ = QDMI_DEVICE_STATUS_BUSY;
-
-  if (job->program_format_ == QDMI_PROGRAM_FORMAT_IQMJSON ||
-      job->program_format_ == QDMI_PROGRAM_FORMAT_QIRBASESTRING) {
-    return IQM_QDMI_device_job_submit_circuit(job);
+  const auto submission_status = [job]() -> int {
+    if (job->program_format_ == QDMI_PROGRAM_FORMAT_IQMJSON ||
+        job->program_format_ == QDMI_PROGRAM_FORMAT_QIRBASESTRING) {
+      return IQM_QDMI_device_job_submit_circuit(job);
+    }
+    if (job->program_format_ == QDMI_PROGRAM_FORMAT_CALIBRATION) {
+      return IQM_QDMI_device_job_submit_calibration(job);
+    }
+    return QDMI_ERROR_INVALIDARGUMENT; // Unreachable; just a safety check
+  }();
+  // Only a job that actually reached the backend occupies the device. A
+  // submission that failed leaves the device as idle as it was before.
+  if (submission_status == QDMI_SUCCESS) {
+    Acquire_device(job);
   }
-  if (job->program_format_ == QDMI_PROGRAM_FORMAT_CALIBRATION) {
-    return IQM_QDMI_device_job_submit_calibration(job);
-  }
-  return QDMI_ERROR_INVALIDARGUMENT; // Unreachable; just a safety check
+  return submission_status;
 }
 
 int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
@@ -1294,9 +1376,11 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
       return status;
     }
     job->status_ = QDMI_JOB_STATUS_FAILED;
+    Release_device(job);
     return QDMI_ERROR_FATAL;
   }
   job->status_ = QDMI_JOB_STATUS_CANCELED;
+  Release_device(job);
   LOG_DEBUG("Job cancellation response:\n" + job_abortion_response.text);
   LOG_INFO("Job with ID: " + job->job_id_ + " canceled");
   return QDMI_SUCCESS;
@@ -1329,6 +1413,7 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
       return status_code;
     }
     job->status_ = QDMI_JOB_STATUS_FAILED;
+    Release_device(job);
     return QDMI_ERROR_FATAL;
   }
   const auto job_status_json_response =
@@ -1340,6 +1425,7 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
       update_status != QDMI_SUCCESS) {
     return update_status;
   }
+  Track_job_status(job);
   job->queue_position_ = std::nullopt;
   if (job->status_ == QDMI_JOB_STATUS_QUEUED) {
     if (const auto position = job_status_json_response.find("queue_position");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -531,6 +531,30 @@ class DeviceJobMockTest : public DeviceIntegrationMockTest {
 protected:
   IQM_QDMI_Device_Job job = nullptr;
 
+  /// @brief Set the program and shot count a job needs before it can be
+  ///        submitted.
+  void prepare_iqm_json_job(IQM_QDMI_Device_Job target) {
+    ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                  target, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                  strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+              QDMI_SUCCESS);
+    constexpr size_t shots = 100;
+    ASSERT_EQ(
+        IQM_QDMI_device_job_set_parameter(
+            target, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+        QDMI_SUCCESS);
+  }
+
+  /// @brief Read the device status the session currently reports.
+  QDMI_Device_Status device_status() {
+    QDMI_Device_Status status{};
+    EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                  session, QDMI_DEVICE_PROPERTY_STATUS, sizeof(status), &status,
+                  nullptr),
+              QDMI_SUCCESS);
+    return status;
+  }
+
   void SetUp() override {
     DeviceIntegrationMockTest::SetUp();
 
@@ -1094,6 +1118,89 @@ TEST_F(DeviceJobMockTest, FullLifecycle) {
                                             hist_values_size,
                                             hist_values.data(), nullptr),
             QDMI_SUCCESS);
+}
+
+TEST_F(DeviceJobMockTest, DeviceReturnsToIdleWhenJobFinishes) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
+
+  prepare_iqm_json_job(job);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_BUSY);
+
+  QDMI_Job_Status job_status{};
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &job_status), QDMI_SUCCESS);
+  ASSERT_EQ(job_status, QDMI_JOB_STATUS_DONE);
+
+  // Before the fix the device stayed busy for the rest of the session's life.
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
+}
+
+TEST_F(DeviceJobMockTest, DeviceStaysBusyUntilTheLastJobFinishes) {
+  IQM_QDMI_Device_Job second_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_create_device_job(session, &second_job),
+            QDMI_SUCCESS);
+
+  http_stub.queue_post(200, R"({"id": "job-1"})");
+  http_stub.queue_post(200, R"({"id": "job-2"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+
+  prepare_iqm_json_job(job);
+  prepare_iqm_json_job(second_job);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(second_job), QDMI_SUCCESS);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_BUSY);
+
+  QDMI_Job_Status job_status{};
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &job_status), QDMI_SUCCESS);
+  ASSERT_EQ(job_status, QDMI_JOB_STATUS_DONE);
+  // One of two jobs finishing must not make the device look idle.
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_BUSY);
+
+  ASSERT_EQ(IQM_QDMI_device_job_check(second_job, &job_status), QDMI_SUCCESS);
+  ASSERT_EQ(job_status, QDMI_JOB_STATUS_DONE);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
+
+  IQM_QDMI_device_job_free(second_job);
+}
+
+TEST_F(DeviceJobMockTest, FailedSubmissionLeavesTheDeviceIdle) {
+  http_stub.queue_post(500);
+
+  prepare_iqm_json_job(job);
+  EXPECT_NE(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  // A job that never reached the backend does not occupy the device.
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
+}
+
+TEST_F(DeviceJobMockTest, FreeingAnUnfinishedJobReleasesTheDevice) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+
+  prepare_iqm_json_job(job);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_BUSY);
+
+  // Dropping the handle makes the job unobservable, so it must not pin the
+  // device to busy forever.
+  IQM_QDMI_device_job_free(job);
+  job = nullptr;
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
+}
+
+TEST_F(DeviceJobMockTest, CanceledJobReleasesTheDevice) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_post(200, "");
+
+  prepare_iqm_json_job(job);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_BUSY);
+
+  ASSERT_EQ(IQM_QDMI_device_job_cancel(job), QDMI_SUCCESS);
+  EXPECT_EQ(device_status(), QDMI_DEVICE_STATUS_IDLE);
 }
 
 TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -533,7 +533,7 @@ protected:
 
   /// @brief Set the program and shot count a job needs before it can be
   ///        submitted.
-  void prepare_iqm_json_job(IQM_QDMI_Device_Job target) {
+  static void prepare_iqm_json_job(IQM_QDMI_Device_Job target) {
     ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                   target, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                   strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),


### PR DESCRIPTION
🤖 *AI text below* 🤖

`IQM_QDMI_device_job_submit` sets the session's device status to `QDMI_DEVICE_STATUS_BUSY`, and nothing ever sets it back. After the first submission a session reports `BUSY` through `QDMI_DEVICE_PROPERTY_STATUS` for the rest of its life, no matter what happens to the job. A consumer that waits for `IDLE` before submitting hangs.

This is currently masked downstream rather than absent: the SPANK plugin gates task launch on the device being either `IDLE` or `BUSY`, so it never notices. Anything stricter does.

## What changed

Rather than writing the status directly at submission time, the session now counts the jobs that have not reached a terminal state. A job starts occupying the device when its submission succeeds and stops when it finishes, is canceled, fails, or is freed. The device reports `IDLE` again once that count drops back to zero.

Counting is what makes the concurrent case right. Resetting to `IDLE` on the first job that reaches a terminal state — the other obvious fix — would report an idle device while a second job is still running.

Two behavior changes fall out of this that are worth calling out explicitly, because both are visible to callers:

- A submission that fails no longer marks the device busy. Previously `BUSY` was written before the request was made, so a rejected submission left the device permanently busy without a job to blame.
- Freeing a job handle that has not finished releases the device. Such a job can no longer be observed through the API, so leaving it counted would pin the session to `BUSY` with no way back. The job itself keeps running on the backend; it is the local status that is being corrected.

A job reopened through `IQM_QDMI_device_session_retrieve_device_job_by_id` is counted too when it comes back queued or running, which keeps a retrieved job consistent with a locally submitted one.

## Testing

Five unit tests over the transitions, all against the hermetic HTTP stub: a single job returning the device to idle, two concurrent jobs keeping it busy until the second finishes, a failed submission leaving it idle, a freed in-flight job releasing it, and a cancellation releasing it. All five fail against the previous behavior — I checked by reverting the source change and rerunning them.

The full unit suite is green (94/94), including a `Debug` build under `-fsanitize=address,undefined -fno-sanitize-recover=all`.

Found while reviewing the device for #173; unrelated to that PR and independent of it.
