### PR TITLE
🩹 Define the missing changelog link for #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ Compatible with QDMI `v1.3.0`.
 <!-- PR links -->
 
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
+[#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175
 [#172]: https://github.com/iqm-finland/QDMI-on-IQM/pull/172
 [#169]: https://github.com/iqm-finland/QDMI-on-IQM/pull/169
 [#163]: https://github.com/iqm-finland/QDMI-on-IQM/pull/163


### PR DESCRIPTION
🤖 *AI text below* 🤖

The `Fixed` entry added in #175 references `([#175])`, but the PR-links block at the bottom of the changelog never defines it. The reference has nothing to resolve against, so it renders as literal text rather than a link.

I checked the rest of the block while I was in there: every other `([#N])` reference in the file resolves. This was the only broken one.

## Testing

Docs only, one line added. `rumdl` passes.

Noticed while rebasing #181, which touches the same part of the changelog.