### PR TITLE
🐛 Stop marking a still-running job as failed when the server cannot be reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Keep a job checkable when a status or cancellation request fails, instead
+  of permanently reporting a still-running job as failed ([#187] — unverified)
+  ([**@marcelwa**])
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
@@ -168,6 +171,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187
 [#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Keep a job checkable when a status or cancellation request fails, instead
-  of permanently reporting a still-running job as failed ([#187] — unverified)
+  of permanently reporting a still-running job as failed ([#187])
   ([**@marcelwa**])
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1322,11 +1322,10 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
       job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_abortion_response);
   if (status != QDMI_SUCCESS) {
-    if (status == QDMI_ERROR_PERMISSIONDENIED) {
-      return status;
-    }
-    job->status_ = QDMI_JOB_STATUS_FAILED;
-    return QDMI_ERROR_FATAL;
+    // A cancellation request that never reached the server says nothing about
+    // the job itself, which keeps running remotely. Leave the status untouched
+    // so that the job stays observable and the request can be retried.
+    return status;
   }
   job->status_ = QDMI_JOB_STATUS_CANCELED;
   LOG_DEBUG("Job cancellation response:\n" + job_abortion_response.text);
@@ -1357,11 +1356,10 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
       *job->session_->connection_pool_, job->session_->request_timeout_);
   const auto status_code = iqm::http::Handle_response(job_status_response);
   if (status_code != QDMI_SUCCESS) {
-    if (status_code == QDMI_ERROR_PERMISSIONDENIED) {
-      return status_code;
-    }
-    job->status_ = QDMI_JOB_STATUS_FAILED;
-    return QDMI_ERROR_FATAL;
+    // A failed status query says nothing about the job itself, which keeps
+    // running remotely. Leave the status untouched so that a transient server
+    // or transport failure does not permanently mark the job as failed.
+    return status_code;
   }
   const auto job_status_json_response =
       nlohmann::json::parse(job_status_response.text);

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1325,6 +1325,9 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
     // A cancellation request that never reached the server says nothing about
     // the job itself, which keeps running remotely. Leave the status untouched
     // so that the job stays observable and the request can be retried.
+    LOG_DEBUG("Cancellation request for job with ID: " + job->job_id_ +
+              " failed with status " + std::to_string(status) +
+              "; keeping its status at " + std::to_string(job->status_));
     return status;
   }
   job->status_ = QDMI_JOB_STATUS_CANCELED;
@@ -1359,6 +1362,9 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
     // A failed status query says nothing about the job itself, which keeps
     // running remotely. Leave the status untouched so that a transient server
     // or transport failure does not permanently mark the job as failed.
+    LOG_DEBUG("Status query for job with ID: " + job->job_id_ +
+              " failed with status " + std::to_string(status_code) +
+              "; keeping its status at " + std::to_string(job->status_));
     return status_code;
   }
   const auto job_status_json_response =

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1106,6 +1106,97 @@ TEST_F(DeviceJobMockTest, RetrievedJobPreservesPermissionFailures) {
   IQM_QDMI_device_job_free(retrieved_job);
 }
 
+TEST_F(DeviceJobMockTest, JobCheckPreservesStatusOnTransportFailure) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
+
+  http_stub.queue_get_connection_error();
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status),
+            QDMI_ERROR_FATAL);
+
+  // An unreachable server says nothing about the job, so the next check has to
+  // query the server again instead of short-circuiting on a terminal status.
+  const auto requests_before_recheck = http_stub.get_urls().size();
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before_recheck + 1);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_RUNNING);
+  IQM_QDMI_device_job_free(retrieved_job);
+}
+
+TEST_F(DeviceJobMockTest, JobCheckPreservesStatusOnServerError) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "queued", "type": "circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
+
+  http_stub.queue_get(502, R"({"message": "Bad gateway"})");
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status),
+            QDMI_ERROR_FATAL);
+
+  const auto requests_before_recheck = http_stub.get_urls().size();
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "queued", "type": "circuit"})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before_recheck + 1);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_QUEUED);
+  IQM_QDMI_device_job_free(retrieved_job);
+}
+
+TEST_F(DeviceJobMockTest, JobCancelPreservesStatusOnServerError) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
+
+  http_stub.queue_post(503, R"({"message": "Service unavailable"})");
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(retrieved_job), QDMI_ERROR_FATAL);
+
+  // The cancellation request never reached the server, so the job is still
+  // whatever it was before and must remain observable.
+  const auto requests_before_recheck = http_stub.get_urls().size();
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before_recheck + 1);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_RUNNING);
+  IQM_QDMI_device_job_free(retrieved_job);
+}
+
+TEST_F(DeviceJobMockTest, JobWaitRemainsRetryableAfterTransportFailure) {
+  http_stub.queue_post(200, R"({"id": "job-flaky"})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  http_stub.queue_get_connection_error();
+  EXPECT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_ERROR_FATAL);
+
+  // Waiting again has to resume polling the still-running job.
+  const auto requests_before_second_wait = http_stub.get_urls().size();
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  EXPECT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before_second_wait + 1);
+
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
+}
+
 TEST_F(DeviceJobMockTest, FullLifecycle) {
   const std::string job_submission_response = R"({"id": "job-123"})";
   const std::string job_status_response = R"({"status": "ready"})";


### PR DESCRIPTION
🤖 *AI text below* 🤖

A single failed status request could permanently kill a healthy job. `IQM_QDMI_device_job_check` treated "we could not ask the server" as "the job failed": any non-success response other than `QDMI_ERROR_PERMISSIONDENIED` set the job to `QDMI_JOB_STATUS_FAILED` and returned `QDMI_ERROR_FATAL`. One 502, 503, or dropped connection during a multi-hour `IQM_QDMI_device_job_wait` was therefore enough to bury a job that was still running fine remotely, and the damage was permanent: the early return at the top of `job_check` short-circuits on a terminal status, so every subsequent check answered from the poisoned cache and the caller could never find out otherwise. Meanwhile the job kept occupying the site's quota. A downstream consumer hit this.

The fix is to stop letting a failed status *query* say anything about the job's status. The job status is only mutated when the server actually reports one; otherwise the mapped error code is returned and the job stays exactly as re-checkable as it was. #160 already carved `QDMI_ERROR_PERMISSIONDENIED` out for precisely this reason — a rejected read tells you nothing about the job — and this change just promotes that carve-out to the general rule, which is both the smaller diff and the more defensible semantic. `job_wait` already returns on a non-success `job_check`, so the caller still sees the error and can simply wait again afterwards; no loop change was needed.

Judgment call worth pushing back on: I included `IQM_QDMI_device_job_cancel`, which had the identical shape and, I think, the identical bug. A cancellation request the server never answered does not mean the job failed — it most likely means the job is still running, unaffected, which is the worst possible moment to tell the caller it is dead and then refuse to look again. Applying the same rule there keeps one invariant instead of two ("a failed request never mutates job status") rather than leaving a second copy of the bug behind. The counterargument is that it widens a bug fix beyond the reported symptom, so if you would rather see cancellation handled separately, say so and I will pull it back out.

The job-submission paths are deliberately untouched. There the job genuinely did fail to be created, so recording a failure is correct.

Explicitly out of scope: no retries and no backoff around the status query. Making transient failures survivable at all is the prerequisite; deciding how hard to retry is a separate piece of work with its own trade-offs.

Four regression tests drive the scripted HTTP stub through the failure modes: a dropped connection and an HTTP 502 during a status check, an HTTP 503 during a cancellation, and a dropped connection during a wait. Each asserts both halves of the property — the job keeps its previous status, and the following check actually reaches the server rather than being answered from a cached terminal status. All four fail on `main` (the job reads back as `QDMI_JOB_STATUS_FAILED` and the follow-up request is never issued) and pass here.
