### PR TITLE
✅ Stop the queue-position test failing when a job outruns the queue

### DIFF
--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -916,6 +916,32 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
   }
   return QDMI_SUCCESS;
 }
+
+/**
+ * @brief Adopt the native status that a submission response reports, as long as
+ *        it says the job is queued.
+ * @details A submission response carries the job's native status, which is a
+ *          more precise observation than the generic submitted status. Only a
+ *          queued observation is adopted: a terminal status would make @ref
+ *          IQM_QDMI_device_job_done consider the job finished and keep @ref
+ *          IQM_QDMI_device_job_wait from ever polling for it.
+ * @param job The job that was just submitted.
+ * @param response The parsed submission response.
+ */
+void Adopt_submission_status(IQM_QDMI_Device_Job job,
+                             const nlohmann::json &response) {
+  const auto native_status = response.find("status");
+  if (native_status == response.end() || !native_status->is_string()) {
+    return;
+  }
+  // Run the observation through the regular mapping rather than repeating the
+  // native status names here.
+  const auto submitted_status = job->status_;
+  if (Set_job_status(job, native_status->get<std::string>()) != QDMI_SUCCESS ||
+      job->status_ != QDMI_JOB_STATUS_QUEUED) {
+    job->status_ = submitted_status;
+  }
+}
 } // namespace
 
 int IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -1235,6 +1261,7 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
 
   job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
+  Adopt_submission_status(job, job_submission_json_response);
 
   // Log queue position if available
   std::string log_message = "Submitted job with ID: " + job->job_id_;
@@ -1281,6 +1308,7 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
 
   job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
+  Adopt_submission_status(job, job_submission_json_response);
 
   // Log queue position if available
   std::string log_message =

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -931,32 +931,6 @@ Submission_queue_position(const nlohmann::json &response) {
   }
   return position->get<size_t>();
 }
-
-/**
- * @brief Adopt the native status that a submission response reports, as long as
- *        it says the job is queued.
- * @details A submission response carries the job's native status, which is a
- *          more precise observation than the generic submitted status. Only a
- *          queued observation is adopted: a terminal status would make @ref
- *          IQM_QDMI_device_job_done consider the job finished and keep @ref
- *          IQM_QDMI_device_job_wait from ever polling for it.
- * @param job The job that was just submitted.
- * @param response The parsed submission response.
- */
-void Adopt_submission_status(IQM_QDMI_Device_Job job,
-                             const nlohmann::json &response) {
-  const auto native_status = response.find("status");
-  if (native_status == response.end() || !native_status->is_string()) {
-    return;
-  }
-  // Run the observation through the regular mapping rather than repeating the
-  // native status names here.
-  const auto submitted_status = job->status_;
-  if (Set_job_status(job, native_status->get<std::string>()) != QDMI_SUCCESS ||
-      job->status_ != QDMI_JOB_STATUS_QUEUED) {
-    job->status_ = submitted_status;
-  }
-}
 } // namespace
 
 int IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -1276,7 +1250,6 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
 
   job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
-  Adopt_submission_status(job, job_submission_json_response);
 
   // Log queue position if available
   std::string log_message = "Submitted job with ID: " + job->job_id_;
@@ -1319,7 +1292,6 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
 
   job->job_id_ = job_submission_json_response.at("id").get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
-  Adopt_submission_status(job, job_submission_json_response);
 
   // Log queue position if available
   std::string log_message =

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -918,6 +918,21 @@ int Set_job_status(IQM_QDMI_Device_Job job, const std::string &native_status) {
 }
 
 /**
+ * @brief Read the queue position that a submission response reports.
+ * @param response The parsed submission response.
+ * @return The reported position, or @c std::nullopt when the response carries
+ *         none that can be trusted.
+ */
+std::optional<size_t>
+Submission_queue_position(const nlohmann::json &response) {
+  const auto position = response.find("queue_position");
+  if (position == response.end() || !position->is_number_unsigned()) {
+    return std::nullopt;
+  }
+  return position->get<size_t>();
+}
+
+/**
  * @brief Adopt the native status that a submission response reports, as long as
  *        it says the job is queued.
  * @details A submission response carries the job's native status, which is a
@@ -1265,14 +1280,10 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
 
   // Log queue position if available
   std::string log_message = "Submitted job with ID: " + job->job_id_;
-  if (job_submission_json_response.contains("queue_position")) {
-    const auto &queue_position_json =
-        job_submission_json_response["queue_position"];
-    if (queue_position_json.is_number_integer()) {
-      const auto queue_position = queue_position_json.get<int>();
-      log_message +=
-          " (queue position: " + std::to_string(queue_position) + ")";
-    }
+  if (const auto queue_position =
+          Submission_queue_position(job_submission_json_response);
+      queue_position.has_value()) {
+    log_message += " (queue position: " + std::to_string(*queue_position) + ")";
   }
   LOG_INFO(log_message);
 
@@ -1313,14 +1324,10 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
   // Log queue position if available
   std::string log_message =
       "Submitted calibration job with ID: " + job->job_id_;
-  if (job_submission_json_response.contains("queue_position")) {
-    const auto &queue_position_json =
-        job_submission_json_response["queue_position"];
-    if (queue_position_json.is_number_integer()) {
-      const auto queue_position = queue_position_json.get<int>();
-      log_message +=
-          " (queue position: " + std::to_string(queue_position) + ")";
-    }
+  if (const auto queue_position =
+          Submission_queue_position(job_submission_json_response);
+      queue_position.has_value()) {
+    log_message += " (queue position: " + std::to_string(*queue_position) + ")";
   }
   LOG_INFO(log_message);
 

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -422,8 +422,8 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
 
   constexpr size_t shots_num = 64;
   constexpr size_t jobs_num = 4;
-  constexpr size_t max_queue_position_queries = 20;
-  constexpr auto query_interval = std::chrono::milliseconds{100};
+  constexpr size_t max_queue_position_queries = 10;
+  constexpr auto query_interval = std::chrono::milliseconds{200};
   const auto circuit = build_iqm_json_test_circuit();
   std::vector<IQM_QDMI_Device_Job> jobs;
   jobs.reserve(jobs_num);
@@ -432,10 +432,13 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
         fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num));
   }
 
-  // The final job should remain in Garnet's queue long enough for its fresh
-  // status response to expose a position. A transiently absent value is valid,
-  // so poll within a small bound rather than relying on submission-time data.
+  // Poll the final job for as long as it plausibly sits in Garnet's queue.
+  // Every outcome here is legitimate: the property answers with a position
+  // while the job is queued, QDMI_ERROR_NOTSUPPORTED while the queue has not
+  // published one yet, and QDMI_ERROR_BADSTATE once the job has left the queue.
+  // What the poll asserts is that no other code ever comes back.
   std::optional<size_t> observed_queue_position;
+  bool job_left_the_queue = false;
   for (size_t i = 0; i < max_queue_position_queries; ++i) {
     size_t queue_position = 0;
     const auto result = IQM_QDMI_device_job_query_property(
@@ -446,6 +449,7 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
       break;
     }
     if (result == QDMI_ERROR_BADSTATE) {
+      job_left_the_queue = true;
       break;
     }
     EXPECT_EQ(result, QDMI_ERROR_NOTSUPPORTED);
@@ -455,8 +459,18 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
     std::this_thread::sleep_for(query_interval);
   }
 
-  EXPECT_TRUE(observed_queue_position.has_value())
-      << "Garnet did not expose a queue position before the job left its queue";
+  // Garnet decides how long a job stays queued, and a mock job of this size can
+  // run to completion before the first query returns. Requiring a position to
+  // have been seen would assert on the timing of a shared service rather than
+  // on this device. The unit tests pin the property's contract against the HTTP
+  // stub, where it is deterministic.
+  if (!observed_queue_position.has_value()) {
+    GTEST_LOG_(INFO) << (job_left_the_queue
+                             ? "The job left Garnet's queue before a position "
+                               "could be observed"
+                             : "Garnet published no queue position within the "
+                               "polling window");
+  }
   for (auto *job : jobs) {
     EXPECT_EQ(wait_for_done(job), QDMI_JOB_STATUS_DONE);
     IQM_QDMI_device_job_free(job);

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1707,9 +1707,9 @@ TEST_F(DeviceJobMockTest, HandleInvalidQueuePositionTypes) {
 }
 
 TEST_F(DeviceJobMockTest, SubmissionQueuePositionDoesNotSkipTheRefresh) {
-  // The submission response reports both the queued status and a position. QDMI
-  // requires the property to refresh anyway, so the position the server reports
-  // at query time is the one that must come back.
+  // The submission response already carries a queue position. QDMI requires the
+  // property to refresh regardless, so the position the server reports at query
+  // time is the one that must come back.
   http_stub.queue_post(
       200, R"({"id": "job-queue", "status": "waiting", "queue_position": 3})");
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
@@ -1730,26 +1730,6 @@ TEST_F(DeviceJobMockTest, SubmissionQueuePositionDoesNotSkipTheRefresh) {
   // The size delta is the assertion that matters: the stub never verifies that
   // a queued response was consumed, so a value check alone passes even when no
   // request was issued at all.
-  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
-}
-
-TEST_F(DeviceJobMockTest, SubmissionStatusIsAdoptedOnlyWhileQueued) {
-  // A submission response reporting a terminal status must not be adopted:
-  // IQM_QDMI_device_job_check short-circuits on a job it believes is finished,
-  // so adopting it would keep the job from ever being polled.
-  http_stub.queue_post(200, R"({"id": "job-queue", "status": "failed"})");
-  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
-                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
-                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
-            QDMI_SUCCESS);
-  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
-
-  const auto gets_after_submission = http_stub.get_urls().size();
-
-  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 2})");
-  QDMI_Job_Status status{};
-  ASSERT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
-  EXPECT_EQ(status, QDMI_JOB_STATUS_QUEUED);
   EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
 }
 
@@ -1971,10 +1951,11 @@ constexpr auto TEST_CALIBRATION_CONFIG = R"(
       "graph_definition": null,
     })";
 
-TEST_F(DeviceJobMockTest, CalibrationSubmissionAdoptsItsQueuedStatus) {
+TEST_F(DeviceJobMockTest,
+       CalibrationSubmissionQueuePositionDoesNotSkipTheRefresh) {
   // The calibration path reads the submission response the same way the circuit
-  // path does, so a queued calibration job must not need a status check before
-  // it reports its position either.
+  // path does, so the position it reports must not stand in for the refresh
+  // there either.
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CALIBRATION_CONFIG) + 1, TEST_CALIBRATION_CONFIG),

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1971,6 +1971,36 @@ constexpr auto TEST_CALIBRATION_CONFIG = R"(
       "graph_definition": null,
     })";
 
+TEST_F(DeviceJobMockTest, CalibrationSubmissionAdoptsItsQueuedStatus) {
+  // The calibration path reads the submission response the same way the circuit
+  // path does, so a queued calibration job must not need a status check before
+  // it reports its position either.
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CALIBRATION_CONFIG) + 1, TEST_CALIBRATION_CONFIG),
+            QDMI_SUCCESS);
+  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(format),
+                &format),
+            QDMI_SUCCESS);
+
+  http_stub.queue_post(
+      200, R"({"id": "cal-queue", "status": "waiting", "queue_position": 6})");
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  const auto gets_after_submission = http_stub.get_urls().size();
+
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 5})");
+  size_t queue_position = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 5U);
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
+}
+
 TEST_F(DeviceJobMockTest, FullLifecycleCalibration) {
   // Job submission
   auto ret = IQM_QDMI_device_job_set_parameter(

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1706,6 +1706,53 @@ TEST_F(DeviceJobMockTest, HandleInvalidQueuePositionTypes) {
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 }
 
+TEST_F(DeviceJobMockTest, SubmissionQueuePositionDoesNotSkipTheRefresh) {
+  // The submission response reports both the queued status and a position. QDMI
+  // requires the property to refresh anyway, so the position the server reports
+  // at query time is the one that must come back.
+  http_stub.queue_post(
+      200, R"({"id": "job-queue", "status": "waiting", "queue_position": 3})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  const auto gets_after_submission = http_stub.get_urls().size();
+
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 1})");
+  size_t queue_position = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION,
+                sizeof(queue_position), &queue_position, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(queue_position, 1U);
+  // The size delta is the assertion that matters: the stub never verifies that
+  // a queued response was consumed, so a value check alone passes even when no
+  // request was issued at all.
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
+}
+
+TEST_F(DeviceJobMockTest, SubmissionStatusIsAdoptedOnlyWhileQueued) {
+  // A submission response reporting a terminal status must not be adopted:
+  // IQM_QDMI_device_job_check short-circuits on a job it believes is finished,
+  // so adopting it would keep the job from ever being polled.
+  http_stub.queue_post(200, R"({"id": "job-queue", "status": "failed"})");
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+
+  const auto gets_after_submission = http_stub.get_urls().size();
+
+  http_stub.queue_get(200, R"({"status": "waiting", "queue_position": 2})");
+  QDMI_Job_Status status{};
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_QUEUED);
+  EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
+}
+
 TEST_F(DeviceJobMockTest, QueryQueuePositionRefreshesJobStatus) {
   http_stub.queue_post(200, R"({"id": "job-queue"})");
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(


### PR DESCRIPTION
🤖 *AI text below* 🤖

`QDMIIntegrationTest.QueuePropertiesOnGarnetMock` fails intermittently, and the reason is a race the test cannot win. It submits four 64-shot mock jobs and polls the last one for a queue position. A status request that hits HTTP 429 absorbs a `Retry-After` wait of tens of seconds, while a 64-shot mock job finishes in well under a second, so by the time the request returns the job has left the queue and the property correctly answers `QDMI_ERROR_BADSTATE`. The test breaks out of its poll loop on that code and then hard-fails on `EXPECT_TRUE(observed_queue_position.has_value())`. In the garnet job of [run 31381541803](https://github.com/iqm-finland/QDMI-on-IQM/actions/runs/31381541803) there were six 429s with a 30-second `Retry-After`, one of them on a job-status GET, and the test failed all three `ctest --repeat until-pass:3` attempts.

This supersedes #184, which tried to fix it in the device by answering the first query from the submission response. That was the wrong place. QDMI states in `include/qdmi/constants.h` that querying `QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` *must* refresh the status and queue position, and *must* return `QDMI_ERROR_BADSTATE` when the refreshed job is not queued. In the failing scenario `BADSTATE` is the specified answer, so the device is already right and the assertion is what is wrong. Thanks to @burgholzer for the pushback.

The test now treats a job that outran the queue as the legitimate outcome it is, and keeps asserting what does hold — that the property only ever answers with a position, `QDMI_ERROR_NOTSUPPORTED`, or `QDMI_ERROR_BADSTATE`. It also polls half as often over the same window. This is the tightest polling loop in the suite, since `IQM_QDMI_device_job_wait` already backs off exponentially from one second, so it is a plausible contributor to the rate limiting — though six 429s in one job does not isolate the source, so treat that as a guess rather than a diagnosis.

Two unit tests take over what the integration test can no longer guarantee. `SubmissionQueuePositionDoesNotSkipTheRefresh` and `CalibrationSubmissionQueuePositionDoesNotSkipTheRefresh` pin the property to the server on both submit paths, even when the submission response already carried a position — they fail against #184's implementation, which is the point of adding them. Both assert on the number of requests rather than on a value alone, because `HttpStub` never verifies that a queued response was consumed.

The one production change left is a tidy: both submit paths carried the same block re-parsing `queue_position` for their log line. That now lives in one helper and reads the value as an unsigned number the way `IQM_QDMI_device_job_check` does, so a negative position is no longer logged as if it were real. An earlier revision also adopted the submission response's native status; @burgholzer's review showed that no public behavior observed it and that it could turn an unknown native status into a logged error on a successful submission, so it is gone.

No `CHANGELOG.md` entry: a flaky test and a log-format tidy are not user-facing behavior. Flagging that as a judgment call rather than leaving it silent.

Full unit suite green at 124 tests on top of current `main`. `uvx nox -s lint` clean, and `clang-tidy` clean on all three changed files. The integration test needs live credentials and `garnet:mock`, so CI exercises it — note that a single green run proves nothing about a flake here; what changed is that the `BADSTATE` path can no longer fail the test.
