### PR TITLE
🐛 Answer the first queue-position query from the submission response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Answer the first `QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` query from the
+  submission response, which already reports the position, instead of losing it
+  to a status round trip that outlives the job's stay in the queue ([#184])
+  ([**@marcelwa**])
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
@@ -168,6 +172,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#184]: https://github.com/iqm-finland/QDMI-on-IQM/pull/184
 [#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -520,9 +520,10 @@ These steps correspond to the initialization sequence described in the
 **When Job Queue Position Is Queried:**
 
 - `GET_JOB_STATUS` or `GET_CALIBRATION_JOB_STATUS`: Called for every
-  `QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` query. The refreshed status and queue
-  position are cached together, and a value is returned only while the job is
-  queued.
+  `QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` query except the first one after a
+  submission that already reported a queue position. The refreshed status and
+  queue position are cached together, and a value is returned only while the job
+  is queued.
 
 **After Calibration Job Completion:**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -375,9 +375,12 @@ including the
 
 After submission,
 {cpp:enumerator}`~QDMI_DEVICE_JOB_PROPERTY_T::QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION`
-reports the number of jobs ahead of the job while it is queued. Every property
-query refreshes the job status and queue position from the IQM server. The query
-returns `QDMI_ERROR_BADSTATE` when the refreshed job is not queued and
+reports the number of jobs ahead of the job while it is queued. Property queries
+refresh the job status and queue position from the IQM server, with one
+exception: when the submission response already reported the job as queued and
+gave its position, the first query answers from that instead of asking again.
+That value is returned once; every later query goes back to the server. The
+query returns `QDMI_ERROR_BADSTATE` when the refreshed job is not queued and
 `QDMI_ERROR_NOTSUPPORTED` when the server does not provide a trustworthy queue
 position.
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -220,6 +220,14 @@ struct IQM_QDMI_Device_Job_impl_d {
   QDMI_Job_Status status_ = QDMI_JOB_STATUS_CREATED;
   /// The number of jobs ahead while this job is queued.
   std::optional<size_t> queue_position_ = std::nullopt;
+  /// @brief Whether @c queue_position_ still holds the value that the
+  ///        submission response reported.
+  /// @details A submission response is a status observation in its own right,
+  ///          so the first queue-position query can be answered from it rather
+  ///          than spending a status round trip re-deriving what the backend
+  ///          has just reported. Cleared once that value has been handed out,
+  ///          and whenever a status check supersedes it.
+  bool queue_position_from_submission_ = false;
 };
 
 /**
@@ -901,6 +909,42 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
   }
   return QDMI_SUCCESS;
 }
+
+/**
+ * @brief Adopt the queue information that a submission response already
+ *        carries.
+ * @details The response to a submission reports the job's native status and,
+ *          while the job is queued, its position in the queue. Recording both
+ *          lets the first queue-position query be answered without a status
+ *          round trip that would only re-derive what the backend has just
+ *          reported. Anything other than a queued observation is ignored, so
+ *          the job keeps the submitted status it had before.
+ * @param job The job that was just submitted.
+ * @param response The parsed submission response.
+ */
+void Adopt_submission_queue_position(IQM_QDMI_Device_Job job,
+                                     const nlohmann::json &response) {
+  const auto native_status = response.find("status");
+  if (native_status == response.end() || !native_status->is_string()) {
+    return;
+  }
+  // Run the observation through the regular mapping rather than repeating the
+  // native status names here, and keep it only if it says the job is queued.
+  const auto submitted_status = job->status_;
+  if (Set_job_status(job, native_status->get<std::string>()) != QDMI_SUCCESS ||
+      job->status_ != QDMI_JOB_STATUS_QUEUED) {
+    job->status_ = submitted_status;
+    return;
+  }
+  const auto position = response.find("queue_position");
+  if (position == response.end() || !position->is_number_unsigned()) {
+    // Queued, but without a position to report. Leave the queued status in
+    // place and let the next query fetch one.
+    return;
+  }
+  job->queue_position_ = position->get<size_t>();
+  job->queue_position_from_submission_ = true;
+}
 } // namespace
 
 int IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -1122,6 +1166,17 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   ADD_STRING_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_ID, job->job_id_.c_str(), prop,
                       size, value, size_ret)
   if (prop == QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION) {
+    if (job->queue_position_from_submission_) {
+      // The submission response already reported this position, so answer from
+      // it rather than spending a status round trip to re-derive it. It is
+      // handed out once; every later query observes the device again.
+      if (value != nullptr) {
+        job->queue_position_from_submission_ = false;
+      }
+      ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION, size_t,
+                                *job->queue_position_, prop, size, value,
+                                size_ret)
+    }
     QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
     const auto result = IQM_QDMI_device_job_check(job, &status);
     if (result != QDMI_SUCCESS) {
@@ -1217,16 +1272,13 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
   job->job_id_ = job_submission_json_response["id"];
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
+  Adopt_submission_queue_position(job, job_submission_json_response);
+
   // Log queue position if available
   std::string log_message = "Submitted job with ID: " + job->job_id_;
-  if (job_submission_json_response.contains("queue_position")) {
-    const auto &queue_position_json =
-        job_submission_json_response["queue_position"];
-    if (queue_position_json.is_number_integer()) {
-      const auto queue_position = queue_position_json.get<int>();
-      log_message +=
-          " (queue position: " + std::to_string(queue_position) + ")";
-    }
+  if (job->queue_position_.has_value()) {
+    log_message +=
+        " (queue position: " + std::to_string(*job->queue_position_) + ")";
   }
   LOG_INFO(log_message);
 
@@ -1259,17 +1311,14 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
   job->job_id_ = job_submission_json_response["id"];
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
+  Adopt_submission_queue_position(job, job_submission_json_response);
+
   // Log queue position if available
   std::string log_message =
       "Submitted calibration job with ID: " + job->job_id_;
-  if (job_submission_json_response.contains("queue_position")) {
-    const auto &queue_position_json =
-        job_submission_json_response["queue_position"];
-    if (queue_position_json.is_number_integer()) {
-      const auto queue_position = queue_position_json.get<int>();
-      log_message +=
-          " (queue position: " + std::to_string(queue_position) + ")";
-    }
+  if (job->queue_position_.has_value()) {
+    log_message +=
+        " (queue position: " + std::to_string(*job->queue_position_) + ")";
   }
   LOG_INFO(log_message);
 
@@ -1372,7 +1421,9 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
       update_status != QDMI_SUCCESS) {
     return update_status;
   }
+  // A fresh observation supersedes whatever the submission response reported.
   job->queue_position_ = std::nullopt;
+  job->queue_position_from_submission_ = false;
   if (job->status_ == QDMI_JOB_STATUS_QUEUED) {
     if (const auto position = job_status_json_response.find("queue_position");
         position != job_status_json_response.end() &&

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1456,6 +1456,87 @@ TEST_F(DeviceJobMockTest, QueryQueuePositionRefreshesJobStatus) {
   EXPECT_EQ(get_urls.back(), "https://localhost/api/v1/jobs/job-queue");
 }
 
+TEST_F(DeviceJobMockTest, QueuePositionFromSubmissionSkipsTheStatusRoundTrip) {
+  // The submission response reports the queue position itself, so the first
+  // query has nothing to learn from a status check.
+  http_stub.queue_post(
+      200, R"({"id": "job-queue", "status": "waiting", "queue_position": 3})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  const auto gets_after_submission = http_stub.get_urls().size();
+
+  size_t queue_position = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 3U);
+  // Before the fix this issued a status request and the position was lost
+  // whenever that request outlived the job's stay in the queue.
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission);
+
+  // The value is handed out once. The next query observes the device again.
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 1})");
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 1U);
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
+}
+
+TEST_F(DeviceJobMockTest, StatusCheckSupersedesTheSubmissionQueuePosition) {
+  http_stub.queue_post(
+      200, R"({"id": "job-queue", "status": "waiting", "queue_position": 3})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  // An explicit check is a fresher observation than the submission response,
+  // so the position it reports is the one that must be returned afterwards.
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 7})");
+  QDMI_Job_Status status{};
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  ASSERT_EQ(status, QDMI_JOB_STATUS_QUEUED);
+
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 7})");
+  size_t queue_position = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 7U);
+}
+
+TEST_F(DeviceJobMockTest, SubmissionQueuePositionIgnoredWhenNotQueued) {
+  // A position alongside a status that is not "queued" or "waiting" says
+  // nothing about a queue, so the regular refresh has to happen.
+  http_stub.queue_post(
+      200, R"({"id": "job-queue", "status": "received", "queue_position": 3})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  const auto gets_after_submission = http_stub.get_urls().size();
+
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 5})");
+  size_t queue_position = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 5U);
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
+}
+
 TEST_F(DeviceJobMockTest, QueuePositionRequiresQueuedJobAndKnownPosition) {
   size_t queue_position = 0;
   EXPECT_EQ(IQM_QDMI_device_job_query_property(


### PR DESCRIPTION
🤖 *AI text below* 🤖

The response to a job submission already tells us the job's native status and, while the job is queued, its position in the queue. Both were thrown away: the status was overwritten with `QDMI_JOB_STATUS_SUBMITTED`, and the position was only formatted into a log line.

`QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` then re-derived over the network something the backend had reported moments earlier.

## Why this is more than a redundant request

The extra round trip is not consequence-free. `QUEUEPOSITION` calls `IQM_QDMI_device_job_check`, which can absorb an HTTP 429 `Retry-After` of tens of seconds. A job that finishes while that request is in flight is no longer queued when it returns, so the property answers `QDMI_ERROR_BADSTATE` — and the position is gone for good, even though the backend had already handed it to us at submission time.

This is observable in CI today. `QDMIIntegrationTest.QueuePropertiesOnGarnetMock` fails intermittently for exactly this reason. From the garnet job of [run 31381541803](https://github.com/iqm-finland/QDMI-on-IQM/actions/runs/31381541803), the submission response:

```json
{"id":"019feb5b-516c-…","queue_position":1,"status":"waiting",…}
```

and, in the same job, six HTTP 429s with a 30-second `Retry-After`, one of them on a job-status GET:

```text
Request to URL 'https://resonance.iqm.tech/api/v1/jobs/019feb5b-d8bf-…'
hit HTTP 429 rate limiting; retrying after 30 second(s) (attempt 1/10)
```

A 64-shot mock job finishes in well under a second, so one rate-limited poll is enough to lose the observation. The test polls up to 20 times at 100 ms intervals, but that budget is illusory: it breaks out of the loop on `QDMI_ERROR_BADSTATE`, so a single stalled request ends it. That run failed all three `ctest --repeat until-pass:3` attempts — under a rate-limited runner it is not a coin flip, it fails reliably.

Measured across the 11 completed garnet jobs since #172 merged, one failed. Small sample, and I looked at only that one failure in depth, so treat the rate as indicative rather than precise.

## What changed

The queued observation is recorded at submission time, and the first `QUEUEPOSITION` query answers from it instead of asking again.

- The value is handed out **once**. Every later query refreshes from the server exactly as before.
- Any status check in between — `job_check`, `job_wait` — supersedes it, so a fresher observation always wins.
- Submission responses that do not report the job as queued are ignored entirely; the job keeps the submitted status it had, and those paths refresh as they always did.
- The queue position is read through the existing native-status mapping rather than by repeating the `"queued"`/`"waiting"` literals, so there is one place where those names live.

## The trade-off, stated plainly

This narrows the documented contract. `docs/usage.md` said *every* property query refreshes from the server; now the first one after a queued submission does not. The cost: a caller that submits, does nothing for a long time, and then queries once gets the submission-time position rather than a current one. Its second query is correct again.

I think that is the right trade, because the submission response is the server's own statement about the job at the moment it entered the queue — for the query that immediately follows a submission it is not merely as good as a re-check, it is the observation the re-check is trying to reproduce. But it is a real behavior change and the alternative is defensible, so it is worth an explicit look. If you would rather not narrow the contract, the other option is to leave the device alone and make the integration test tolerate a missing position — cheaper, but it leaves the redundant round trip in place and the test asserting less.

## Testing

Three unit tests against the hermetic HTTP stub, all asserting on `http_stub.get_urls()` so the round trips are counted rather than assumed:

- `QueuePositionFromSubmissionSkipsTheStatusRoundTrip` — the first query returns the submission's position with **no** additional GET; the second query does issue one and returns the refreshed value. This one fails against the previous behavior.
- `StatusCheckSupersedesTheSubmissionQueuePosition` — an explicit `job_check` in between wins.
- `SubmissionQueuePositionIgnoredWhenNotQueued` — a position alongside a non-queued status is ignored and the regular refresh happens.

The last two pass against the previous behavior as well, by design: they are guards pinning that the paths this PR does not intend to change stay unchanged.

The four pre-existing queue tests from #172 pass untouched. `QueryQueuePositionRefreshesJobStatus` still exercises the refresh path genuinely, because its submission response carries neither `status` nor `queue_position`.

Full unit suite green (93/93) under a `Debug` build with `-fsanitize=address,undefined -fno-sanitize-recover=all`.

Docs updated in `docs/usage.md` and `docs/contributing.md` to describe the narrowed contract.

Found while investigating the intermittent `QueuePropertiesOnGarnetMock` failure noticed in #182.
