### PR TITLE
🩹 Documented SPANK build command leaves an untracked tree that breaks pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 .ccache/
 cmake-build-*
 
+# SPANK plugin build dirs
+build-spank*/
+
 # Distribution / packaging
 .Python
 /build/


### PR DESCRIPTION
🤖 *AI text below* 🤖

Following the repo's own documentation for the SPANK plugin leaves an untracked build tree in the working copy. `docs/admin_guide.md` and `docs/spank_plugin.md` both configure the plugin with `cmake -S . -B build-spank -DBUILD_IQM_SPANK=ON`, and `spank/Dockerfile` together with `spank/test/entrypoint.sh` use `build-spank-docker`. None of the existing build-directory rules in `.gitignore` — `/build/`, `cmake-build-*`, `*/build`, and `test/**/build/` — match either name, so anyone who runs the documented command ends up with a large generated tree showing up in `git status`.

The more disruptive consequence is that `prek` treats `build-spank/_deps/qdmi-src` as a nested workspace and runs `ty` across the vendored QDMI template sources. That produces dozens of unresolved-import failures on every single commit, so the pre-commit hooks are unusable for as long as the directory exists. The obvious workaround is `--no-verify`, which disables all the hooks rather than just the spurious ones — a bad trade for anyone who was only trying to follow the admin guide.

This adds a single `build-spank*/` rule alongside the other CMake build-directory patterns, which covers both `build-spank/` and `build-spank-docker/`. Nothing tracked is affected: `git ls-files -i -c --exclude-standard` reports no tracked file newly matched by the pattern, and `spank/` itself along with its sources, `Dockerfile`, and test scripts remain unignored. No CHANGELOG entry is included, since comparable repository-hygiene and tool-configuration changes here have not carried one.
