### PR TITLE
🐛 Canceling a job that already finished reports a denied permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Report a cancellation that the server refuses because the job already
+  finished as `QDMI_ERROR_INVALIDARGUMENT` rather than
+  `QDMI_ERROR_PERMISSIONDENIED`, which said the session was not allowed to use
+  the job interface ([#199]) ([**@marcelwa**])
 - 🐛 Report the status the quantum computer is actually in, instead of pinning a
   session to busy from its first job submission onwards ([#190])
   ([**@marcelwa**])
@@ -179,6 +183,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#199]: https://github.com/iqm-finland/QDMI-on-IQM/pull/199
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 #include <chrono>
 #include <cpr/connection_pool.h>
+#include <cpr/response.h>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -1329,6 +1330,37 @@ int IQM_QDMI_device_job_submit(IQM_QDMI_Device_Job job) try {
   return QDMI_ERROR_FATAL;
 }
 
+namespace {
+/**
+ * @brief Whether a refused request reports that the job was in an illegal
+ *        status for it.
+ * @details The IQM Server refuses to cancel a job that has already reached a
+ *          terminal status, and says so with an @c illegal_job_status error
+ *          code alongside HTTP 403. That status code on its own is
+ *          indistinguishable from an authorization failure, so the error code
+ *          is what separates the two. It arrives either at the root of the
+ *          response or inside an @c errors array.
+ * @param response The raw response to a request that did not succeed.
+ * @return @c true if the response reports an illegal job status.
+ */
+bool Reports_illegal_job_status(const cpr::Response &response) {
+  const auto json = nlohmann::json::parse(response.text, nullptr, false);
+  if (json.is_discarded()) {
+    return false;
+  }
+  const auto reports_it = [](const nlohmann::json &error) {
+    const auto code = error.find("error_code");
+    return code != error.end() && code->is_string() &&
+           code->get<std::string>() == "illegal_job_status";
+  };
+  if (const auto errors = json.find("errors");
+      errors != json.end() && errors->is_array()) {
+    return std::ranges::any_of(*errors, reports_it);
+  }
+  return reports_it(json);
+}
+} // namespace
+
 int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) try {
   if (job == nullptr || job->status_ == QDMI_JOB_STATUS_DONE) {
     return QDMI_ERROR_INVALIDARGUMENT;
@@ -1349,6 +1381,17 @@ int IQM_QDMI_device_job_cancel(IQM_QDMI_Device_Job job) try {
       job->session_->request_timeout_);
   const auto status = iqm::http::Handle_response(job_abortion_response);
   if (status != QDMI_SUCCESS) {
+    if (Reports_illegal_job_status(job_abortion_response)) {
+      // The job already reached a terminal status, so it can no longer be
+      // canceled. QDMI documents QDMI_ERROR_INVALIDARGUMENT for that, which is
+      // also what the guard at the top of this function returns when the
+      // device already knows the status locally. The refusal does not say
+      // which terminal status the job reached, so leave that for the next
+      // check to observe.
+      LOG_DEBUG("Cancellation request for job with ID: " + job->job_id_ +
+                " was refused because the job is no longer running");
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
     // A cancellation request that never reached the server says nothing about
     // the job itself, which keeps running remotely. Leave the status untouched
     // so that the job stays observable and the request can be retried.

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -882,10 +882,27 @@ TEST_F(QDMIIntegrationTest, JobCancellation) {
   constexpr size_t shots_num = 64;
   const auto circuit = build_iqm_json_test_circuit();
   auto *job = fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
-  EXPECT_EQ(IQM_QDMI_device_job_cancel(job), QDMI_SUCCESS);
+
+  // A mock job of this size can reach a terminal status before the cancellation
+  // request lands, and a job that is no longer running can no longer be
+  // canceled. Which of the two happens is the backend's timing rather than this
+  // device's behavior, so assert against whichever one occurred.
+  const auto cancellation = IQM_QDMI_device_job_cancel(job);
   QDMI_Job_Status status{};
-  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
-  EXPECT_EQ(status, QDMI_JOB_STATUS_CANCELED);
+  ASSERT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  if (cancellation == QDMI_SUCCESS) {
+    EXPECT_EQ(status, QDMI_JOB_STATUS_CANCELED);
+  } else {
+    EXPECT_EQ(cancellation, QDMI_ERROR_INVALIDARGUMENT)
+        << "A cancellation can only be refused because the job already reached "
+           "a terminal status";
+    EXPECT_TRUE(status == QDMI_JOB_STATUS_DONE ||
+                status == QDMI_JOB_STATUS_CANCELED ||
+                status == QDMI_JOB_STATUS_FAILED)
+        << "The cancellation was refused, so the job must have finished; its "
+           "status is "
+        << status;
+  }
   IQM_QDMI_device_job_free(job);
 }
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1306,6 +1306,40 @@ TEST_F(DeviceJobMockTest, JobCheckPreservesStatusOnServerError) {
   IQM_QDMI_device_job_free(retrieved_job);
 }
 
+TEST_F(DeviceJobMockTest, CancelingAJobThatAlreadyFinishedIsAnInvalidArgument) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
+
+  // The server refuses to cancel a job that has already reached a terminal
+  // status. The HTTP 403 it answers with is also what an authorization failure
+  // looks like, so the error code is what tells them apart.
+  http_stub.queue_post(403, R"({"error_code": "illegal_job_status",
+                                "message": "Illegal job status"})");
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
+
+  // The same refusal, reported through the errors array the API also uses.
+  http_stub.queue_post(403, R"({"errors": [{"error_code": "illegal_job_status",
+                                            "message": "Illegal job status"}]})");
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(retrieved_job),
+            QDMI_ERROR_INVALIDARGUMENT);
+
+  // The refusal does not say which terminal status the job reached, so the job
+  // stays observable and the next check is what learns it.
+  const auto requests_before_recheck = http_stub.get_urls().size();
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "completed", "type": "circuit"})");
+  QDMI_Job_Status status = QDMI_JOB_STATUS_CREATED;
+  EXPECT_EQ(IQM_QDMI_device_job_check(retrieved_job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before_recheck + 1);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_DONE);
+  IQM_QDMI_device_job_free(retrieved_job);
+}
+
 TEST_F(DeviceJobMockTest, JobCancelPreservesStatusOnServerError) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -1340,6 +1340,24 @@ TEST_F(DeviceJobMockTest, CancelingAJobThatAlreadyFinishedIsAnInvalidArgument) {
   IQM_QDMI_device_job_free(retrieved_job);
 }
 
+TEST_F(DeviceJobMockTest,
+       CancelRefusalWithAnUnreadableBodyKeepsItsHttpMapping) {
+  http_stub.queue_get(
+      200, R"({"id": "job-123", "status": "running", "type": "circuit"})");
+  IQM_QDMI_Device_Job retrieved_job = nullptr;
+  ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
+                session, "job-123", &retrieved_job),
+            QDMI_SUCCESS);
+
+  // Reading the error code must not change what a refusal means when there is
+  // no error code to read. A body that is not JSON at all keeps the mapping the
+  // HTTP status code alone would have produced.
+  http_stub.queue_post(403, "<html>Forbidden</html>");
+  EXPECT_EQ(IQM_QDMI_device_job_cancel(retrieved_job),
+            QDMI_ERROR_PERMISSIONDENIED);
+  IQM_QDMI_device_job_free(retrieved_job);
+}
+
 TEST_F(DeviceJobMockTest, JobCancelPreservesStatusOnServerError) {
   http_stub.queue_get(
       200, R"({"id": "job-123", "status": "running", "type": "circuit"})");


### PR DESCRIPTION
🤖 *AI text below* 🤖

Closes #197.

Canceling a job that the IQM Server has already finished returned `QDMI_ERROR_PERMISSIONDENIED`. QDMI defines that code for this function as the device not allowing the [device job interface](https://munich-quantum-software-stack.github.io/QDMI/) for the current session, so a client that cancels a job it submitted moments earlier and gets that answer would reasonably conclude its token is wrong — when in fact its job had simply completed. The cancel path's own `catch (const iqm::ClientAuthenticationError &)` returns the same code, so the two were indistinguishable.

The device also contradicted itself. `IQM_QDMI_device_job_cancel` already returns `QDMI_ERROR_INVALIDARGUMENT` when it knows locally that the job is `QDMI_JOB_STATUS_DONE`, which is what QDMI documents for a job that can no longer be canceled and what `JobCycleCornerCases` already asserts. The same fact produced a different answer depending only on whether this device happened to have refreshed its status.

`iqm::http::Handle_response` maps every HTTP 403 to `QDMI_ERROR_PERMISSIONDENIED` regardless of the body. That is right in general — 403 does mean permission denied elsewhere — so the fix stays inside the cancel path rather than changing the shared mapping. The server distinguishes the two cases itself with an `illegal_job_status` error code, which `Handle_response` already parses and logs but does not act on. The new check keys on that error code rather than on the status code, so it keeps working if the server ever answers with a different one, and it reads both shapes the code arrives in: at the root of the response, and inside an `errors` array.

The job status is deliberately left alone. The refusal establishes that the job is terminal but not which terminal status it reached — `completed`, `failed`, and `cancelled` are all possible — so the next `IQM_QDMI_device_job_check` is what observes it.

## The test

`QDMIIntegrationTest.JobCancellation` required a mock job to still be cancellable moments after submission. That is not something a shared backend can promise: a 64-shot job finishes in well under a second, and a rate-limited cancel request waits out a `Retry-After` of tens of seconds before it arrives. It failed exactly that way in the sanitizer job of [run 32476694628](https://github.com/iqm-finland/QDMI-on-IQM/actions/runs/32476694628), taking 32.5 seconds, essentially all of it the block.

It now asserts against whichever outcome occurred: a cancellation that succeeds must leave the job canceled, and one that is refused must be refused with `QDMI_ERROR_INVALIDARGUMENT` and leave the job in some terminal status. Both branches carry a real assertion, so this loosens what the test demands of the backend without loosening what it demands of the device.

There is no second race on the success path, which is why no polling is needed: a successful cancellation sets the status to `QDMI_JOB_STATUS_CANCELED` locally, and `IQM_QDMI_device_job_check` returns early for terminal statuses without issuing a request.

## Testing

`CancelingAJobThatAlreadyFinishedIsAnInvalidArgument` drives both response shapes against the HTTP stub and asserts the job stays observable afterwards, with a request-count delta rather than a value check alone. It fails against the previous mapping, returning `-8` where `-7` is expected, which is the point of adding it. The neighboring `JobCancelPreservesStatusOnServerError` and the existing 403-without-an-error-code case are untouched, and the latter is what keeps this mapping from widening into genuine authorization failures. A third test pins that a refusal whose body is not JSON at all keeps the mapping the status code alone would have produced.

Full unit suite green at 121 tests, `uvx nox -s lint` clean, and `clang-tidy` clean on all three changed files.

## Note on sequencing

This is independent of #196 and reviewable on its own — different function, different test — though both touch `test/integration/test_iqm_device_integration.cpp` in well-separated places, so whichever lands second may want a trivial rebase.
