### PR TITLE
🐛 Survive an IQM server schema change instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,11 @@ releases may include breaking changes.
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
-- 🐛 Contain exceptions during device-session initialization and leave failed
-  sessions retryable ([#175]) ([**@burgholzer**])
+- 🐛 Contain exceptions during device-session initialization and at every device
+  entry point that talks to the IQM server, check every field read from a server
+  response so that a schema change or an unreadable body is reported as an error
+  instead of corrupting memory, and leave failed sessions retryable ([#175],
+  [#188]) ([**@burgholzer**], [**@marcelwa**])
 - 🐛 Serialize move-gate and active-reset options using the canonical IQM
   RunRequest field names ([#169]) ([**@burgholzer**])
 - 🩹 Preserve exact program bytes across QDMI job parameter updates and property
@@ -168,6 +171,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#182]: https://github.com/iqm-finland/QDMI-on-IQM/pull/182
 [#177]: https://github.com/iqm-finland/QDMI-on-IQM/pull/177
 [#175]: https://github.com/iqm-finland/QDMI-on-IQM/pull/175

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,7 @@ releases may include breaking changes.
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
-- 🐛 Contain exceptions during device-session initialization and at every device
-  entry point that talks to the IQM server, check every field read from a server
-  response so that a schema change or an unreadable body is reported as an error
-  instead of corrupting memory, and leave failed sessions retryable ([#175],
-  [#188]) ([**@burgholzer**], [**@marcelwa**])
+- 🐛 Contain exceptions so they do not escape the C interface ([#175], [#188]) ([**@burgholzer**], [**@marcelwa**])
 - 🐛 Serialize move-gate and active-reset options using the canonical IQM
   RunRequest field names ([#169]) ([**@burgholzer**])
 - 🩹 Preserve exact program bytes across QDMI job parameter updates and property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ releases may include breaking changes.
 - 🐛 Report the number of qubits without the computational resonators, which
   inflated `QDMI_DEVICE_PROPERTY_QUBITSNUM` on Star-topology devices ([#182])
   ([**@marcelwa**])
-- 🐛 Contain exceptions so they do not escape the C interface ([#175], [#188]) ([**@burgholzer**], [**@marcelwa**])
+- 🐛 Contain exceptions so they do not escape the C interface ([#175], [#188])
+  ([**@burgholzer**], [**@marcelwa**])
 - 🐛 Serialize move-gate and active-reset options using the canonical IQM
   RunRequest field names ([#169]) ([**@burgholzer**])
 - 🩹 Preserve exact program bytes across QDMI job parameter updates and property

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -356,7 +356,11 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
     return status;
   }
   const auto json_response = nlohmann::json::parse(
-      qc_list_response.text); // NOLINT(misc-include-cleaner)
+      qc_list_response.text, nullptr, false); // NOLINT(misc-include-cleaner)
+  if (json_response.is_discarded()) {
+    LOG_ERROR("Failed to parse the quantum computers response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Received quantum computers response: " + json_response.dump());
 
   // Extract the quantum_computers array from the response
@@ -376,9 +380,9 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
     // Search for the specified quantum computer by ID
     bool found = false;
     for (const auto &qc : json_qc_list) {
-      if (qc["id"].get<std::string>() == qc_id) {
+      if (qc.at("id").get<std::string>() == qc_id) {
         found = true;
-        session->quantum_computer_alias_ = qc["alias"].get<std::string>();
+        session->quantum_computer_alias_ = qc.at("alias").get<std::string>();
         break;
       }
     }
@@ -391,8 +395,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
     // Search for the specified quantum computer by alias
     bool found = false;
     for (const auto &qc : json_qc_list) {
-      if (qc["alias"].get<std::string>() == qc_alias) {
-        session->quantum_computer_id_ = qc["id"].get<std::string>();
+      if (qc.at("alias").get<std::string>() == qc_alias) {
+        session->quantum_computer_id_ = qc.at("id").get<std::string>();
         found = true;
         break;
       }
@@ -404,8 +408,8 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   } else {
     // Use first available quantum computer
     const auto &qc = json_qc_list[0];
-    session->quantum_computer_id_ = qc["id"].get<std::string>();
-    session->quantum_computer_alias_ = qc["alias"].get<std::string>();
+    session->quantum_computer_id_ = qc.at("id").get<std::string>();
+    session->quantum_computer_alias_ = qc.at("alias").get<std::string>();
   }
   LOG_INFO("Using quantum computer ID: " + *session->quantum_computer_id_);
   LOG_INFO("Using quantum computer alias: " +
@@ -421,8 +425,12 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
       status != QDMI_SUCCESS) {
     return status;
   }
-  const auto arch_array =
-      nlohmann::json::parse(arch_response.text); // NOLINT(misc-include-cleaner)
+  const auto arch_array = nlohmann::json::parse(
+      arch_response.text, nullptr, false); // NOLINT(misc-include-cleaner)
+  if (arch_array.is_discarded()) {
+    LOG_ERROR("Failed to parse the static quantum architecture response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Received quantum architecture response: " + arch_array.dump());
 
   // Extract first element from array (API returns array with single object)
@@ -432,7 +440,7 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   }
   const auto &architecture = arch_array[0];
 
-  const auto &qubits = architecture["qubits"];
+  const auto &qubits = architecture.at("qubits");
   const auto num_qubits = qubits.size();
   session->num_qubits_ = num_qubits;
   LOG_INFO("Found " + std::to_string(num_qubits) + " qubits");
@@ -464,20 +472,19 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   };
 
   for (size_t i = 0; i < num_qubits; ++i) {
-    add_site(qubits[i].get<std::string>(), i);
+    add_site(qubits.at(i).get<std::string>(), i);
   }
   for (size_t i = 0; i < computational_resonators.size(); ++i) {
     add_site(computational_resonators[i], num_qubits + i);
   }
 
-  const auto &connectivity = architecture["connectivity"];
+  const auto &connectivity = architecture.at("connectivity");
   const auto num_edges = connectivity.size();
   LOG_INFO("Found " + std::to_string(num_edges) + " connectivity edges");
   session->connectivity_.reserve(num_edges * 2);
-  for (size_t i = 0; i < num_edges; ++i) {
-    const auto &edge = connectivity[i];
-    const auto site_name1 = edge[0].get<std::string>();
-    const auto site_name2 = edge[1].get<std::string>();
+  for (const auto &edge : connectivity) {
+    const auto site_name1 = edge.at(0).get<std::string>();
+    const auto site_name2 = edge.at(1).get<std::string>();
     const auto site1_it = session->sites_map_.find(site_name1);
     const auto site2_it = session->sites_map_.find(site_name2);
     if (site1_it == session->sites_map_.end() ||
@@ -508,15 +515,19 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
     return status;
   }
   const auto dynamic_architecture =
-      nlohmann::json::parse(dyn_arch_response.text);
+      nlohmann::json::parse(dyn_arch_response.text, nullptr, false);
+  if (dynamic_architecture.is_discarded()) {
+    LOG_ERROR("Failed to parse the dynamic quantum architecture response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Received dynamic quantum architecture response: " +
             dynamic_architecture.dump());
 
   session->calibration_set_id_ =
-      dynamic_architecture["calibration_set_id"].get<std::string>();
+      dynamic_architecture.at("calibration_set_id").get<std::string>();
   LOG_INFO("Using calibration set ID: " + session->calibration_set_id_);
 
-  const auto &gates = dynamic_architecture["gates"];
+  const auto &gates = dynamic_architecture.at("gates");
   session->operations_.reserve(gates.size());
   session->operations_map_.reserve(gates.size());
   for (const auto &[gate_name, gate_details] : gates.items()) {
@@ -532,10 +543,12 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
     session->operations_ptr_.emplace_back(operation.get());
     session->operations_map_[gate_name] = operation.get();
 
-    const auto default_implementation = gate_details["default_implementation"];
-    operation->implementation_ = default_implementation.get<std::string>();
-    const auto &qubit_lists =
-        gate_details["implementations"][default_implementation]["loci"];
+    const auto default_implementation =
+        gate_details.at("default_implementation").get<std::string>();
+    operation->implementation_ = default_implementation;
+    const auto &qubit_lists = gate_details.at("implementations")
+                                  .at(default_implementation)
+                                  .at("loci");
     auto &operation_qubit_lists =
         session->operations_sites_map_[operation.get()];
     operation_qubit_lists.reserve(qubit_lists.size());
@@ -577,18 +590,23 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
     return status;
   }
   const auto calibration_json_response =
-      nlohmann::json::parse(calibration_response.text);
+      nlohmann::json::parse(calibration_response.text, nullptr, false);
+  if (calibration_json_response.is_discarded()) {
+    LOG_ERROR("Failed to parse the calibration set quality metrics response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Received calibration set quality metrics response: " +
             calibration_json_response.dump());
 
-  const auto &observations = calibration_json_response["observations"];
+  const auto &observations = calibration_json_response.at("observations");
   auto metrics = std::unordered_map<std::string, double>{};
   for (const auto &observation : observations) {
-    if (observation["invalid"].get<bool>()) {
+    // Only observations that are explicitly marked invalid are skipped.
+    if (observation.value("invalid", false)) {
       continue;
     }
-    const auto &dut_field = observation["dut_field"].get<std::string>();
-    const auto value = observation["value"].get<double>();
+    const auto &dut_field = observation.at("dut_field").get<std::string>();
+    const auto value = observation.at("value").get<double>();
     metrics[dut_field] = value;
   }
 
@@ -1211,10 +1229,14 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
     return QDMI_ERROR_FATAL;
   }
   const auto job_submission_json_response =
-      nlohmann::json::parse(job_submission_response.text);
+      nlohmann::json::parse(job_submission_response.text, nullptr, false);
+  if (job_submission_json_response.is_discarded()) {
+    LOG_ERROR("Failed to parse the job submission response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Job submission response:\n" + job_submission_json_response.dump());
 
-  job->job_id_ = job_submission_json_response["id"];
+  job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
   // Log queue position if available
@@ -1252,11 +1274,15 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
     return QDMI_ERROR_FATAL;
   }
   const auto job_submission_json_response =
-      nlohmann::json::parse(job_submission_response.text);
+      nlohmann::json::parse(job_submission_response.text, nullptr, false);
+  if (job_submission_json_response.is_discarded()) {
+    LOG_ERROR("Failed to parse the calibration job submission response");
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Calibration job submission response:\n" +
             job_submission_json_response.dump());
 
-  job->job_id_ = job_submission_json_response["id"];
+  job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
   // Log queue position if available
@@ -1364,10 +1390,15 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
     return QDMI_ERROR_FATAL;
   }
   const auto job_status_json_response =
-      nlohmann::json::parse(job_status_response.text);
+      nlohmann::json::parse(job_status_response.text, nullptr, false);
+  if (job_status_json_response.is_discarded()) {
+    LOG_ERROR("Failed to parse the status response for job " + job->job_id_);
+    return QDMI_ERROR_FATAL;
+  }
   LOG_DEBUG("Job status response:\n" + job_status_json_response.dump());
 
-  const auto job_status = job_status_json_response["status"].get<std::string>();
+  const auto job_status =
+      job_status_json_response.at("status").get<std::string>();
   if (const auto update_status = Set_job_status(job, job_status);
       update_status != QDMI_SUCCESS) {
     return update_status;
@@ -1474,13 +1505,25 @@ int IQM_QDMI_device_job_get_results_hist(IQM_QDMI_Device_Job job,
         return status;
       }
       const auto job_results_json_response =
-          nlohmann::json::parse(job_results_response.text);
+          nlohmann::json::parse(job_results_response.text, nullptr, false);
+      if (job_results_json_response.is_discarded()) {
+        LOG_ERROR("Failed to parse the results response for job " +
+                  job->job_id_);
+        return QDMI_ERROR_FATAL;
+      }
       LOG_DEBUG("Job results response:\n" + job_results_json_response.dump());
 
       // Response is an array with one result for the submitted circuit.
-      job->measurement_keys_ = job_results_json_response[0]["measurement_keys"]
-                                   .get<std::vector<std::string>>();
-      for (const auto &counts = job_results_json_response[0]["counts"];
+      if (!job_results_json_response.is_array() ||
+          job_results_json_response.empty()) {
+        LOG_ERROR("Expected a non-empty array of results for job " +
+                  job->job_id_);
+        return QDMI_ERROR_FATAL;
+      }
+      const auto &counts_result = job_results_json_response.at(0);
+      job->measurement_keys_ =
+          counts_result.at("measurement_keys").get<std::vector<std::string>>();
+      for (const auto &counts = counts_result.at("counts");
            const auto &[bitstring, count] : counts.items()) {
         job->counts_[bitstring] = count.get<size_t>();
       }
@@ -1559,19 +1602,23 @@ int IQM_QDMI_device_job_get_results_calibration_id(IQM_QDMI_Device_Job job,
       return status;
     }
     const auto job_calibration_json_response =
-        nlohmann::json::parse(job_calibration_response.text);
+        nlohmann::json::parse(job_calibration_response.text, nullptr, false);
+    if (job_calibration_json_response.is_discarded()) {
+      LOG_ERROR("Failed to parse the calibration status response for job " +
+                job->job_id_);
+      return QDMI_ERROR_FATAL;
+    }
     LOG_DEBUG("Calibration job status response:\n" +
               job_calibration_json_response.dump());
 
-    if (!job_calibration_json_response["result"].contains("success") ||
-        !job_calibration_json_response["result"]["success"].get<bool>()) {
+    const auto &calibration_result = job_calibration_json_response.at("result");
+    if (!calibration_result.value("success", false)) {
       LOG_ERROR("Calibration job failed");
       job->status_ = QDMI_JOB_STATUS_FAILED;
       return QDMI_ERROR_FATAL;
     }
     job->new_calibration_set_id_ =
-        job_calibration_json_response["result"]["calibration_set_id"]
-            .get<std::string>();
+        calibration_result.at("calibration_set_id").get<std::string>();
 
     // Update the dynamic quantum architecture with the new calibration set ID
     auto ret = IQM_QDMI_device_update_dynamic_quantum_architecture(
@@ -1635,7 +1682,12 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
     }
 
     const auto job_measurements_json_response =
-        nlohmann::json::parse(job_measurements_response.text);
+        nlohmann::json::parse(job_measurements_response.text, nullptr, false);
+    if (job_measurements_json_response.is_discarded()) {
+      LOG_ERROR("Failed to parse the measurements response for job " +
+                job->job_id_);
+      return QDMI_ERROR_FATAL;
+    }
     LOG_DEBUG("Job measurements response:\n" +
               job_measurements_json_response.dump());
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1444,8 +1444,9 @@ bool IQM_QDMI_device_job_done(IQM_QDMI_Device_Job job) {
 }
 } // namespace
 
-int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job,
-                             const size_t timeout) try {
+// All network access happens inside IQM_QDMI_device_job_check, which contains
+// its own exceptions, so no additional guard is needed here.
+int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job, const size_t timeout) {
   if (job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -1492,12 +1493,6 @@ int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job,
     sleep_duration = (std::min)(sleep_duration * 2, max_sleep_duration);
   }
   return QDMI_SUCCESS;
-} catch (const iqm::ClientAuthenticationError &) {
-  return QDMI_ERROR_PERMISSIONDENIED;
-} catch (const std::bad_alloc &) {
-  return QDMI_ERROR_OUTOFMEM;
-} catch (...) {
-  return QDMI_ERROR_FATAL;
 }
 
 namespace {

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1303,7 +1303,7 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
 }
 } // namespace
 
-int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
+int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) try {
   if (job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -1326,9 +1326,15 @@ int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) {
     return IQM_QDMI_device_job_submit_calibration(job);
   }
   return QDMI_ERROR_INVALIDARGUMENT; // Unreachable; just a safety check
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
-int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
+int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) try {
   if (job == nullptr || job->status_ == QDMI_JOB_STATUS_DONE) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -1358,10 +1364,16 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) {
   LOG_DEBUG("Job cancellation response:\n" + job_abortion_response.text);
   LOG_INFO("Job with ID: " + job->job_id_ + " canceled");
   return QDMI_SUCCESS;
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
 int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
-                              QDMI_Job_Status *status) {
+                              QDMI_Job_Status *status) try {
   if (job == nullptr || status == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -1415,6 +1427,12 @@ int IQM_QDMI_device_job_check(IQM_QDMI_Device_Job job,
   LOG_DEBUG("Job status: " + std::to_string(job->status_) +
             " (native status: " + job_status + ")");
   return QDMI_SUCCESS;
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
 namespace {
@@ -1426,7 +1444,8 @@ bool IQM_QDMI_device_job_done(IQM_QDMI_Device_Job job) {
 }
 } // namespace
 
-int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job, const size_t timeout) {
+int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job,
+                             const size_t timeout) try {
   if (job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -1473,6 +1492,12 @@ int IQM_QDMI_device_job_wait(IQM_QDMI_Device_Job job, const size_t timeout) {
     sleep_duration = (std::min)(sleep_duration * 2, max_sleep_duration);
   }
   return QDMI_SUCCESS;
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
 namespace {
@@ -1894,7 +1919,7 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
 
 int IQM_QDMI_device_job_get_results(IQM_QDMI_Device_Job job,
                                     QDMI_Job_Result result, const size_t size,
-                                    void *data, size_t *size_ret) {
+                                    void *data, size_t *size_ret) try {
   if (job == nullptr || (data != nullptr && size == 0) ||
       (result >= QDMI_JOB_RESULT_MAX && result != QDMI_JOB_RESULT_CUSTOM1 &&
        result != QDMI_JOB_RESULT_CUSTOM2 && result != QDMI_JOB_RESULT_CUSTOM3 &&
@@ -1926,6 +1951,12 @@ int IQM_QDMI_device_job_get_results(IQM_QDMI_Device_Job job,
   default:
     return QDMI_ERROR_NOTSUPPORTED;
   }
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
 namespace {
@@ -1967,7 +1998,7 @@ std::optional<size_t> Get_queue_length(IQM_QDMI_Device_Session session) {
 
 int IQM_QDMI_device_session_query_device_property(
     IQM_QDMI_Device_Session session, const QDMI_Device_Property prop,
-    const size_t size, void *value, size_t *size_ret) {
+    const size_t size, void *value, size_t *size_ret) try {
   if (session == nullptr || (value != nullptr && size == 0) ||
       (prop >= QDMI_DEVICE_PROPERTY_MAX &&
        prop != QDMI_DEVICE_PROPERTY_CUSTOM1 &&
@@ -2039,6 +2070,12 @@ int IQM_QDMI_device_session_query_device_property(
                       session->calibration_set_id_.c_str(), prop, size, value,
                       size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
+} catch (const iqm::ClientAuthenticationError &) {
+  return QDMI_ERROR_PERMISSIONDENIED;
+} catch (const std::bad_alloc &) {
+  return QDMI_ERROR_OUTOFMEM;
+} catch (...) {
+  return QDMI_ERROR_FATAL;
 }
 
 int IQM_QDMI_device_session_query_site_property(IQM_QDMI_Device_Session session,

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1847,6 +1847,282 @@ TEST_F(DeviceJobMockTest, JobSubmissionFailure) {
 }
 
 // ============================================================================
+// SCHEMA DRIFT TESTS - well-formed responses that omit expected fields
+// ============================================================================
+
+TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationRejectsQuantumComputersWithoutIdentifiers) {
+  const std::string qc_list_without_identifiers =
+      R"({"quantum_computers":[{"display_name":"x"}]})";
+
+  // No selection criteria: the first entry is used and must be identifiable.
+  http_stub.queue_get(200, qc_list_without_identifiers);
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+
+  // Selection by alias.
+  const std::string alias = "default";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2,
+                alias.size() + 1, alias.c_str()),
+            QDMI_SUCCESS);
+  http_stub.queue_get(200, qc_list_without_identifiers);
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+
+  // Selection by ID takes precedence over the alias.
+  const std::string qc_id = "01966208-f3ec-73b7-890d-100000000000";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
+                qc_id.size() + 1, qc_id.c_str()),
+            QDMI_SUCCESS);
+  http_stub.queue_get(200, qc_list_without_identifiers);
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+}
+
+TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationRejectsIncompleteStaticArchitecture) {
+  const auto expect_rejected = [this](const std::string &architecture) {
+    http_stub.queue_get(200, list_quantum_computers_response);
+    http_stub.queue_get(200, architecture);
+    EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+  };
+
+  expect_rejected(R"([{"connectivity":[["QB1","QB2"]]}])");
+  expect_rejected(R"([{"qubits":["QB1","QB2"]}])");
+  expect_rejected(R"([{"qubits":["QB1","QB2"],"connectivity":[["QB1"]]}])");
+  // A truncated body must not escape as a parse error either.
+  expect_rejected(R"([{"qubits":["QB1")");
+}
+
+TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationRejectsIncompleteDynamicArchitecture) {
+  const auto expect_rejected = [this](const std::string &architecture) {
+    http_stub.queue_get(200, list_quantum_computers_response);
+    http_stub.queue_get(200, get_static_quantum_architectures_response);
+    http_stub.queue_get(200, architecture);
+    EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+  };
+
+  expect_rejected(R"({"gates":{}})");
+  expect_rejected(R"({"calibration_set_id":"f0fb4be5"})");
+  expect_rejected(
+      R"({"calibration_set_id":"f0fb4be5","gates":{"cz":{"implementations":{}}}})");
+  expect_rejected(R"({"calibration_set_id":)");
+}
+
+TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationRejectsIncompleteQualityMetrics) {
+  const auto expect_rejected = [this](const std::string &metrics) {
+    http_stub.queue_get(200, list_quantum_computers_response);
+    http_stub.queue_get(200, get_static_quantum_architectures_response);
+    http_stub.queue_get(200, get_dynamic_quantum_architectures_response);
+    http_stub.queue_get(200, metrics);
+    EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+  };
+
+  expect_rejected(R"({"observation_set_type":"quality-metric-set"})");
+  expect_rejected(R"({"observations":[{"value":0.96,"invalid":false}]})");
+  expect_rejected(
+      R"({"observations":[{"dut_field":"characterization.model.QB1.t1_time","invalid":false}]})");
+  expect_rejected(R"({"observations":)");
+}
+
+TEST_F(DeviceIntegrationMockTest, QualityMetricObservationsMayOmitInvalidFlag) {
+  // Observations are only skipped when they are explicitly marked invalid, so
+  // a missing flag is tolerated instead of failing the initialization.
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, get_dynamic_quantum_architectures_response);
+  http_stub.queue_get(
+      200,
+      R"({"observations":[{"dut_field":"characterization.model.QB1.t1_time","value":0.00002}]})");
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+
+  std::vector<IQM_QDMI_Site> sites(2);
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES,
+                sites.size() * sizeof(IQM_QDMI_Site),
+                static_cast<void *>(sites.data()), nullptr),
+            QDMI_SUCCESS);
+  uint64_t t1 = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_query_site_property(
+                session, sites.front(), QDMI_SITE_PROPERTY_T1, sizeof(t1), &t1,
+                nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(t1, 20U);
+}
+
+TEST_F(DeviceIntegrationMockTest, QueueLengthQueryContainsCxxExceptions) {
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+
+  auto &get_hook = iqm::http::internal::Get_hooks().get;
+  const auto expect_mapped_exception = [&](const std::exception_ptr &exception,
+                                           const int expected_status) {
+    get_hook = [exception](const auto &, const auto &, const auto &,
+                           const auto &, const auto) -> cpr::Response {
+      std::rethrow_exception(exception);
+    };
+    size_t queue_length = 0;
+    EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                  session, QDMI_DEVICE_PROPERTY_QUEUELENGTH,
+                  sizeof(queue_length), &queue_length, nullptr),
+              expected_status);
+  };
+
+  expect_mapped_exception(
+      std::make_exception_ptr(iqm::ClientAuthenticationError{"denied"}),
+      QDMI_ERROR_PERMISSIONDENIED);
+  expect_mapped_exception(std::make_exception_ptr(std::bad_alloc{}),
+                          QDMI_ERROR_OUTOFMEM);
+  expect_mapped_exception(
+      std::make_exception_ptr(std::runtime_error{"transport failure"}),
+      QDMI_ERROR_FATAL);
+  expect_mapped_exception(std::make_exception_ptr(42), QDMI_ERROR_FATAL);
+}
+
+TEST_F(DeviceJobMockTest, JobSubmissionRejectsResponsesWithoutJobId) {
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+
+  http_stub.queue_post(200, R"({"queue_position": 3})");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+
+  http_stub.queue_post(200, R"({"id": )");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+
+  // An unreadable submission response says nothing about the remote job, so
+  // the handle stays usable and can be submitted again.
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+}
+
+TEST_F(DeviceJobMockTest, MalformedProgramSubmissionReturnsAnErrorCode) {
+  const auto *const invalid_circuit = R"({"invalid": json})";
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(invalid_circuit) + 1, invalid_circuit),
+            QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  const auto *const invalid_dd_strategy = R"({"strategy": )";
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job,
+                // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
+                static_cast<QDMI_Device_Job_Parameter>(
+                    QDMI_DEVICE_JOB_PARAMETER_CUSTOM5 + 3),
+                strlen(invalid_dd_strategy) + 1, invalid_dd_strategy),
+            QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+}
+
+TEST_F(DeviceJobMockTest, JobStatusRejectsResponsesWithoutStatus) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  http_stub.queue_get(200, R"({"id": "job-123"})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_ERROR_FATAL);
+
+  http_stub.queue_get(200, R"({"status": )");
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_ERROR_FATAL);
+
+  // An unreadable status response does not decide the fate of the job.
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
+}
+
+TEST_F(DeviceJobMockTest, HistogramResultsRejectMalformedCountsResponses) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  const auto expect_rejected = [this](const std::string &counts) {
+    http_stub.queue_get(200, counts);
+    size_t size = 0;
+    EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                              nullptr, &size),
+              QDMI_ERROR_FATAL);
+  };
+
+  expect_rejected(R"([{"counts":{"0":1}}])");
+  expect_rejected(R"([{"measurement_keys":["m"]}])");
+  expect_rejected(R"([])");
+  expect_rejected(R"([{"measurement_keys":)");
+}
+
+TEST_F(DeviceJobMockTest, ShotResultsRejectMalformedMeasurementResponses) {
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 1;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  http_stub.queue_get(200, R"([{"measurement_keys":["m"],"counts":{"0":1}}])");
+  http_stub.queue_get(200, R"([{"m": [[0)");
+  size_t size = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_SHOTS, 0,
+                                            nullptr, &size),
+            QDMI_ERROR_FATAL);
+}
+
+TEST_F(DeviceJobMockTest, CalibrationResultsRejectMalformedStatusResponses) {
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CALIBRATION_CONFIG) + 1, TEST_CALIBRATION_CONFIG),
+            QDMI_SUCCESS);
+  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(format),
+                &format),
+            QDMI_SUCCESS);
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
+
+  const auto expect_rejected = [this](const std::string &calibration_status) {
+    http_stub.queue_get(200, calibration_status);
+    size_t size = 0;
+    EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_CUSTOM1, 0,
+                                              nullptr, &size),
+              QDMI_ERROR_FATAL);
+  };
+
+  expect_rejected(R"({"status":"ready"})");
+  expect_rejected(R"({"result":{"success":true}})");
+  expect_rejected(R"({"result":)");
+}
+
+// ============================================================================
 // JOB HANDLING TESTS
 // ============================================================================
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1879,6 +1879,51 @@ TEST_F(DeviceIntegrationMockTest,
 }
 
 TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationSelectsQuantumComputerByAliasOrId) {
+  const auto device_name = [](IQM_QDMI_Device_Session device_session) {
+    size_t name_size = 0;
+    EXPECT_EQ(
+        IQM_QDMI_device_session_query_device_property(
+            device_session, QDMI_DEVICE_PROPERTY_NAME, 0, nullptr, &name_size),
+        QDMI_SUCCESS);
+    std::string name(name_size, '\0');
+    EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                  device_session, QDMI_DEVICE_PROPERTY_NAME, name_size,
+                  name.data(), nullptr),
+              QDMI_SUCCESS);
+    // The queried size includes the terminator that the property writes.
+    name.resize(name_size - 1);
+    return name;
+  };
+
+  const std::string qc_alias = "default";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2,
+                qc_alias.size() + 1, qc_alias.c_str()),
+            QDMI_SUCCESS);
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_EQ(device_name(session), qc_alias);
+
+  IQM_QDMI_Device_Session session_by_id = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_alloc(&session_by_id), QDMI_SUCCESS);
+  const std::string base_url = "https://localhost";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session_by_id, QDMI_DEVICE_SESSION_PARAMETER_BASEURL,
+                base_url.size() + 1, base_url.c_str()),
+            QDMI_SUCCESS);
+  const std::string qc_id = "01966208-f3ec-73b7-890d-100000000000";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session_by_id, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
+                qc_id.size() + 1, qc_id.c_str()),
+            QDMI_SUCCESS);
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session_by_id), QDMI_SUCCESS);
+  EXPECT_EQ(device_name(session_by_id), qc_alias);
+  IQM_QDMI_device_session_free(session_by_id);
+}
+
+TEST_F(DeviceIntegrationMockTest,
        SessionInitializationRejectsIncompleteStaticArchitecture) {
   const auto expect_rejected = [this](const std::string &architecture) {
     http_stub.queue_get(200, list_quantum_computers_response);
@@ -1888,7 +1933,10 @@ TEST_F(DeviceIntegrationMockTest,
 
   expect_rejected(R"([{"connectivity":[["QB1","QB2"]]}])");
   expect_rejected(R"([{"qubits":["QB1","QB2"]}])");
+  // A short connectivity edge is an out-of-range array subscript rather than a
+  // missing key, and nlohmann does not assert on those at all.
   expect_rejected(R"([{"qubits":["QB1","QB2"],"connectivity":[["QB1"]]}])");
+  expect_rejected(R"([{"qubits":["QB1","QB2"],"connectivity":[[]]}])");
   // A truncated body must not escape as a parse error either.
   expect_rejected(R"([{"qubits":["QB1")");
 }
@@ -1995,6 +2043,10 @@ TEST_F(DeviceJobMockTest, JobSubmissionRejectsResponsesWithoutJobId) {
   http_stub.queue_post(200, R"({"queue_position": 3})");
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
 
+  // A job ID of the wrong type must be reported, not retyped.
+  http_stub.queue_post(200, R"({"id": 5})");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+
   http_stub.queue_post(200, R"({"id": )");
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
 
@@ -2039,6 +2091,9 @@ TEST_F(DeviceJobMockTest, JobStatusRejectsResponsesWithoutStatus) {
   http_stub.queue_get(200, R"({"id": "job-123"})");
   EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_ERROR_FATAL);
 
+  http_stub.queue_get(200, R"({"status": []})");
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_ERROR_FATAL);
+
   http_stub.queue_get(200, R"({"status": )");
   EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_ERROR_FATAL);
 
@@ -2068,6 +2123,10 @@ TEST_F(DeviceJobMockTest, HistogramResultsRejectMalformedCountsResponses) {
 
   expect_rejected(R"([{"counts":{"0":1}}])");
   expect_rejected(R"([{"measurement_keys":["m"]}])");
+  // Values of the wrong type must be reported rather than retyped.
+  expect_rejected(R"([{"measurement_keys":[0],"counts":{"0":4}}])");
+  expect_rejected(R"([{"measurement_keys":["m"],"counts":{"0":"many"}}])");
+  // An empty array is an out-of-range subscript on the leading result object.
   expect_rejected(R"([])");
   expect_rejected(R"([{"measurement_keys":)");
 }
@@ -2094,6 +2153,68 @@ TEST_F(DeviceJobMockTest, ShotResultsRejectMalformedMeasurementResponses) {
             QDMI_ERROR_FATAL);
 }
 
+TEST_F(DeviceJobMockTest, JobEntryPointsContainCxxExceptions) {
+  auto &hooks = iqm::http::internal::Get_hooks();
+  auto stub_get = hooks.get;
+  auto stub_post = hooks.post;
+  const auto throw_from_transport = [&](const std::exception_ptr &exception) {
+    hooks.get = [exception](const auto &, const auto &, const auto &,
+                            const auto &, const auto) -> cpr::Response {
+      std::rethrow_exception(exception);
+    };
+    hooks.post = [exception](const auto &, const auto &, const auto &,
+                             const auto &, const auto &,
+                             const auto) -> cpr::Response {
+      std::rethrow_exception(exception);
+    };
+  };
+  const auto restore_transport = [&]() {
+    hooks.get = stub_get;
+    hooks.post = stub_post;
+  };
+  const std::array<std::pair<std::exception_ptr, int>, 4> mappings{
+      {{std::make_exception_ptr(iqm::ClientAuthenticationError{"denied"}),
+        QDMI_ERROR_PERMISSIONDENIED},
+       {std::make_exception_ptr(std::bad_alloc{}), QDMI_ERROR_OUTOFMEM},
+       {std::make_exception_ptr(std::runtime_error{"transport failure"}),
+        QDMI_ERROR_FATAL},
+       {std::make_exception_ptr(42), QDMI_ERROR_FATAL}}};
+
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  for (const auto &[exception, expected_status] : mappings) {
+    throw_from_transport(exception);
+    EXPECT_EQ(IQM_QDMI_device_job_submit(job), expected_status);
+  }
+
+  restore_transport();
+  http_stub.queue_post(200, R"({"id": "job-123"})");
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  for (const auto &[exception, expected_status] : mappings) {
+    throw_from_transport(exception);
+    EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), expected_status);
+    EXPECT_EQ(IQM_QDMI_device_job_cancel(job), expected_status);
+  }
+
+  restore_transport();
+  http_stub.queue_get(200, R"({"status": "ready"})");
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
+
+  for (const auto &[exception, expected_status] : mappings) {
+    throw_from_transport(exception);
+    size_t size = 0;
+    EXPECT_EQ(IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                              nullptr, &size),
+              expected_status);
+  }
+  restore_transport();
+}
+
 TEST_F(DeviceJobMockTest, CalibrationResultsRejectMalformedStatusResponses) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
@@ -2104,6 +2225,8 @@ TEST_F(DeviceJobMockTest, CalibrationResultsRejectMalformedStatusResponses) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(format),
                 &format),
             QDMI_SUCCESS);
+  http_stub.queue_post(200, R"({"id": )");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
   http_stub.queue_post(200, R"({"id": "job-123"})");
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
   http_stub.queue_get(200, R"({"status": "ready"})");


### PR DESCRIPTION
🤖 *AI text below* 🤖

`src/iqm_device.cpp` reads fields out of parsed IQM responses without checking they exist. The parsed responses are `const`, so an expression like `qc["id"].get<std::string>()` resolves to nlohmann's *const* `operator[]`, which is documented as undefined behavior for a missing key. Under a Debug build that trips nlohmann's internal assertion and aborts, which is loud and survivable. Under the shipped Release configuration `NDEBUG` compiles the assertion out and the very same expression performs an out-of-bounds read instead — silent memory unsafety in the deployed library, triggered by nothing more than IQM renaming a field. No `try`/`catch` helps here, because nothing throws.

Out-of-range *array* subscripts are the same bug without even the Debug-build warning. `connectivity[i][0]` on an edge that carries fewer than two sites, and `job_results_json_response[0]` on an empty measurement-counts array, land in `std::vector::operator[]`, where nlohmann has no assertion of its own. A fuzzing exploration over these response shapes reports `AddressSanitizer: heap-buffer-overflow, READ of size 1` for `"connectivity": [["QB2"]]` and `reference binding to null pointer` for `"connectivity": [[]]`, and reaches the second one through the public `IQM_QDMI_device_job_get_results` with a two-byte response body.

The second failure mode is the roughly dozen bare `nlohmann::json::parse(...)` calls on response bodies, and the `get<T>()` conversions that follow them. A truncated body throws `nlohmann::json::parse_error`; a field of the wrong type throws `nlohmann::json::type_error`. Both propagate straight out through the QDMI C ABI. Propagating a C++ exception through a C function pointer is undefined behavior, and in practice it calls `std::terminate` and takes the caller's process down instead of returning an error code. `IQM_QDMI_device_job_submit`, `_job_check`, `_job_cancel`, and `_job_get_results` have no handler at all today, and each has a demonstrated escape: a numeric `id` in a submission response, a non-string `status`, a non-JSON status body, and non-string `measurement_keys` or a non-numeric count in a results body.

This is not a hypothetical failure mode for this project: #169 landed because IQM renamed RunRequest fields. Schema drift has already happened here once, and the shipped configuration currently answers it with memory unsafety.

The first half of this PR replaces every unchecked read on a server response with a checked one — array subscripts as well as object keys. Required fields are read with `at()`, genuinely optional ones stay behind `contains()`/`value()`, and response bodies are parsed with the non-throwing `parse(..., nullptr, false)` overload followed by an `is_discarded()` check, the shape `Get_queue_length` already established in this file. One deliberate loosening comes with it: a calibration observation that omits `invalid` is now treated as valid rather than read out of bounds, since only observations explicitly marked invalid should be skipped. Everything else that is missing is an error.

The second half extends the exception guarding that #175 introduced on `IQM_QDMI_device_session_init` to every remaining exported entry point that performs network I/O: `IQM_QDMI_device_job_submit`, `_cancel`, `_check`, `_get_results`, and `IQM_QDMI_device_session_query_device_property`. That is where an exception can actually originate, since those are the functions that fetch a bearer token, talk to the server, and parse what comes back. The remaining entry points are deliberately left alone: `_initialize`, `_finalize`, `_session_alloc`, `_session_free`, `_session_set_parameter`, `_session_create_device_job`, `_job_free`, `_job_set_parameter`, `_session_query_site_property`, and `_session_query_operation_property` perform no I/O and no JSON handling, so their only possible exception is `std::bad_alloc` from a small allocation. `IQM_QDMI_device_job_query_property` and `IQM_QDMI_device_job_wait` reach the network only by delegating to the now-guarded `IQM_QDMI_device_job_check`, so they need nothing of their own. Guarding the allocation-only entry points too would be defensible, but it is a separate concern from schema drift and would have made this diff harder to review; happy to add it here if you would rather have the boundary be uniform.

On style: I considered a small `Guard(lambda)` helper to avoid repeating the same four-line catch chain, and decided against it. Applying it would mean either reindenting each entry point's body into a lambda, which makes the diff enormous and buries the actual change, or splitting each entry point into a thin wrapper plus a renamed implementation function, which doubles the function count. It would also leave two different idioms in the same file, since #175 and #160 already use the explicit function-try-block. As written, each guarded function costs one keyword on its signature line and six lines at the end, and the body is untouched. Push back if you would prefer the helper.

One behavioral note worth flagging: the new malformed-response branches return an error code without marking the job `FAILED`. A response we could not parse says nothing about the state of the job on the server, and the caller can retry. Existing status transitions are untouched.

The new tests fail against `main`. Most abort outright under the Debug build:

```
unit_tests: json.hpp:2174: const_reference basic_json<>::operator[](const key_type&) const:
Assertion `it != m_data.m_value.object->end()' failed.
```

The out-of-range subscript cases do not reach that assertion at all — they trip libstdc++'s container hardening instead (`Assertion '__n < this->size()' failed`), which is equally absent from a Release build. The rest escape as C++ exceptions through the QDMI entry points (`C++ exception with description "[json.exception.type_error.302] type must be string, but is number" thrown in the test body`); GoogleTest's catch-all reports those as failures, but a real C consumer gets `std::terminate` instead. `uvx nox -s lint` is clean, `clang-tidy` reports no findings on either changed file, all 104 unit tests pass, and every changed line in `src/iqm_device.cpp` is covered by the unit suite.
