### PR TITLE
👷 Run the C++ CI jobs when their own workflow files change

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,12 @@ jobs:
     name: 🔍 Change
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@579203ef22082fa5d5483412f442e50d0c5ff4a7 # v2.2.2
     with:
+      additional-cpp-files: |
+        .github/workflows/CI.yml
+        .github/workflows/cpp-tests-*.yml
+        .github/workflows/cpp-coverage.yml
+        .github/workflows/cpp-linter.yml
+        .github/workflows/cpp-install-tests.yml
       additional-cd-files: |
         spank/**
         .github/workflows/spank-tests.yml


### PR DESCRIPTION
🤖 *AI text below* 🤖

The reusable change-detection workflow decides whether the C++ jobs run by matching changed files against a built-in path filter. That filter keys C++ workflow changes off the upstream repository's own file names — `reusable-cpp-tests-ubuntu.yml`, `reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-windows.yml`, `reusable-cpp-coverage.yml`, `reusable-cpp-ci.yml`, and a lowercase `ci.yml`. This repository uses none of those names: our workflows are `CI.yml`, `cpp-tests-ubuntu.yml`, `cpp-tests-macos.yml`, `cpp-tests-windows.yml`, `cpp-coverage.yml`, `cpp-linter.yml`, and `cpp-install-tests.yml`. Because we only passed `additional-cd-files`, nothing filled that gap.

The consequence is that a pull request editing only C++ workflow files produced `run-cpp-tests=false`, every C++ job skipped, and `required-checks-pass` still went green because those jobs are on its `allowed-skips` list. Changes to C++ CI could therefore merge without ever having been exercised. This was observed live on #173, where the sanitizer job skipped on its first run while the merge gate reported success.

This adds `additional-cpp-files` to the `change-detection` call, listing this repository's actual C++ workflow file names. The upstream workflow feeds that one input into both the C++ test filter and the C++ linter filter, so `run-cpp-tests` and `run-cpp-linter` both start reacting to those files. The underlying `get-changed-files` action matches with minimatch, so the `cpp-tests-*.yml` glob resolves to the three per-platform workflows and stays correct if another is added.

Worth flagging explicitly: this widens which jobs run for unrelated pull requests. Any change to `CI.yml` itself now triggers the full C++ matrix, coverage, install tests, and the C++ linter, even when the edit only touches, say, a Python job definition. That is the intended trade-off — `CI.yml` is where the C++ jobs are defined, so an edit to it can change how they run — but it does cost CI time on pull requests that are not about C++ at all, and narrowing it is the maintainers' call if the cost is judged too high.

This pull request is its own verification: it edits only a workflow file, so the C++ jobs must run here rather than skip. No changelog entry, following the precedent of #118, which was likewise a `CI.yml`-only change-detection fix.
