### PR TITLE
⬆️ Consume the MQT Core 3.9.0 and QDMI 1.3.3 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,9 @@ releases may include breaking changes.
 - ⬆️ Update MQT Core to 3.9.0, moving to its `mqt.core.qdmi.driver` namespace
   and its explicit sampler and estimator shot and precision defaults ([#195])
   ([**@marcelwa**])
-- ⬆️ Pin QDMI to the released v1.3.3 tag instead of a `develop` commit, and
-  publish the device target's stable ID and symbol prefix through QDMI's
-  `configure_qdmi_device_target` ([#195]) ([**@marcelwa**])
+- ⬆️ Update QDMI to v1.3.3, and publish the device target's stable ID and symbol
+  prefix through QDMI's `configure_qdmi_device_target` ([#195])
+  ([**@marcelwa**])
 - ⚡️ Reuse HTTP connections within each QDMI device session to reduce TCP/TLS
   setup during initialization and subsequent requests ([#163])
   ([**@burgholzer**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
+- ✅ Cover the device's queue length, a queued job's position, retrieval of an
+  existing job by ID, and calibration-format advertisement through MQT Core's
+  Python QDMI API ([#195]) ([**@marcelwa**])
 - 👷 Add an `IQM_QDMI_SANITIZERS` CMake option for building with
   AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer, or
   MemorySanitizer, and run the C++ test suite under ASan and UBSan in CI
@@ -50,6 +53,12 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⬆️ Update MQT Core to 3.9.0, moving to its `mqt.core.qdmi.driver` namespace
+  and its explicit sampler and estimator shot and precision defaults ([#195])
+  ([**@marcelwa**])
+- ⬆️ Pin QDMI to the released v1.3.3 tag instead of a `develop` commit, and
+  publish the device target's stable ID and symbol prefix through QDMI's
+  `configure_qdmi_device_target` ([#195]) ([**@marcelwa**])
 - ⚡️ Reuse HTTP connections within each QDMI device session to reduce TCP/TLS
   setup during initialization and subsequent requests ([#163])
   ([**@burgholzer**])
@@ -179,6 +188,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#195]: https://github.com/iqm-finland/QDMI-on-IQM/pull/195
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Added
 
 - ✅ Cover the device's queue length, a queued job's position, retrieval of an
-  existing job by ID, and calibration-format advertisement through MQT Core's
+  existing job by ID, and its advertised program formats through MQT Core's
   Python QDMI API ([#195]) ([**@marcelwa**])
 - 👷 Add an `IQM_QDMI_SANITIZERS` CMake option for building with
   AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer, or

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -27,7 +27,7 @@ else()
       CACHE STRING "Minimum QDMI version")
   set(QDMI_VERSION 1.3.3
       CACHE STRING "QDMI version")
-  set(QDMI_REV "e80020f7ace5c0a716142378c812f30f86263c4e" # QDMI develop
+  set(QDMI_REV "18cfb67fd9042761d3005c2f8655751c1758f9c5" # v1.3.3
       CACHE STRING "QDMI identifier (tag, branch or commit hash)")
   set(QDMI_REPO_OWNER "Munich-Quantum-Software-Stack"
       CACHE STRING "QDMI repository owner (change when using a fork)")

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,7 +43,7 @@ These are installed when users request the `qiskit` extra via
 
 | Dependency | Version | License     | Purpose                                                                  |
 | :--------- | :------ | :---------- | :----------------------------------------------------------------------- |
-| [MQT Core] | ~=3.8.0 | MIT License | QDMI-aware Qiskit provider, backend, sampler, and estimator integrations |
+| [MQT Core] | ~=3.9.0 | MIT License | QDMI-aware Qiskit provider, backend, sampler, and estimator integrations |
 | [Qiskit]   | ≥1.1    | Apache-2.0  | Quantum circuit construction, transpilation, and primitive interfaces    |
 
 ## End-to-End Example Dependencies

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -225,19 +225,3 @@ print(job.check())
 ```
 
 A retrieved job cannot be resubmitted, and its parameters cannot be changed.
-
-### Triggering a Calibration Run
-
-Where the quantum computer supports it, the device advertises
-`ProgramFormat.CALIBRATION` among its supported program formats, and
-`submit_calibration_job` starts a run. A calibration run executes no circuit, so
-it takes no shot count, and the optional payload is a configuration for the run:
-
-```python
-job = device.submit_calibration_job()
-```
-
-```{warning}
-A calibration run is a real operation on a shared quantum computer. Trigger one
-only with the operator's agreement.
-```

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -177,3 +177,67 @@ qc.measure_all()
 counts = sample(qc, shots=512, simulator=True)
 print("Counts:", counts)
 ```
+
+## Querying the Device Directly
+
+The Qiskit backend covers circuit execution, but a QDMI device also answers
+questions about itself. Open a session with MQT Core's driver to reach them.
+Constructing an {py:class}`~iqm.qdmi.qiskit.IQMBackend` registers the device
+under the stable ID {py:data}`~iqm.qdmi.IQM_QDMI_DEVICE_ID`, after which
+`open_device` resolves it:
+
+```python
+from mqt.core.qdmi.driver import open_device
+
+from iqm.qdmi import IQM_QDMI_DEVICE_ID
+
+device = open_device(IQM_QDMI_DEVICE_ID, token="…", custom2="emerald")
+
+print(device.status())
+print(device.supported_program_formats())
+```
+
+### Queue Length and Queue Position
+
+The device reports how busy the quantum computer is, so a client can decide
+whether to submit now or wait:
+
+```python
+waiting = device.queue_length()  # jobs waiting, excluding those executing
+```
+
+`queue_length()` returns `None` when the IQM API does not supply a trustworthy
+value. A queued job reports how many jobs are ahead of it; querying it refreshes
+the job's status first:
+
+```python
+ahead = job.queue_position  # None once the job is no longer queued
+```
+
+### Retrieving an Existing Job
+
+A job outlives the session that submitted it. Given its ID, a later session can
+pick it up again to poll, wait, cancel, or fetch results:
+
+```python
+job = device.retrieve_job_by_id("d3416f0a-…")
+print(job.check())
+```
+
+A retrieved job cannot be resubmitted, and its parameters cannot be changed.
+
+### Triggering a Calibration Run
+
+Where the quantum computer supports it, the device advertises
+`ProgramFormat.CALIBRATION` among its supported program formats, and
+`submit_calibration_job` starts a run. A calibration run executes no circuit, so
+it takes no shot count, and the optional payload is a configuration for the run:
+
+```python
+job = device.submit_calibration_job()
+```
+
+```{warning}
+A calibration run is a real operation on a shared quantum computer. Trigger one
+only with the operator's agreement.
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -202,7 +202,7 @@ runtime-copy helper to synthesize a relocatable manifest and colocate it with
 the device library beside the executable:
 
 ```cmake
-find_package(mqt-core 3.8 CONFIG REQUIRED)
+find_package(mqt-core 3.9 CONFIG REQUIRED)
 find_package(iqm-qdmi-device CONFIG REQUIRED)
 
 add_executable(my-application main.cpp)

--- a/examples/mqt_bench.py
+++ b/examples/mqt_bench.py
@@ -37,18 +37,14 @@ import argparse
 import logging
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import numpy as np
 from mqt.bench import BenchmarkLevel, get_benchmark
-from mqt.core.plugins.qiskit.provider import QDMIProvider
+from mqt.core.plugins.qiskit.backend import QDMIBackend
 from mqt.core.plugins.qiskit.sampler import QDMISampler
 from qiskit.quantum_info import hellinger_fidelity
 
 from iqm.qdmi.qiskit import IQMBackend
-
-if TYPE_CHECKING:
-    from mqt.core.plugins.qiskit.backend import QDMIBackend
 
 log = logging.getLogger(__name__)
 
@@ -128,7 +124,7 @@ BENCHMARKS: dict[str, BenchmarkConfig] = {
 def _build_backend(backend_name: str) -> QDMIBackend:
     if backend_name == "iqm":
         return IQMBackend()
-    return QDMIProvider().get_backend("MQT Core DDSIM QDMI Device")
+    return QDMIBackend.from_device_id("mqt.ddsim.default")
 
 
 def _describe_result(key: str, counts: dict[str, int], num_qubits: int, shots: int) -> str:

--- a/examples/qsci_h2.py
+++ b/examples/qsci_h2.py
@@ -42,8 +42,8 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import scipy.linalg as sla
+from mqt.core.plugins.qiskit.backend import QDMIBackend
 from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-from mqt.core.plugins.qiskit.provider import QDMIProvider
 from mqt.core.plugins.qiskit.sampler import QDMISampler
 from pyscf import ao2mo, gto, scf
 from qiskit.compiler import transpile
@@ -93,7 +93,7 @@ def main() -> None:
     )
 
     log.info("Initialising '%s' backend...", args.backend)
-    backend = IQMBackend() if args.backend == "iqm" else QDMIProvider().get_backend("MQT Core DDSIM QDMI Device")
+    backend = IQMBackend() if args.backend == "iqm" else QDMIBackend.from_device_id("mqt.ddsim.default")
     log.info("Backend ready: '%s' | %d qubits", backend.name, backend.num_qubits)
 
     log.info("Setting up H2 problem (atom='%s', basis='%s')...", ATOM.strip(), BASIS)

--- a/examples/qsci_h2.py
+++ b/examples/qsci_h2.py
@@ -141,7 +141,7 @@ def main() -> None:
     )
 
     log.info("Running VQE (optimizer=L-BFGS-B, maxiter=%d, shots=%d)...", args.maxiter, args.shots)
-    estimator = QDMIEstimator(backend, options={"default_shots": args.shots})
+    estimator = QDMIEstimator(backend, default_shots=args.shots)
     vqe = VQE(estimator, ansatz, L_BFGS_B(maxiter=args.maxiter))
     result = vqe.compute_minimum_eigenvalue(operator=observable)
     optimal_parameters = result.optimal_parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 qiskit = [
-  "mqt-core~=3.8.0",
+  "mqt-core~=3.9.0",
   "qiskit[qasm3-import]>=1.1",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",
@@ -74,7 +74,7 @@ iqm-estimator = "iqm.qdmi.estimator:main"
 
 [dependency-groups]
 qiskit = [
-  "mqt-core~=3.8.0",
+  "mqt-core~=3.9.0",
   "qiskit[qasm3-import]>=1.1",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",

--- a/python/iqm/qdmi/_backends.py
+++ b/python/iqm/qdmi/_backends.py
@@ -19,18 +19,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from mqt.core.plugins.qiskit.backend import QDMIBackend
 from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-from mqt.core.plugins.qiskit.provider import QDMIProvider
 from mqt.core.plugins.qiskit.sampler import QDMISampler
 
 from iqm.qdmi.qiskit import IQMBackend
 
-if TYPE_CHECKING:
-    from mqt.core.plugins.qiskit.backend import QDMIBackend
-
-_SIMULATOR_DEVICE = "MQT Core DDSIM QDMI Device"
+_SIMULATOR_DEVICE_ID = "mqt.ddsim.default"
 
 #: Optimization level used whenever a circuit is transpiled for execution
 #: (offloader local path and the `iqm-sampler` Slurm worker), so the two
@@ -45,18 +40,18 @@ def build_sampler(
     tokens_file: str | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
-) -> tuple[QDMIBackend, QDMISampler]:
-    """Build the backend and Sampler primitive to use for a sampling job.
+) -> QDMISampler:
+    """Build the Sampler primitive to use for a sampling job.
 
     Returns:
-        A tuple of the resolved backend and a Sampler primitive bound to it.
+        A Sampler primitive bound to the resolved backend, which it exposes as
+        its `backend` property.
     """
     if simulator:
-        backend = QDMIProvider().get_backend(_SIMULATOR_DEVICE)
-        return backend, QDMISampler(backend)
+        return QDMISampler(QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID))
 
     backend = IQMBackend(base_url=base_url, tokens_file=tokens_file, qc_id=qc_id, qc_alias=qc_alias)
-    return backend, backend.sampler()
+    return backend.sampler()
 
 
 def build_estimator(
@@ -66,15 +61,15 @@ def build_estimator(
     tokens_file: str | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
-) -> tuple[QDMIBackend, QDMIEstimator]:
-    """Build the backend and Estimator primitive to use for a VQE estimation job.
+) -> QDMIEstimator:
+    """Build the Estimator primitive to use for a VQE estimation job.
 
     Returns:
-        A tuple of the resolved backend and an Estimator primitive bound to it.
+        An Estimator primitive bound to the resolved backend, which it exposes
+        as its `backend` property.
     """
     if simulator:
-        backend = QDMIProvider().get_backend(_SIMULATOR_DEVICE)
-        return backend, QDMIEstimator(backend)
+        return QDMIEstimator(QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID))
 
     backend = IQMBackend(base_url=base_url, tokens_file=tokens_file, qc_id=qc_id, qc_alias=qc_alias)
-    return backend, backend.estimator()
+    return backend.estimator()

--- a/python/iqm/qdmi/_backends.py
+++ b/python/iqm/qdmi/_backends.py
@@ -19,11 +19,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mqt.core.plugins.qiskit.backend import QDMIBackend
-from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-from mqt.core.plugins.qiskit.sampler import QDMISampler
 
 from iqm.qdmi.qiskit import IQMBackend
+
+if TYPE_CHECKING:
+    from mqt.core.plugins.qiskit.estimator import QDMIEstimator
+    from mqt.core.plugins.qiskit.sampler import QDMISampler
 
 _SIMULATOR_DEVICE_ID = "mqt.ddsim.default"
 
@@ -48,7 +52,7 @@ def build_sampler(
         its `backend` property.
     """
     if simulator:
-        return QDMISampler(QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID))
+        return QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID).sampler()
 
     backend = IQMBackend(base_url=base_url, tokens_file=tokens_file, qc_id=qc_id, qc_alias=qc_alias)
     return backend.sampler()
@@ -69,7 +73,7 @@ def build_estimator(
         as its `backend` property.
     """
     if simulator:
-        return QDMIEstimator(QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID))
+        return QDMIBackend.from_device_id(_SIMULATOR_DEVICE_ID).estimator()
 
     backend = IQMBackend(base_url=base_url, tokens_file=tokens_file, qc_id=qc_id, qc_alias=qc_alias)
     return backend.estimator()

--- a/python/iqm/qdmi/estimator.py
+++ b/python/iqm/qdmi/estimator.py
@@ -70,7 +70,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     with Path(args.observable).open("rb") as file_obj:
         observable: SparsePauliOp = pickle.load(file_obj)  # ruff:ignore[suspicious-pickle-usage]
 
-    _, estimator = build_estimator(
+    estimator = build_estimator(
         simulator=args.simulator,
         base_url=args.base_url,
         tokens_file=args.tokens_file,

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -303,8 +303,8 @@ def sample(
         )
         raise ImportError(msg) from _IMPORT_ERROR
     if local:
-        backend, sampler = build_sampler(simulator=simulator)
-        qc_for_execution = transpile(qc, backend, optimization_level=TRANSPILE_OPTIMIZATION_LEVEL)
+        sampler = build_sampler(simulator=simulator)
+        qc_for_execution = transpile(qc, sampler.backend, optimization_level=TRANSPILE_OPTIMIZATION_LEVEL)
         job = sampler.run([(qc_for_execution,)], shots=shots)
         first_pub = _first_pub(cast("Iterable[PubResult]", job.result()))
         return extract_counts(first_pub)
@@ -411,7 +411,7 @@ def estimate(
         )
         raise ImportError(msg) from _IMPORT_ERROR
     if local:
-        _, estimator = build_estimator(simulator=simulator)
+        estimator = build_estimator(simulator=simulator)
         vqe = VQE(estimator, ansatz, L_BFGS_B(maxiter=maxiter))
         return vqe.compute_minimum_eigenvalue(operator=operator)
 

--- a/python/iqm/qdmi/qiskit.py
+++ b/python/iqm/qdmi/qiskit.py
@@ -21,13 +21,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
 
 try:
-    from mqt.core.fomac import DeviceDefinition, open_device, register_device_if_absent
     from mqt.core.plugins.qiskit.backend import QDMIBackend
-    from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-    from mqt.core.plugins.qiskit.sampler import QDMISampler
+    from mqt.core.qdmi.driver import DeviceDefinition, open_device, register_device_if_absent
 except ImportError as e:
     msg = (
         "Failed to import Qiskit plugin. "
@@ -95,21 +92,3 @@ class IQMBackend(QDMIBackend):
             custom2=resolved_qc_alias,
         )
         super().__init__(device=device)
-
-    def sampler(
-        self,
-        *,
-        default_shots: int = 1024,
-        options: dict[str, Any] | None = None,
-    ) -> QDMISampler:
-        """Returns SamplerV2 primitive bound to this backend."""
-        return QDMISampler(self, default_shots=default_shots, options=options)
-
-    def estimator(
-        self,
-        *,
-        default_precision: float = 0.0,
-        options: dict[str, Any] | None = None,
-    ) -> QDMIEstimator:
-        """Returns an EstimatorV2 primitive bound to this backend."""
-        return QDMIEstimator(self, default_precision=default_precision, options=options)

--- a/python/iqm/qdmi/sampler.py
+++ b/python/iqm/qdmi/sampler.py
@@ -62,7 +62,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     with Path(args.circuit).open("rb") as file_obj:
         circuit = qpy.load(file_obj)[0]
 
-    backend, sampler = build_sampler(
+    sampler = build_sampler(
         simulator=args.simulator,
         base_url=args.base_url,
         tokens_file=args.tokens_file,
@@ -70,7 +70,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         qc_alias=args.qc_alias,
     )
 
-    circuit_for_execution = transpile(circuit, backend, optimization_level=TRANSPILE_OPTIMIZATION_LEVEL)
+    circuit_for_execution = transpile(circuit, sampler.backend, optimization_level=TRANSPILE_OPTIMIZATION_LEVEL)
     job = sampler.run([(circuit_for_execution,)], shots=args.shots)
     pickled = pickle.dumps(job.result())
     print(base64.b64encode(pickled).decode("utf-8"))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,13 +50,8 @@ target_link_libraries(
 
 # Publish the metadata consumers need to identify this separately built QDMI
 # device target and synthesize a relocatable manifest.
-set_target_properties(
-  ${QDMI_TARGET_NAME} PROPERTIES QDMI_DEVICE_ID iqm.default QDMI_DEVICE_PREFIX
-                                                            ${QDMI_PREFIX})
-set_property(
-  TARGET ${QDMI_TARGET_NAME}
-  APPEND
-  PROPERTY EXPORT_PROPERTIES QDMI_DEVICE_ID QDMI_DEVICE_PREFIX)
+configure_qdmi_device_target(TARGET ${QDMI_TARGET_NAME} ID iqm.default PREFIX
+                             ${QDMI_PREFIX})
 
 set(IQM_QDMI_CONFIG_INSTALL_DIR
     "${CMAKE_INSTALL_DATADIR}/cmake/${QDMI_TARGET_NAME}"

--- a/test/python/test_device_capabilities.py
+++ b/test/python/test_device_capabilities.py
@@ -15,12 +15,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Tests for device capabilities reached through MQT Core's QDMI client API.
+"""Tests for the device's queue, job-retrieval, and calibration capabilities.
 
-The device implements queue reporting, retrieval of an existing job by its ID,
-and calibration jobs. MQT Core 3.9.0 is the first release whose Python API
-reaches all three, so these tests cover the seam between the two packages
-rather than the device internals, which `test/unit/` already covers.
+These drive the device through MQT Core's Python QDMI client, the way an
+application reaches it. `test/unit/` covers the same properties at the C API
+level, against a stubbed server.
 """
 
 from __future__ import annotations
@@ -88,10 +87,9 @@ def circuit() -> QuantumCircuit:
 def test_device_advertises_exactly_its_supported_formats(device: Device) -> None:
     """The device should advertise QIR and IQM JSON, and calibration where supported.
 
-    Calibration is the only optional format. It is advertised when the quantum
-    computer's API reports calibration support, which is what makes
-    `Device.submit_calibration_job` usable against this device at all. No test
-    calls it: a calibration run is a real operation on shared hardware.
+    Calibration is the only optional format; the device advertises it when the
+    quantum computer's API reports calibration support. No test submits one,
+    because a calibration run is a real operation on shared hardware.
     """
     formats = set(device.supported_program_formats())
 

--- a/test/python/test_device_capabilities.py
+++ b/test/python/test_device_capabilities.py
@@ -15,8 +15,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# pyright: reportArgumentType=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportMissingImports=false, reportMissingModuleSource=false, reportMissingTypeStubs=false
-
 """Tests for device capabilities reached through MQT Core's QDMI client API.
 
 The device implements queue reporting, retrieval of an existing job by its ID,

--- a/test/python/test_device_capabilities.py
+++ b/test/python/test_device_capabilities.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025 - 2026 IQM Finland Oy
+# All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://github.com/iqm-finland/QDMI-on-IQM/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# pyright: reportArgumentType=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportMissingImports=false, reportMissingModuleSource=false, reportMissingTypeStubs=false
+
+"""Tests for device capabilities reached through MQT Core's QDMI client API.
+
+The device implements queue reporting, retrieval of an existing job by its ID,
+and calibration jobs. MQT Core 3.9.0 is the first release whose Python API
+reaches all three, so these tests cover the seam between the two packages
+rather than the device internals, which `test/unit/` already covers.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from mqt.core.qdmi import Device, Job, ProgramFormat
+from mqt.core.qdmi.driver import open_device
+from qiskit.circuit import QuantumCircuit
+from qiskit.compiler import transpile
+
+from iqm.qdmi import IQM_QDMI_DEVICE_ID
+from iqm.qdmi.qiskit import IQMBackend
+
+# Every IQM quantum computer accepts these two.
+BASE_PROGRAM_FORMATS = {ProgramFormat.QIR_BASE_STRING, ProgramFormat.IQM_JSON}
+
+
+def _skip_without_iqm_access() -> None:
+    """Skip live tests when IQM credentials are unavailable."""
+    if not os.getenv("IQM_TOKEN") and not os.getenv("IQM_TOKENS_FILE"):
+        pytest.skip(
+            "Either IQM_TOKEN or IQM_TOKENS_FILE environment variable must be set to run live IQM backend tests."
+        )
+
+
+@pytest.fixture
+def backend() -> IQMBackend:
+    """Returns the IQM backend, which also registers the device."""
+    _skip_without_iqm_access()
+    return IQMBackend()
+
+
+@pytest.fixture
+def device(backend: IQMBackend) -> Device:
+    """Returns a fresh device session over the registration the backend made.
+
+    Constructing the backend registers `iqm.default`, so opening it here needs
+    only the credentials. It resolves the same environment the backend resolves.
+    """
+    tokens_file = os.getenv("IQM_TOKENS_FILE")
+    del backend
+    return open_device(
+        IQM_QDMI_DEVICE_ID,
+        base_url=os.getenv("IQM_BASE_URL") or None,
+        token=os.getenv("IQM_TOKEN"),
+        auth_file=Path(tokens_file) if tokens_file else None,
+        custom1=os.getenv("IQM_QC_ID"),
+        custom2=os.getenv("IQM_QC_ALIAS"),
+    )
+
+
+@pytest.fixture
+def circuit() -> QuantumCircuit:
+    """Returns a simple Bell state circuit."""
+    circuit = QuantumCircuit(2)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure_all()
+    return circuit
+
+
+def test_device_advertises_exactly_its_supported_formats(device: Device) -> None:
+    """The device should advertise QIR and IQM JSON, and calibration where supported.
+
+    Calibration is the only optional format. It is advertised when the quantum
+    computer's API reports calibration support, which is what makes
+    `Device.submit_calibration_job` usable against this device at all. No test
+    calls it: a calibration run is a real operation on shared hardware.
+    """
+    formats = set(device.supported_program_formats())
+
+    assert formats in (BASE_PROGRAM_FORMATS, BASE_PROGRAM_FORMATS | {ProgramFormat.CALIBRATION})
+
+
+def test_device_reports_queue_length(device: Device) -> None:
+    """Querying the queue length should return a count or report no support."""
+    queue_length = device.queue_length()
+
+    assert queue_length is None or queue_length >= 0
+
+
+def test_retrieve_job_by_id_reaches_a_job_from_another_session(
+    circuit: QuantumCircuit, backend: IQMBackend, device: Device
+) -> None:
+    """A submitted job should be retrievable by ID from a separate session."""
+    transpiled_circuit = transpile(circuit, backend=backend)
+    submitted = backend.run(transpiled_circuit, shots=8)
+    job_id = submitted.job_id()
+
+    retrieved = device.retrieve_job_by_id(job_id)
+
+    assert retrieved.id == job_id
+    # A retrieved job is queryable; only submission and parameter changes are
+    # closed off.
+    assert retrieved.check() in set(Job.Status)
+
+
+def test_queue_position_is_reported_only_while_a_job_is_queued(
+    circuit: QuantumCircuit, backend: IQMBackend, device: Device
+) -> None:
+    """Querying a job's queue position should never raise, queued or not."""
+    transpiled_circuit = transpile(circuit, backend=backend)
+    submitted = backend.run(transpiled_circuit, shots=8)
+
+    retrieved = device.retrieve_job_by_id(submitted.job_id())
+    queue_position = retrieved.queue_position
+
+    assert queue_position is None or queue_position >= 0

--- a/test/python/test_qiskit_backend.py
+++ b/test/python/test_qiskit_backend.py
@@ -264,7 +264,7 @@ def test_iqm_backend_estimator(circuit: QuantumCircuit, backend: IQMBackend) -> 
     """The bound estimator should execute a simple observable on the live IQM backend."""
     observable = SparsePauliOp("Z" * backend.num_qubits)
     transpiled_circuit = transpile(circuit, backend=backend)
-    job = backend.estimator(options={"default_shots": 32}).run([(transpiled_circuit, observable)])
+    job = backend.estimator(default_shots=32).run([(transpiled_circuit, observable)])
     result = job.result()[0]
     expectation_value = float(result.data["evs"][()])
     standard_deviation = float(result.data["stds"][()])

--- a/test/python/test_qiskit_backend.py
+++ b/test/python/test_qiskit_backend.py
@@ -15,8 +15,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# pyright: reportArgumentType=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportMissingImports=false, reportMissingModuleSource=false, reportMissingTypeStubs=false
-
 """Tests for the Qiskit-facing IQM backend wrapper."""
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.8.0" },
+    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.9.0" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'qiskit'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.3.2" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1" },
@@ -1022,7 +1022,7 @@ provides-extras = ["qiskit"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mqt-core", specifier = "~=3.8.0" },
+    { name = "mqt-core", specifier = "~=3.9.0" },
     { name = "nox", specifier = ">=2026.4.10" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
@@ -1045,14 +1045,14 @@ docs = [
     { name = "sphinx-llm", specifier = ">=0.4.1" },
 ]
 qiskit = [
-    { name = "mqt-core", specifier = "~=3.8.0" },
+    { name = "mqt-core", specifier = "~=3.9.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "mqt-core", specifier = "~=3.8.0" },
+    { name = "mqt-core", specifier = "~=3.9.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
@@ -1320,34 +1320,43 @@ wheels = [
 
 [[package]]
 name = "mqt-core"
-version = "3.8.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/38/065fb5394e823213e7fbc2185139b8979f77c369d53e2b23ed9faf701a4f/mqt_core-3.8.0.tar.gz", hash = "sha256:d4babb5009b9f4c3d50211caf2cd8fc850c5ba97bfe47627446e2103253462e8", size = 798862, upload-time = "2026-07-30T11:00:04.607Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/03/1c635e3f8f1fec612c2084e02b3441db729c35d991cea2389004a16622b7/mqt_core-3.9.0.tar.gz", hash = "sha256:dc3d6dc0d8cadff1c82f8dffd8fcd9dcc7d07e3c56f2e08341b0586f012cf66c", size = 807188, upload-time = "2026-08-19T17:32:34.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/6a/4e503b1980861af6d9e8814839231059635fa0bbd5396580b6fffa363b44/mqt_core-3.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:074e6540c8db507b9f2124898681e28e8eac884b7e0651ac404642efe8308fc0", size = 5923197, upload-time = "2026-07-30T10:59:16.188Z" },
-    { url = "https://files.pythonhosted.org/packages/88/6a/d23553d0f29694a3af95a993091f7b3e0059a11b8f9f95cef8066021c5e4/mqt_core-3.8.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:9a77fabaa0e1d0dd05d3284f748928445920bf9de98f1784d3be8400d61d9d20", size = 6463531, upload-time = "2026-07-30T10:59:18.15Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/41/80338cfef72931f799d50fa13dea06974d91f9ac48097a8551f59be07407/mqt_core-3.8.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2f28eadc8648a81ad8542be5c8b13246893d6acddda8520c76a659397e6b48a", size = 8619340, upload-time = "2026-07-30T10:59:19.829Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/4a/cf5957b699c49a574c93622a0d60be7e9be346ba8d2aaa5ac16ed423e47a/mqt_core-3.8.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d060a3cbf7890679e2d195db5889c687393e8db4ada9b4c8eb5f608352ed5d4", size = 9122704, upload-time = "2026-07-30T10:59:21.954Z" },
-    { url = "https://files.pythonhosted.org/packages/96/c7/583b7e5b0efaa7970a8cde71b10c78001e635548398ebd1bc112dc5b37a1/mqt_core-3.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:91bbf8c4669faf9538f33cd05ad2e8ad2bbdcecab8ee387d36e8c5d6ebbbe6f4", size = 8890690, upload-time = "2026-07-30T10:59:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/09/0353203e75450b61e55ea08edf15ba398e9a0def78a4bff5dbaf9836cb9c/mqt_core-3.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:e15a7e2f5af311ed416363e3736914025dbd15fa936c2060d57eac69ebfb76cf", size = 8755273, upload-time = "2026-07-30T10:59:26.032Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/1d/019704bc4ef65073b52d6df5334111ef1409d2f9ad31e54162c8a9bfbdd9/mqt_core-3.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f46a302c3835410d381dc67e983c64daebdc3d2e3028c060dd9b6960e3c00084", size = 5922996, upload-time = "2026-07-30T10:59:28.044Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/f0/6da6f47ca9be2aecd6df1b6a95e51e79963abdee6daf1326ef9bb4ae2bcb/mqt_core-3.8.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:6f955f5915836588912c3bd937f5407f4787dc8700143f0d9cbdbf21d56dcd5d", size = 6463290, upload-time = "2026-07-30T10:59:29.549Z" },
-    { url = "https://files.pythonhosted.org/packages/66/fc/d802b81e5f387222906b8fc7bf2a90f2ad35bffcae5d7648cc2f10a6d228/mqt_core-3.8.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6afd9d88164c28c3581b67f1128e6f7a8a1b7caa5254c6c6c7449463896d9469", size = 8618894, upload-time = "2026-07-30T10:59:31.14Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/13/623188e259257f207a6304b2983d94b8624b8dd1a7f5ba8db430981cca96/mqt_core-3.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd4f5af2e5025c342c7fafabd3da20760da10259ffdc8ddb94f756649f8407c9", size = 9122519, upload-time = "2026-07-30T10:59:33.271Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b1/e51323c61b4f87ec132fa40a97d0bd09a11234db1da1a897e1c154f96cf1/mqt_core-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:07b576db58330df4ebe4f6d1cb1b191b2b51e74001ec2531ecd24b38b4f9caa2", size = 8890796, upload-time = "2026-07-30T10:59:35.47Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/62/c00011d1824f5502e82680ecdd41f29db2c939bb03daa892d4d9fc70a781/mqt_core-3.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:9c3890fd9c973c15aa613900c6b09261d7c2a9142b2f4396f993bf5eb91e92ad", size = 8754942, upload-time = "2026-07-30T10:59:38.183Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/34/53d1ce1e91f67f04159f150e2b95a56b5218ac57aff34df43c27ae1db297/mqt_core-3.8.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:95fb79da1b20091e30854a3df7cbe4a9dcf05559e9b8fcc7da9eb2a94532f306", size = 5915266, upload-time = "2026-07-30T10:59:40.084Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3b/cfc424187319a4296f60b284dc2f04dff2cd8675644dcd8baf9299449955/mqt_core-3.8.0-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:5f51bac17c06e9821bc683b6056d8f903cb69da9f49007e51f2437da280681ee", size = 6457283, upload-time = "2026-07-30T10:59:41.819Z" },
-    { url = "https://files.pythonhosted.org/packages/23/01/56f07166708741cb42ed5cf2cd20c211cb1d6e6a3defdea02592b36e98f0/mqt_core-3.8.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73a6c317672de4d6c2ace8b0ba90d0c315f4dbedb3d6bc545125f7f64060f2f6", size = 8601979, upload-time = "2026-07-30T10:59:43.619Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/8c/02b56ae87cba4e13ea647386eb01918aa20df7dcf88be78f061339e8f4b2/mqt_core-3.8.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9f7e8229c5b4d16723878a1479e0a72d71540311c9cae778ba0ee92b053e021", size = 9103875, upload-time = "2026-07-30T10:59:45.598Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c3/38cca4a2e3b5a3b6c7499a5cafaf2ca9641cea52350ae3af72e92abf71b2/mqt_core-3.8.0-cp312-abi3-win_amd64.whl", hash = "sha256:82285d6c507416c5ac72a774a48b9774076a4b0619009dd3c2cddfdd763e8399", size = 8881574, upload-time = "2026-07-30T10:59:47.61Z" },
-    { url = "https://files.pythonhosted.org/packages/97/32/f94326ec648af06ec03446b4ca8c7eb2f95d05f98e8d61cc5c59d1447f7c/mqt_core-3.8.0-cp312-abi3-win_arm64.whl", hash = "sha256:d55203e256ae24eb77de7287b9db70e7414b172894f7d664d8b97b6d646cd759", size = 8743120, upload-time = "2026-07-30T10:59:49.659Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6f/d134df84cf31dfb5802f973494ea7cf8e90facf648acf162ae6cd1b31fd9/mqt_core-3.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9982625ee26ae97757e9ff79fd05b51775cfcd21dee661cd4f5b1a806741482a", size = 5929425, upload-time = "2026-07-30T10:59:51.97Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b7/98ca3ef20e8d11eb7de6255412542833293e9fb5923a8961049df1ce55f1/mqt_core-3.8.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:43869178ba5ba181b80d612ca8b5ee012480c8f63331c7b051bada3740d4aabd", size = 6472802, upload-time = "2026-07-30T10:59:53.731Z" },
-    { url = "https://files.pythonhosted.org/packages/09/dd/7e0efe5d8951829be73a462b434d89ed3f11478bf1d4b91095b32c5fdced/mqt_core-3.8.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86a9eda4ddd33a996177c929f2990b47eddbc3998036061e8a4f9daaf9fbb2d7", size = 8620976, upload-time = "2026-07-30T10:59:55.592Z" },
-    { url = "https://files.pythonhosted.org/packages/47/7e/73d09410aaef55f013cb7748a1e694e454f142a70f53085adcd2eea8a38b/mqt_core-3.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd9f38caee1f30bf66e3dbbe53fee403817bd3190a02a40b773b09f4de7730b2", size = 9122076, upload-time = "2026-07-30T10:59:57.883Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/5c/10edf81250ca314fa01c0ccf7f9cbc94381f9a725b4e770ab4d6924660f3/mqt_core-3.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4679b94e2a166186883708cc937b40567ba42c3d379bfcded3a8cddae33be672", size = 8965499, upload-time = "2026-07-30T11:00:00.139Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/b9/017e6ccb3c84312b472bced475499394da3f84390fba3a01d0268340756f/mqt_core-3.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a166fe03fd5b60ebe038c4d17ef450f2583508be86db2f4f084f3d327572a34f", size = 8833359, upload-time = "2026-07-30T11:00:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1b/effdb5ec0b21818117a45718eedae2ffb944b2f93bb5c8e42f02d580df74/mqt_core-3.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c07549da619f32b0ec5fc5bdf168407a1eca8023d85db75c39643957dd3996a", size = 5985921, upload-time = "2026-08-19T17:31:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2c/4e09371868333ee323fbb1a85ca20667a93a95d6b13895a885dc0efad202/mqt_core-3.9.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:89318ab4a3dd102f5afd0094530dbb400b584d4cecb000c8f7cc7308a32c6059", size = 6436562, upload-time = "2026-08-19T17:31:23.794Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/2d/775d41bfd7d68e1a988f0d0c72c22b7b557aaf5d62ea37740aa604010719/mqt_core-3.9.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28635bac8a678ca31823a72bcd9348d70717ea669062434c0fa4a60e860b4506", size = 8670146, upload-time = "2026-08-19T17:31:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e8/1d558302bd3a24f0366a96a06e4f7b1539804b700e60c24f0863c2c97fef/mqt_core-3.9.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d8aae849c852a6cb26d64feb28bb1a5b7931a8dfc4139e3673aafc5ac12a890", size = 9199506, upload-time = "2026-08-19T17:31:28.513Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b5/9499fb0022a8af7cd89687106ded89a275b391b9f08848f2f58db33b137a/mqt_core-3.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:31391b78f2d7095f235a5ad0d6030a6a04dd57711f3ee1c564f8a9f924ed2a1d", size = 9171752, upload-time = "2026-08-19T17:31:31.168Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/24/7544735b9406d009038c3275bb1a3e417f3d6f18b77f3f9c5b2edde56b1e/mqt_core-3.9.0-cp310-cp310-win_arm64.whl", hash = "sha256:517212bba2574e7a2a4e367016f447a5d8a43936edcba31849d43870db08358f", size = 9022329, upload-time = "2026-08-19T17:31:33.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/97/38c827432f0a95eb0df1662aa262d7425645c892fb25622d7de71a3ffd05/mqt_core-3.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e3a60e3b4f19bdfdb17dae1052c6e1f80eb564882d9ba63b6b8a1d264568fa1", size = 5985966, upload-time = "2026-08-19T17:31:36.072Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ac/fac65887cf9afa2f94edd8b24f4f7627dfa50e2e08e072f2657bcb8ef741/mqt_core-3.9.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:1d8e7338a1628ba3a61020080f238d3fd5e1310994a076e2b0ab41561aea6c6f", size = 6436577, upload-time = "2026-08-19T17:31:38.336Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ae/e938a76a7b2a1fa0c0c69be6389101150e8ae46ae04a27ae20d591c538f2/mqt_core-3.9.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a3ed88e62e56b174fd9f4d3b1718417f6c39fe3d7cd9410be76943610f8b6e3", size = 8669782, upload-time = "2026-08-19T17:31:40.27Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ae/eb625bdef384df3a26ffa911c7f7fdfa1d7a6cf6e7a826f1b9099ff54831/mqt_core-3.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d08c346cd5a4342897b4478fba2b007352462299348a644019f2ed58a10c101", size = 9199357, upload-time = "2026-08-19T17:31:42.646Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/6ecc656ff53a982a390ccd7f12347ed48b65bb66165471f53623d7b4dc82/mqt_core-3.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:502c83c1a49570cecc74acda133ad9b9c46949c5a034032ec85df8c044c13c61", size = 9171934, upload-time = "2026-08-19T17:31:45.22Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/73/c941dc0fcdaf1187870937b3a81e06a51a8f2a6395bf7a54ad887af0f7cb/mqt_core-3.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:50397ef2ae92aea784fbfc16d9f449fa528ac4d8b8cebe3d8e345c43d88dfea7", size = 9022123, upload-time = "2026-08-19T17:31:47.548Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/dbf6ceb3acf623faefdb77faabfdfe4a6defaf093abb4e3c25f4caca8031/mqt_core-3.9.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a33e2790277376f2560788f86c9c2fe49468b9797911a09cc8e014842882554", size = 5978389, upload-time = "2026-08-19T17:31:49.834Z" },
+    { url = "https://files.pythonhosted.org/packages/04/27/18f5a287a61eb45335858de81d395465caf4c0762bf438d0ef333bbf890c/mqt_core-3.9.0-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:81ecb3613838326b22afeba1f55c2291df8ece05d6ff952d4d6d1f19040d716c", size = 6430547, upload-time = "2026-08-19T17:31:51.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/17/cdd2d3e6cc5a0835df468a58d88e2d43bef00730acbc7b69e89b63181f9a/mqt_core-3.9.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f43a6393e09b655ef3673a4d090ee5de8bfb69742af8c6279b7851d896d5a8e9", size = 8652637, upload-time = "2026-08-19T17:31:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6b/301a044282fa1b6cd71b5226c87393597badb247e3a3a01722cf0e276778/mqt_core-3.9.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d41d59abffd7784f2b346b93a8b39e20b5588d2025178ffe08fe0dc4e2637799", size = 9179700, upload-time = "2026-08-19T17:31:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/18ed0c753ba87049e080f35cb720d08b849e21a89e7d102fa849068fe0b3/mqt_core-3.9.0-cp312-abi3-win_amd64.whl", hash = "sha256:32d32e553f291c87f83417ccf394dd7ba9d10c91aaf308ae3a12ec89c326bf2b", size = 9163002, upload-time = "2026-08-19T17:32:01.008Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b8/079af2ae1501bb2984597161e583ea42260245f1817b1b36307337de26f3/mqt_core-3.9.0-cp312-abi3-win_arm64.whl", hash = "sha256:72ebed110d11bde895438c58dde16939d3451ff9ac0be50ef5ada024e523fe56", size = 9011828, upload-time = "2026-08-19T17:32:03.685Z" },
+    { url = "https://files.pythonhosted.org/packages/27/07/c2770c2c226d8de4f12c3e7549b592c5e73f2169813e4696c825f8aa2cfe/mqt_core-3.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eefd9a97f47ac781897d48b82040df8f58d6cbbcf161ed21a6ffb8ae93130106", size = 5992824, upload-time = "2026-08-19T17:32:06.345Z" },
+    { url = "https://files.pythonhosted.org/packages/af/52/2156ef2d77f7bb22023a5785ebc5a1c22813139961e2b7ba973a53f059bb/mqt_core-3.9.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:ea910d27a3176f02b501bd60f2ff0958de7986c99145bac65d468632640b18ef", size = 6445639, upload-time = "2026-08-19T17:32:08.265Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/fcc752312023bc7b9fdceefc1ea24efcc8d3fc5d27f99f50fc1236e49516/mqt_core-3.9.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66a1836f9101be6e1defb48f6a433268bb50f64c619847ffa91b24d818628d01", size = 8672164, upload-time = "2026-08-19T17:32:10.298Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6d/9f86ce8409aa6906b013eee03510cf7ae8419856292c3c609cf01ea5e0bd/mqt_core-3.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40bde33f7720a63cf789686225f8528fb4b5659c411acf40c55c38a126bf322e", size = 9199277, upload-time = "2026-08-19T17:32:12.947Z" },
+    { url = "https://files.pythonhosted.org/packages/88/80/3f3274d9ede1f7bbf03d4367ccb6dda244cbdafbc25951ca0a0fc55d7200/mqt_core-3.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:67263812bae94adc139a33755131ae91ee3e984aae2c472c095abc01c38d414a", size = 9250494, upload-time = "2026-08-19T17:32:15.344Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/81d1e21a7d0b181b33a0208feb9c3f2eab9cad87815147573166d5a1a3ed/mqt_core-3.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2245c0a9eb2973e7d7d1ba2dc1e0f4d64c946f2727072370c8a52c91dde3f79c", size = 9096296, upload-time = "2026-08-19T17:32:18.021Z" },
+    { url = "https://files.pythonhosted.org/packages/71/04/1867645f87d073e14bcae1d9a594b51e2a60b664bb04b2eb5892a498fd32/mqt_core-3.9.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:ce36c36c21069a1291df6051583aa36585e7f25fbc0ca14fbf05171ac4dca2ce", size = 5992762, upload-time = "2026-08-19T17:32:20.29Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/aa/d8ad8cc8cbaf8d5c2e6b5e791059291680dc1234dad0c07747753f7feea6/mqt_core-3.9.0-cp315-cp315t-macosx_11_0_x86_64.whl", hash = "sha256:d6bf5222e0094b9a49f19d96e198ebf50fb5de4480d6db305320183f8d4b30cb", size = 6445646, upload-time = "2026-08-19T17:32:22.5Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/23f70934e579137353757b218770a31df54691fb8469ddccfff3e211f56f/mqt_core-3.9.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cbaa10e58f555d7ff55c5f911981f789f4eb52109b522bcc4a92e6e301cdcaec", size = 8672144, upload-time = "2026-08-19T17:32:25.051Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8c/6089b263ea426542053885a8f71e4cb60bc7f18246f812f33e013f80a97f/mqt_core-3.9.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd0f74ced269b443bd1fa6449bff5e38b27102c98a74d30a8aa73748982e4158", size = 9199285, upload-time = "2026-08-19T17:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/60a850a5001af0cb82fd29b2049d8adcba11a048ebb554fac28185b9e0d9/mqt_core-3.9.0-cp315-cp315t-win_amd64.whl", hash = "sha256:49ce7a96022d5b804a6cd0e82013acf6f9ca4e370b218793aa49d9264f2bc83b", size = 9250247, upload-time = "2026-08-19T17:32:30.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/89/71bf4ea74646cdea62f2eba052f89a0f885fea2315f2faef4f6ab6cf13d2/mqt_core-3.9.0-cp315-cp315t-win_arm64.whl", hash = "sha256:052bd33e9efccdbeb8465cf64b030b4a3dfcd3ad46ee7eef6d01acf4ce0354e9", size = 9096309, upload-time = "2026-08-19T17:32:32.712Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Takes the MQT Core 3.9.0 and QDMI 1.3.3 releases (both 2026-08-19), adopts what they newly expose, and tests the seam.

### MQT Core 3.8.0 → 3.9.0

Two of its changes break this repo.

- **`mqt.core.fomac` → `mqt.core.qdmi.driver`** (#2074). The old module still works but emits a `DeprecationWarning`, and `[tool.pytest]` sets `filterwarnings = ["error"]`. On 3.9.0 that import fails collection across the whole Python suite.
- **`QDMISampler` and `QDMIEstimator` lost their `options` mapping** in favour of explicit shot and precision defaults (#2084). `IQMBackend.sampler` and `IQMBackend.estimator` are removed rather than rewritten: the inherited methods have the same signatures, and the inherited `estimator` also accepts `default_shots`. The two callers that passed `options={"default_shots": …}` now pass `default_shots=`.

Checked rather than assumed, and not applicable here: there is no `[tool.qdmi]` table to migrate to `qdmi.json`, and no `libmqt-core-*.so.3.8` entry in any wheel-repair config, so the SOVERSION note does not bite. `MQT::CoreFoMaC` and the C++ `fomac::` namespace are unchanged in 3.9.0, so `docs/usage.md` keeps that target name.

### QDMI → the released v1.3.3 tag

`QDMI_REV` pointed at a `develop` commit that predates the release. The tag is 13 commits ahead of it and all 13 are maintenance — renovate, lockfiles, docs, pre-commit sync — so the interface is identical and this is a provenance fix. `#485`, `#486`, and `#475` were already in the pinned commit.

1.3.3 also adds `configure_qdmi_device_target`, which replaces the block in `src/CMakeLists.txt` that set `QDMI_DEVICE_ID` and `QDMI_DEVICE_PREFIX` and appended them to `EXPORT_PROPERTIES` by hand. The function body is those same two calls plus argument validation.

I did not adopt the template's overridable `<PREFIX>_QDMI_DEVICE_ID` cache variable. `iqm.default` is also hard-coded in `python/iqm/qdmi/__init__.py`, and a settable CMake ID would let the two drift.

### New coverage

The device already reports its queue length and a queued job's position (#172), retrieves an existing job by ID (#160), and accepts calibration jobs. MQT Core 3.9.0 is the first release whose Python API reaches all of them, so `test/python/test_device_capabilities.py` covers that seam. The device internals are already covered under `test/unit/`.

**No test submits a calibration run.** That is a real operation on a shared quantum computer, and CD passes `IQM_TOKEN` into the wheel tests, so a live call would fire on every wheel job. The tests assert only that the device advertises `ProgramFormat.CALIBRATION`.

`QDMIBackend.device` is private in 3.9.0, so the tests reach the device through `mqt.core.qdmi.driver.open_device` — the same call `IQMBackend.__init__` makes.

`docs/python_package.md` gains a section on all four, with a warning on the calibration entry point.

### Dead pyright pragmas removed

Its own commit, so it is easy to drop. `test/python/test_qiskit_backend.py` carried a `# pyright: report…=false` header, and I copied it into the new test file before noticing that this project type-checks with `ty` and has no pyright configuration anywhere. Both headers are gone and `ty` passes without them.

## Two findings, no change requested

Neither is a defect in this repo. Both are recorded here rather than papered over.

1. **PennyLane cannot reach an IQM device.** MQT Core 3.9.0 added a PennyLane QDMI device, but its `_select_program_format` accepts only OpenQASM 3 or 2 and raises otherwise. This device advertises only `QIR_BASE_STRING` and `IQM_JSON`, so a `pennylane` extra would be dead on arrival until MQT Core's serializer registry covers the PennyLane path.
2. **`needs_calibration()` is not implemented** even though `QDMI_PROGRAM_FORMAT_CALIBRATION` is advertised. A client can trigger a calibration run but cannot learn that one is needed. No test pins this, since a test would freeze the gap rather than record it.

## Relationship to #189

#189 takes over `qiskit_to_iqm_json` and `MoveGate` from MQT Core. It stays blocked on v4: there is no `v4.0.0` tag, PyPI's latest `mqt-core` is 3.9.0, and 3.9.0 still ships both functions. Checked against the tag rather than the changelog — `serializers.py`, `register_program_serializer`, `_EXTRA_GATES`, `is_binary_program_format`, and the `mqt.core.qiskit.program_serializers` entry point group are absent from `v3.9.0` and present on `main`.

What #189 carried that 3.9.0 did release — the driver namespace move, the sampler and estimator removal, and the two `options=` call sites — is in this PR. #189 should rebase onto `main` after this merges and shrink to the v4-only half. 3.9.0 publishes wheels for every platform this repo builds, so none of #189's temporary MLIR CI scaffolding is needed here.

## Validation

- `uv lock` and `uv sync --group test` — `mqt-core` 3.9.0 resolves from a wheel, nothing builds from source
- `uv run python -W error::DeprecationWarning -c "import iqm.qdmi.qiskit"` — clean, which is the check that the `fomac` migration is complete
- `uv run pytest test/python` — 36 passed, 7 skipped; the skips are the live-hardware tests, which need `IQM_TOKEN`
- `uvx nox@latest -s lint` — full `prek` hook set, including `ty`
- CMake configure and build against the `v1.3.3` pin, then `ctest --test-dir …/test/unit` — 119/119 pass. The `test/integration/` failures are HTTP 401 from absent credentials.
- `uv run --script examples/qsci_h2.py --help` — builds the local package and parses the edited estimator call
- `uvx nox@latest -s docs` — `examples.md` and `python_package.md` execute cleanly, which covers the section added here. The build then fails in `qiskit.md`, whose first cell opens a live Resonance session and gets HTTP 401. That file is untouched by this PR and fails the same way on `main` without `IQM_TOKEN`, so the docs build is **not** fully verified locally. CI has the token and is the real check.

Not run: the live IQM and Resonance paths, which need credentials this machine does not have. The five new tests self-skip without them and first execute in CI, against `emerald:mock`.

## Checklist

- [x] Tests added for the new behavior
- [x] `CHANGELOG.md` updated
- [x] License headers and SPDX identifiers preserved
- [x] Lint and targeted tests pass

AI assistance: written by Claude Opus 5 via Claude Code, under my direction, and reviewed by me before submission.
