### PR TITLE
🐛 Fix a potential histogram buffer size mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,7 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🐛 Size the histogram key buffer from all measurement bitstrings instead of
-  the first one, which overran the caller's buffer when the keys differed in
-  width ([#181]) ([**@marcelwa**])
+- 🐛 Fix a potential histogram buffer size mismatch ([#181]) ([**@marcelwa**])
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Size the histogram key buffer from all measurement bitstrings instead of
+  the first one, which overran the caller's buffer when the keys differed in
+  width ([#181]) ([**@marcelwa**])
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
@@ -169,6 +172,7 @@ Compatible with QDMI `v1.3.0`.
 <!-- PR links -->
 
 [#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
+[#181]: https://github.com/iqm-finland/QDMI-on-IQM/pull/181
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175
 [#172]: https://github.com/iqm-finland/QDMI-on-IQM/pull/172

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1502,7 +1502,7 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
       }
     } else {
       // The keys are not guaranteed to share a length, so the buffer has to be
-      // measured from all of them. One extra byte per key covers its 
+      // measured from all of them. One extra byte per key covers its
       // separator, the last of which becomes the null terminator.
       const size_t req_size = std::transform_reduce(
           job->counts_.begin(), job->counts_.end(), job->counts_.size(),

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1502,10 +1502,8 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
       }
     } else {
       // The keys are not guaranteed to share a length, so the buffer has to be
-      // measured from all of them rather than extrapolated from the first. One
-      // extra byte per key covers its separator, the last of which becomes the
-      // null terminator. For keys of equal length this is the same size the
-      // previous computation produced.
+      // measured from all of them. One extra byte per key covers its 
+      // separator, the last of which becomes the null terminator.
       const size_t req_size = std::transform_reduce(
           job->counts_.begin(), job->counts_.end(), job->counts_.size(),
           std::plus{},

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -46,6 +46,7 @@
 #include <new>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
+#include <numeric>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -1500,8 +1501,15 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
         *data_ptr = '\0';
       }
     } else {
-      const size_t bitstring_size = job->counts_.begin()->first.length();
-      const size_t req_size = job->counts_.size() * (bitstring_size + 1);
+      // The keys are not guaranteed to share a length, so the buffer has to be
+      // measured from all of them rather than extrapolated from the first. One
+      // extra byte per key covers its separator, the last of which becomes the
+      // null terminator. For keys of equal length this is the same size the
+      // previous computation produced.
+      const size_t req_size = std::transform_reduce(
+          job->counts_.begin(), job->counts_.end(), job->counts_.size(),
+          std::plus{},
+          [](const auto &entry) -> size_t { return entry.first.length(); });
       if (size_ret != nullptr) {
         *size_ret = req_size;
       }

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1178,8 +1178,7 @@ TEST_F(DeviceJobMockTest, HistogramKeysOfDifferingLength) {
   // "00" + ',' + "111" + '\0'
   EXPECT_EQ(hist_keys_size, 7U);
 
-  // Allocate exactly what the API asked for. Before the fix this reported 6 and
-  // the write below overran the buffer by one byte.
+  // Allocate exactly what the API asked for.
   std::vector<char> hist_keys(hist_keys_size);
   ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS,
                                             hist_keys_size, hist_keys.data(),

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1152,6 +1152,75 @@ TEST_F(DeviceJobMockTest, FullLifecycle) {
             QDMI_SUCCESS);
 }
 
+TEST_F(DeviceJobMockTest, HistogramKeysOfDifferingLength) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  // The keys are stored in a std::map, which orders the shorter one first, so
+  // sizing the buffer from the first key under-counts what the writes need.
+  http_stub.queue_get(
+      200, R"([{"measurement_keys": ["m"], "counts": {"00": 5, "111": 3}}])");
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 8;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  size_t hist_keys_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                            nullptr, &hist_keys_size),
+            QDMI_SUCCESS);
+  // "00" + ',' + "111" + '\0'
+  EXPECT_EQ(hist_keys_size, 7U);
+
+  // Allocate exactly what the API asked for. Before the fix this reported 6 and
+  // the write below overran the buffer by one byte.
+  std::vector<char> hist_keys(hist_keys_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS,
+                                            hist_keys_size, hist_keys.data(),
+                                            nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(hist_keys.data(), "00,111");
+}
+
+TEST_F(DeviceJobMockTest, HistogramKeysOfEqualLengthAreUnaffected) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  http_stub.queue_get(
+      200,
+      R"([{"measurement_keys": ["m"], "counts": {"00": 5, "01": 2, "11": 1}}])");
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 8;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  size_t hist_keys_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                            nullptr, &hist_keys_size),
+            QDMI_SUCCESS);
+  // Unchanged from the previous computation for uniform keys: 3 * (2 + 1).
+  EXPECT_EQ(hist_keys_size, 9U);
+
+  std::vector<char> hist_keys(hist_keys_size);
+  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS,
+                                            hist_keys_size, hist_keys.data(),
+                                            nullptr),
+            QDMI_SUCCESS);
+  EXPECT_STREQ(hist_keys.data(), "00,01,11");
+}
+
 TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
   http_stub.queue_post(200, R"({"id": "job-canonical-fields"})");
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1188,39 +1188,6 @@ TEST_F(DeviceJobMockTest, HistogramKeysOfDifferingLength) {
   EXPECT_STREQ(hist_keys.data(), "00,111");
 }
 
-TEST_F(DeviceJobMockTest, HistogramKeysOfEqualLengthAreUnaffected) {
-  http_stub.queue_post(200, R"({"id": "job-123"})");
-  http_stub.queue_get(200, R"({"status": "ready"})");
-  http_stub.queue_get(
-      200,
-      R"([{"measurement_keys": ["m"], "counts": {"00": 5, "01": 2, "11": 1}}])");
-
-  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
-                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
-                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
-            QDMI_SUCCESS);
-  constexpr size_t shots = 8;
-  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
-                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
-            QDMI_SUCCESS);
-  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
-  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
-
-  size_t hist_keys_size = 0;
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
-                                            nullptr, &hist_keys_size),
-            QDMI_SUCCESS);
-  // Unchanged from the previous computation for uniform keys: 3 * (2 + 1).
-  EXPECT_EQ(hist_keys_size, 9U);
-
-  std::vector<char> hist_keys(hist_keys_size);
-  ASSERT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS,
-                                            hist_keys_size, hist_keys.data(),
-                                            nullptr),
-            QDMI_SUCCESS);
-  EXPECT_STREQ(hist_keys.data(), "00,01,11");
-}
-
 TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
   http_stub.queue_post(200, R"({"id": "job-canonical-fields"})");
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

`IQM_QDMI_device_job_get_results_hist` sizes the `QDMI_JOB_RESULT_HIST_KEYS` buffer as the length of the *first* key times the number of keys, and then writes each key at its own actual length. The two only agree when every key has the same width.

The counts are held in a `std::map`, so when widths do differ the shortest key sorts first and the reported size under-counts. A caller that does exactly the right thing — query `size_ret`, allocate that many bytes, call again — gets its buffer overrun by the library.

A `{"00": 5, "111": 3}` counts payload is enough. The API reports 6 bytes and writes 7:

```text
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 1 at 0x7bbc6ade4816 thread T0
    #0 IQM_QDMI_device_job_get_results_hist src/iqm_device.cpp:1484:23
0x7bbc6ade4816 is located 0 bytes after 6-byte region
```

## What changed

The size is now accumulated over all the keys instead of extrapolated from one. For keys of equal length the arithmetic is identical to what it was — `n` keys of width `w` still give `n * (w + 1)` — so responses from a well-behaved backend produce byte-for-byte the same result as before.

This is a robustness fix rather than a response to an observed backend behavior: I have not seen IQM return mixed-width keys. The point is that the library should not corrupt a caller's heap if it ever does, and mixed measurement registers are a plausible way to get there.

## Testing

One unit test against the hermetic HTTP stub, covering keys of differing width. It fails on the size assertion against the previous code and trips AddressSanitizer on the write that follows.

An equal-width companion test was dropped after review: the uniform path is already exercised by several existing unit tests as well as the integration and fomac suites, so pinning its size a second time added no coverage.

Verified with a `Debug` build under `-fsanitize=address,undefined -fno-sanitize-recover=all`: the full unit suite is 91/91 green with the fix, and reproduces the overflow above without it.

Found while reviewing the device for #173.
