### PR TITLE
🐛 Stop counting computational resonators as qubits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Report the number of qubits without the computational resonators, which
+  inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
+  ([**@marcelwa**])
 - 🐛 Contain exceptions during device-session initialization and leave failed
   sessions retryable ([#175]) ([**@burgholzer**])
 - 🐛 Serialize move-gate and active-reset options using the canonical IQM
@@ -165,6 +168,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#172]: https://github.com/iqm-finland/QDMI-on-IQM/pull/172
 [#169]: https://github.com/iqm-finland/QDMI-on-IQM/pull/169

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -292,13 +292,19 @@ The following properties about the device can be queried via the
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_QUBITSNUM`: The
   number of qubits available on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_SITES`: The
-  list of available qubit sites on the device.
+  list of available sites on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_OPERATIONS`:
   The list of available calibrated operations on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_COUPLINGMAP`:
   The coupling map between qubits on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_CUSTOM1`: The
   current calibration set ID used by the session.
+
+**Note:** Sites and qubits are not the same quantity. On Star-topology devices
+the site list also contains the computational resonators, so it is longer than
+the qubit count. Allocate registers from
+{cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_QUBITSNUM` and
+address hardware through the site list.
 
 The following properties about every site (qubit) can be queried via the
 {cpp:func}`IQM_QDMI_device_session_query_site_property` function:

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -99,6 +99,11 @@ struct IQM_QDMI_Device_Session_impl_d {
   /// Device status
   QDMI_Device_Status device_status_ = QDMI_DEVICE_STATUS_OFFLINE;
 
+  /// @brief Number of qubits on the device.
+  /// @details Distinct from @c sites_.size(), which also counts the
+  ///          computational resonators of Star-topology devices.
+  size_t num_qubits_ = 0;
+
   /// Quantum computer ID
   std::optional<std::string> quantum_computer_id_ = std::nullopt;
 
@@ -429,6 +434,7 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
 
   const auto &qubits = architecture["qubits"];
   const auto num_qubits = qubits.size();
+  session->num_qubits_ = num_qubits;
   LOG_INFO("Found " + std::to_string(num_qubits) + " qubits");
 
   std::vector<std::string> computational_resonators;
@@ -1947,8 +1953,10 @@ int IQM_QDMI_device_session_query_device_property(
     ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUEUELENGTH, size_t,
                               *queue_length, prop, size, value, size_ret)
   }
+  // Deliberately not sites_.size(): the site list also holds the computational
+  // resonators of Star-topology devices, which are not qubits.
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUBITSNUM, size_t,
-                            session->sites_.size(), prop, size, value, size_ret)
+                            session->num_qubits_, prop, size, value, size_ret)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_SITES, IQM_QDMI_Site,
                     session->sites_ptr_, prop, size, value, size_ret)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_OPERATIONS, IQM_QDMI_Operation,

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -464,18 +464,21 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
 }
 
 TEST_F(QDMIIntegrationTest, QuerySiteProperties) {
-  // Check whether there are equally many sites as reported qubits
+  // The site list covers the qubits and, on Star-topology devices, the
+  // computational resonators as well, so it is at least as long as the qubit
+  // count and longer whenever the device has resonators.
   const auto sites = fomac.get_sites();
   const auto qubits_num = fomac.get_qubits_num();
-  EXPECT_EQ(sites.size(), qubits_num);
+  EXPECT_GE(sites.size(), qubits_num);
 
   const auto duration_scale_factor = fomac.get_duration_scale_factor();
   ASSERT_GT(duration_scale_factor, 0.0);
 
-  // For every site check that the site ID is less than the number of qubits.
+  // Site IDs index the site list, so they are bounded by its size rather than
+  // by the qubit count.
   for (const auto &site : sites) {
     const auto site_id = fomac.get_site_index(site);
-    EXPECT_LT(site_id, qubits_num);
+    EXPECT_LT(site_id, sites.size());
     const auto site_name = fomac.get_site_name(site);
     EXPECT_FALSE(site_name.empty());
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -650,6 +650,71 @@ TEST_F(DeviceIntegrationMockTest, QueueLengthIsOptional) {
             QDMI_ERROR_NOTSUPPORTED);
 }
 
+TEST_F(DeviceIntegrationMockTest, QubitCountExcludesComputationalResonators) {
+  // A Star-topology device: three qubits around one computational resonator.
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, R"([
+      {
+        "computational_resonators": ["CR1"],
+        "connectivity": [["QB1","CR1"],["QB2","CR1"],["QB3","CR1"]],
+        "dut_label":"M160_W0_H01_Z99",
+        "qubits":["QB1","QB2","QB3"]
+      }
+    ])");
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2", "QB3"],
+      "computational_resonators": ["CR1"],
+      "gates": {
+        "measure": {
+          "implementations": {
+            "constant": {"loci": [["QB1"], ["QB2"], ["QB3"]]}
+          },
+          "default_implementation": "constant",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, R"({"observations": []})");
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+
+  size_t num_qubits = 0;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(num_qubits),
+                &num_qubits, nullptr),
+            QDMI_SUCCESS);
+  // Three qubits, not the four sites. Before the fix this reported 4.
+  EXPECT_EQ(num_qubits, 3U);
+
+  // The site list still covers qubits and resonators alike, which is what
+  // QDMI expects of it.
+  size_t sites_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES, 0, nullptr, &sites_size),
+            QDMI_SUCCESS);
+  EXPECT_EQ(sites_size / sizeof(IQM_QDMI_Site), 4U);
+}
+
+TEST_F(DeviceIntegrationMockTest, QubitCountMatchesSiteCountWithoutResonators) {
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+
+  size_t num_qubits = 0;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(num_qubits),
+                &num_qubits, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(num_qubits, 2U);
+
+  size_t sites_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES, 0, nullptr, &sites_size),
+            QDMI_SUCCESS);
+  EXPECT_EQ(sites_size / sizeof(IQM_QDMI_Site), 2U);
+}
+
 TEST_F(DeviceTest, SessionAllocation) {
   // Session should be allocated in SetUp
   EXPECT_NE(session, nullptr);


### PR DESCRIPTION
🤖 *AI text below* 🤖

`QDMI_DEVICE_PROPERTY_QUBITSNUM` is answered with `sites_.size()`. But the site list deliberately holds qubits *and* computational resonators — they are appended together while the static architecture is parsed, which is correct for `QDMI_DEVICE_PROPERTY_SITES` and wrong for a qubit count.

On Crystal-topology devices the two happen to coincide, which is why this has gone unnoticed. On Star-topology devices (Deneb and successors) the reported qubit count is inflated by the number of resonators, so a consumer that sizes a register from `QUBITSNUM` asks for qubits the device does not have.

## What changed

The qubit count is recorded on the session while the static architecture is parsed — it is already computed there, as `architecture["qubits"].size()` — and the property is answered from that instead. The site list is untouched.

Devices without computational resonators are unaffected, since there the two counts are equal by construction.

## Testing

Two unit tests. The first adds a three-qubit, one-resonator architecture to the mock and asserts that the qubit count reports three while `QDMI_DEVICE_PROPERTY_SITES` still reports four sites; it reports four against the previous behavior. The second pins the resonator-free case so the equal-count path cannot regress.

Full unit suite green (92/92), including a `Debug` build under `-fsanitize=address,undefined -fno-sanitize-recover=all`.

Also adds a note to `docs/usage.md`. Consumers hit this distinction exactly when allocating registers, and the docs previously described `QDMI_DEVICE_PROPERTY_SITES` as "the list of available qubit sites", which reads as though the two are the same list.

Found while reviewing the device for #173.

## The integration suite was asserting the bug

Worth flagging for review, because it is the strongest evidence the fix is correct and it is the one place this PR touches an existing test's expectations.

`QDMIIntegrationTest.QuerySiteProperties` required the site list to be exactly as long as the qubit count, and every site ID to be below that count. CI failed it against `sirius:mock`, which reports **25 sites for 24 qubits** — 24 qubits plus `COMPR1`. The assertion had been passing only because the qubit count was inflated to match the site count. The test was pinning the defect.

It now asserts the real invariants: the site list is at least as long as the qubit count, and site IDs are bounded by the size of the list they actually index. On resonator-free devices both still hold with equality.

This also means the finding is not hypothetical for Deneb alone — it is observable on a mock the suite runs against today.

> **Correction.** An earlier revision of this description also named `garnet:mock` here. That was wrong: `garnet:mock` is a Crystal-topology device with no computational resonators (20 qubits, 20 sites), and it passed `QuerySiteProperties` both before and after this change. It did fail the same CI run, but on `QueuePropertiesOnGarnetMock` — an unrelated queue-position assertion. Thanks to @burgholzer for catching it. `sirius:mock` is the only mock in the matrix that exhibits the inflated count.
