### PR TITLE
👷 Run the Python CI jobs when their own workflow files change

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,9 @@ jobs:
         .github/workflows/cpp-linter.yml
         .github/workflows/cpp-install-tests.yml
         .github/workflows/cpp-sanitizers.yml
+      additional-python-files: |
+        .github/workflows/CI.yml
+        .github/workflows/python-*.yml
       additional-cd-files: |
         spank/**
         .github/workflows/spank-tests.yml


### PR DESCRIPTION
🤖 *AI text below* 🤖

#186 fixed the C++ half of this. The Python half was left untouched, and it has the same cause.

The reusable change-detection workflow decides whether the Python jobs run by matching changed files against a built-in path filter. That filter keys Python workflow changes off the upstream repository's own file names — `reusable-python-linter.yml`, `reusable-python-tests.yml`, `reusable-python-ci.yml`, and a lowercase `ci.yml`. This repository's Python workflows are `python-examples.yml`, `python-packaging-sdist.yml`, and `python-packaging-cibuildwheel.yml`. We passed no `additional-python-files` at all, so nothing filled the gap.

The `ci.yml` entry deserves its own note, because the mismatch there is not the `reusable-` prefix. The matcher is `Ana06/get-changed-files@25f79e6`, which calls `minimatch(file, pattern, {matchBase: true, dot: true})`. It does not pass `nocase`, and minimatch is case-sensitive, so upstream's `.github/workflows/ci.yml` could never have matched our `.github/workflows/CI.yml`. The casing alone breaks it. Nothing reports this: a filter that matches no file is indistinguishable from a pull request that changed nothing relevant, so any downstream repository that renames or re-cases its workflows loses change detection silently.

This is less severe than the C++ half was. The Python filters also carry broad patterns — `python/**`, `test/**/*.py`, `noxfile.py`, `pyproject.toml`, `uv.lock`, `.pre-commit-config.yaml` — so real Python work still triggers the jobs. Only a pull request that edits Python workflow files and nothing else slips through, which is the case this fixes.

This adds `additional-python-files` alongside the existing `additional-cpp-files`, listing `CI.yml` and a `python-*.yml` glob that covers all three workflows and stays correct if a fourth is added. Note the shape of the upstream input: there is one `additional-python-files` feeding both the Python test filter (`run-python-tests`, at `reusable-change-detection.yml:126`) and the Python linter filter (`run-python-linter`, at line 158). It cannot be widened for one and not the other, so a change to a packaging workflow now also wakes the linter, and vice versa.

Worth flagging explicitly, as in #186: this widens which jobs run for unrelated pull requests. Any change to `CI.yml` now triggers the end-to-end examples, the sdist build, the full six-platform wheel matrix, and the Python linter, even when the edit only touches a C++ job definition. Since the wheel jobs are where `pytest test/python` actually runs, that is not a cheap addition. The trade-off is intended — `CI.yml` is where the Python jobs are defined — but narrowing it is the maintainers' call.

This pull request is its own verification: it edits only a workflow file, so the Python jobs must run here rather than skip.

No `CHANGELOG.md` entry. This is CI plumbing with no user-facing behavior change, which is where this repository's changelog draws its line, and #186 made the same call for the C++ half. Flagging it as a judgment rather than leaving it silent.
