### PR TITLE
✨ Let callers choose the Slurm partition and node count for offloaded jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,8 @@
 # Directory for job files (circuit QPY, operator PKL files)
 # Default: ~/.qdmi_jobs (user's home directory under .qdmi_jobs)
 #IQM_JOBS_DIR=
+
+# Slurm partition the offloader submits its srun jobs to
+# Default: quantum
+# Example: IQM_SLURM_PARTITION=qc-nodes
+#IQM_SLURM_PARTITION=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add `partition` and `nodes` keyword arguments to `iqm.qdmi.offloader`'s
-  `sample`/`estimate`, resolving the partition from `IQM_SLURM_PARTITION` when
-  it is not passed, so a site whose quantum partition is not named `quantum` can
-  use the offloader ([#202]) ([**@marcelwa**])
+  `sample`/`estimate`, with the partition also resolvable from
+  `IQM_SLURM_PARTITION`, so a site whose quantum partition is not named
+  `quantum` can use the offloader ([#202]) ([**@marcelwa**])
 
 ## [1.4.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add `partition` and `nodes` keyword arguments to `iqm.qdmi.offloader`'s
+  `sample`/`estimate`, resolving the partition from `IQM_SLURM_PARTITION` when
+  it is not passed, so a site whose quantum partition is not named `quantum` can
+  use the offloader ([#202]) ([**@marcelwa**])
 - 👷 Add an `IQM_QDMI_SANITIZERS` CMake option for building with
   AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer, or
   MemorySanitizer, and run the C++ test suite under ASan and UBSan in CI
@@ -179,6 +183,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#202]: https://github.com/iqm-finland/QDMI-on-IQM/pull/202
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -77,13 +77,17 @@ sudo scontrol reconfigure
 ```
 
 Provision the `quantum` partition itself (or whatever name you chose) as a
-regular Slurm partition gating the nodes with QC access. The
-{py:mod}`~iqm.qdmi.offloader` module submits to `quantum` by default; if you
-chose another name, export `IQM_SLURM_PARTITION` in your users' login
-environment so they do not have to pass it on every call — see
-[Python Package](python_package.md#selecting-the-slurm-partition). See the full
-option reference, including `iqm_validation_timeout`, `iqm_license_prefix`, and
-`iqm_require_license`, in
+regular Slurm partition gating the nodes with QC access. A name other than
+`quantum` has to appear in two further places:
+
+- The `partitions=` option above. The plugin skips every job outside that list
+  and injects nothing, without reporting an error.
+- `IQM_SLURM_PARTITION` in your users' login environment, so the
+  {py:mod}`~iqm.qdmi.offloader` module stops defaulting to `quantum` — see
+  [Python Package](python_package.md#selecting-the-slurm-partition).
+
+See the full option reference, including `iqm_validation_timeout`,
+`iqm_license_prefix`, and `iqm_require_license`, in
 [Configuration](spank_plugin.md#configuration).
 
 ## 4. Set Up Authentication

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -77,11 +77,13 @@ sudo scontrol reconfigure
 ```
 
 Provision the `quantum` partition itself (or whatever name you chose) as a
-regular Slurm partition gating the nodes with QC access — the
-{py:mod}`~iqm.qdmi.offloader` module submits jobs to a partition named `quantum`
-by default, so match that name unless your users configure otherwise. See the
-full option reference, including `iqm_validation_timeout`, `iqm_license_prefix`,
-and `iqm_require_license`, in
+regular Slurm partition gating the nodes with QC access. The
+{py:mod}`~iqm.qdmi.offloader` module submits to `quantum` by default; if you
+chose another name, export `IQM_SLURM_PARTITION` in your users' login
+environment so they do not have to pass it on every call — see
+[Python Package](python_package.md#selecting-the-slurm-partition). See the full
+option reference, including `iqm_validation_timeout`, `iqm_license_prefix`, and
+`iqm_require_license`, in
 [Configuration](spank_plugin.md#configuration).
 
 ## 4. Set Up Authentication

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -115,15 +115,26 @@ Both functions support a `local=True` argument for running simulation/hardware
 compilation locally (useful for debugging) and a `simulator=True` argument when
 submitting Slurm jobs to target simulated devices instead of real QPU hardware.
 
-### Slurm Partition Requirement
+### Selecting the Slurm Partition
 
-Both functions submit their `srun` jobs to a partition named `quantum`
-(`srun --partition=quantum ...`). This assumes the cluster has a partition of
-that exact name configured, typically gating access to nodes with the quantum
-computer exposed as a Slurm GRES resource. Ensure such a `quantum` partition
-exists before using the offloader; see the
-[SPANK plugin documentation](spank_plugin.md) for an example cluster
-configuration.
+Both functions submit their `srun` jobs to the partition gating the nodes that
+expose the quantum computer as a Slurm GRES resource. Its name is a per-site
+choice, resolved in this order:
+
+1. The `partition` keyword argument.
+2. The `IQM_SLURM_PARTITION` environment variable, which lets an administrator
+   set the site's name once for every user.
+3. `quantum`, the name used throughout the
+   [SPANK plugin documentation](spank_plugin.md) and the
+   [Administrator Guide](admin_guide.md).
+
+Both functions also accept a `nodes` keyword argument, forwarded as `--nodes`
+and defaulting to a single node. It has no environment fallback: the node count
+is a per-job resource request rather than a site-wide constant.
+
+```python
+counts = sample(qc, shots=512, partition="qc-nodes", nodes=1)
+```
 
 ### Shared Jobs Directory
 

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -123,18 +123,35 @@ choice, resolved in this order:
 
 1. The `partition` keyword argument.
 2. The `IQM_SLURM_PARTITION` environment variable, which lets an administrator
-   set the site's name once for every user.
+   set the site's name once for every user. An empty value counts as unset.
 3. `quantum`, the name used throughout the
    [SPANK plugin documentation](spank_plugin.md) and the
    [Administrator Guide](admin_guide.md).
 
-Both functions also accept a `nodes` keyword argument, forwarded as `--nodes`
-and defaulting to a single node. It has no environment fallback: the node count
-is a per-job resource request rather than a site-wide constant.
-
 ```python
-counts = sample(qc, shots=512, partition="qc-nodes", nodes=1)
+counts = sample(qc, shots=512, partition="qc-nodes")
 ```
+
+Slurm's own `SLURM_PARTITION` has no effect here, because the resolved name is
+always passed as an explicit `--partition`, which takes precedence over it.
+
+:::{important}
+Renaming the partition is not enough on its own. The SPANK plugin only runs on
+the partitions its `partitions=` option lists, so that list has to carry the new
+name too — see [Configuration](spank_plugin.md#configuration). Otherwise the
+plugin silently skips the job and never injects `IQM_BASE_URL`, `IQM_QC_ID`, or
+`IQM_QC_ALIAS`.
+:::
+
+### Sizing the Slurm Allocation
+
+Both functions accept a `nodes` keyword argument, forwarded as `--nodes` and
+defaulting to a single node. The worker itself always runs as one task
+(`--ntasks=1`), so `nodes` only sizes the allocation for a site whose partition
+demands more than one node; it does not distribute or parallelize the workload.
+
+It has no environment fallback: the node count is a per-job resource request
+rather than a site-wide constant.
 
 ### Shared Jobs Directory
 

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -156,8 +156,8 @@ def _spank_qc_selection_args(qc_id: str | None, qc_alias: str | None) -> list[st
     Unlike backend credentials (`IQM_BASE_URL`/`IQM_TOKENS_FILE`), which reach
     the job purely through the environment -- either plain Slurm propagation
     from the submitting shell, or the QDMI-on-IQM SPANK plugin's own
-    plugstack.conf.d defaults on the `quantum` partition -- QC selection is a
-    per-call choice. It is passed as a `--iqm-qc-id`/`--iqm-qc-alias` option on
+    plugstack.conf.d defaults on whichever partitions it is configured for --
+    QC selection is a per-call choice. It is passed as a `--iqm-qc-id`/`--iqm-qc-alias` option on
     `srun` itself, which the SPANK plugin resolves into the job's
     `IQM_QC_ID`/`IQM_QC_ALIAS` environment variable.
 
@@ -196,7 +196,9 @@ def _resolve_partition(partition: str | None) -> str:
     `IQM_SLURM_PARTITION` environment variable, which in turn takes precedence
     over the `quantum` name the administrator guide provisions. This mirrors how
     the QDMI-on-IQM SPANK plugin's `IQM_BASE_URL`/`IQM_QC_ID`/`IQM_QC_ALIAS`
-    variables let a site set a default once for every user.
+    variables let a site set a default once for every user. Slurm's own
+    `SLURM_PARTITION` cannot serve that role here, because the resolved name is
+    always passed as an explicit `--partition`, which overrides it.
 
     Returns:
         The partition name to pass to `srun`.
@@ -313,8 +315,10 @@ def sample(
             to `srun`. Defaults to the `IQM_SLURM_PARTITION` environment
             variable, and to `quantum` when that is unset. Only used when
             `local=False`.
-        nodes: The number of nodes to request, passed as `--nodes` to `srun`.
-            Default is 1. Only used when `local=False`.
+        nodes: The number of nodes to allocate, passed as `--nodes` to `srun`.
+            The worker always runs as a single task (`--ntasks=1`), so this
+            only sizes the allocation for sites whose partition demands more
+            than one node. Default is 1. Only used when `local=False`.
 
     Returns:
         A dictionary of measurement counts.
@@ -351,6 +355,7 @@ def sample(
         "srun",
         f"--job-name={job_name}",
         f"--nodes={nodes}",
+        "--ntasks=1",
         f"--partition={_resolve_partition(partition)}",
         *_spank_qc_selection_args(qc_id, qc_alias),
         *_licenses_arg(licenses),
@@ -429,8 +434,10 @@ def estimate(
             to `srun`. Defaults to the `IQM_SLURM_PARTITION` environment
             variable, and to `quantum` when that is unset. Only used when
             `local=False`.
-        nodes: The number of nodes to request, passed as `--nodes` to `srun`.
-            Default is 1. Only used when `local=False`.
+        nodes: The number of nodes to allocate, passed as `--nodes` to `srun`.
+            The worker always runs as a single task (`--ntasks=1`), so this
+            only sizes the allocation for sites whose partition demands more
+            than one node. Default is 1. Only used when `local=False`.
 
     Returns:
         The VQE result, including the optimal parameters and eigenvalue.
@@ -469,6 +476,7 @@ def estimate(
         "srun",
         f"--job-name={job_name}",
         f"--nodes={nodes}",
+        "--ntasks=1",
         f"--partition={_resolve_partition(partition)}",
         *_spank_qc_selection_args(qc_id, qc_alias),
         *_licenses_arg(licenses),

--- a/python/iqm/qdmi/offloader.py
+++ b/python/iqm/qdmi/offloader.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
     from qiskit.quantum_info import SparsePauliOp
     from qiskit_algorithms import VQEResult
 
+_DEFAULT_PARTITION = "quantum"
+_DEFAULT_NODES = 1
+
 
 def _count_to_int(count: object) -> int:
     """Convert an external count payload to a plain integer.
@@ -185,6 +188,22 @@ def _licenses_arg(licenses: str | None) -> list[str]:
     return [f"--licenses={licenses}"] if licenses else []
 
 
+def _resolve_partition(partition: str | None) -> str:
+    """Resolve the Slurm partition the `srun` job is submitted to.
+
+    The partition holding the QC nodes carries whatever name its administrator
+    gave it, so an explicit *partition* takes precedence over the
+    `IQM_SLURM_PARTITION` environment variable, which in turn takes precedence
+    over the `quantum` name the administrator guide provisions. This mirrors how
+    the QDMI-on-IQM SPANK plugin's `IQM_BASE_URL`/`IQM_QC_ID`/`IQM_QC_ALIAS`
+    variables let a site set a default once for every user.
+
+    Returns:
+        The partition name to pass to `srun`.
+    """
+    return partition or os.getenv("IQM_SLURM_PARTITION") or _DEFAULT_PARTITION
+
+
 def _run_srun(
     command: list[str],
     job_dir: Path,
@@ -258,6 +277,8 @@ def sample(
     qc_id: str | None = None,
     qc_alias: str | None = None,
     licenses: str | None = None,
+    partition: str | None = None,
+    nodes: int = _DEFAULT_NODES,
 ) -> dict[str, int]:
     """Sample from a quantum circuit.
 
@@ -288,6 +309,12 @@ def sample(
             cap concurrent jobs against a QC -- e.g. required by the SPANK
             plugin's `iqm_require_license` option. Only used when
             `local=False`.
+        partition: The Slurm partition to submit to, passed as `--partition`
+            to `srun`. Defaults to the `IQM_SLURM_PARTITION` environment
+            variable, and to `quantum` when that is unset. Only used when
+            `local=False`.
+        nodes: The number of nodes to request, passed as `--nodes` to `srun`.
+            Default is 1. Only used when `local=False`.
 
     Returns:
         A dictionary of measurement counts.
@@ -323,8 +350,8 @@ def sample(
     command = [
         "srun",
         f"--job-name={job_name}",
-        "--nodes=1",
-        "--partition=quantum",
+        f"--nodes={nodes}",
+        f"--partition={_resolve_partition(partition)}",
         *_spank_qc_selection_args(qc_id, qc_alias),
         *_licenses_arg(licenses),
         "iqm-sampler",
@@ -359,6 +386,8 @@ def estimate(
     qc_id: str | None = None,
     qc_alias: str | None = None,
     licenses: str | None = None,
+    partition: str | None = None,
+    nodes: int = _DEFAULT_NODES,
 ) -> VQEResult:
     """Estimate the optimal parameters for a given ansatz circuit and operator.
 
@@ -396,6 +425,12 @@ def estimate(
             cap concurrent jobs against a QC -- e.g. required by the SPANK
             plugin's `iqm_require_license` option. Only used when
             `local=False`.
+        partition: The Slurm partition to submit to, passed as `--partition`
+            to `srun`. Defaults to the `IQM_SLURM_PARTITION` environment
+            variable, and to `quantum` when that is unset. Only used when
+            `local=False`.
+        nodes: The number of nodes to request, passed as `--nodes` to `srun`.
+            Default is 1. Only used when `local=False`.
 
     Returns:
         The VQE result, including the optimal parameters and eigenvalue.
@@ -433,8 +468,8 @@ def estimate(
     command = [
         "srun",
         f"--job-name={job_name}",
-        "--nodes=1",
-        "--partition=quantum",
+        f"--nodes={nodes}",
+        f"--partition={_resolve_partition(partition)}",
         *_spank_qc_selection_args(qc_id, qc_alias),
         *_licenses_arg(licenses),
         "iqm-estimator",

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -365,6 +365,118 @@ def test_estimate_slurm_forwards_licenses(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert captured_command.index("--licenses=iqm_qc_emerald_mock:1") < worker_index
 
 
+@pytest.mark.parametrize(
+    ("partition", "partition_env", "expected"),
+    [
+        (None, None, "--partition=quantum"),
+        (None, "qc-nodes", "--partition=qc-nodes"),
+        ("qc-nodes", "ignored", "--partition=qc-nodes"),
+    ],
+)
+def test_sample_slurm_resolves_partition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    partition: str | None,
+    partition_env: str | None,
+    expected: str,
+) -> None:
+    """An explicit `partition` wins over `IQM_SLURM_PARTITION`, which wins over the `quantum` default."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    if partition_env is None:
+        monkeypatch.delenv("IQM_SLURM_PARTITION", raising=False)
+    else:
+        monkeypatch.setenv("IQM_SLURM_PARTITION", partition_env)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    offloader.sample(circuit, shots=7, local=False, simulator=True, partition=partition)
+
+    assert expected in captured_command
+    assert captured_command.index(expected) < captured_command.index("iqm-sampler")
+
+
+def test_sample_slurm_requests_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The `nodes` kwarg sets `--nodes` on `srun`, defaulting to a single node."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps([FakePubResult({"meas": FakeBitArray({"0": 1})})]))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+
+    offloader.sample(circuit, shots=7, local=False, simulator=True)
+    assert "--nodes=1" in captured_command
+
+    offloader.sample(circuit, shots=7, local=False, simulator=True, nodes=4)
+    assert "--nodes=4" in captured_command
+
+
+def test_estimate_slurm_forwards_partition_and_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mirrors `test_sample_slurm_resolves_partition` and `test_sample_slurm_requests_nodes` for `estimate()`."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setenv("IQM_SLURM_PARTITION", "ignored")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True, partition="qc-nodes", nodes=2)
+
+    worker_index = captured_command.index("iqm-estimator")
+    assert "--partition=qc-nodes" in captured_command
+    assert captured_command.index("--partition=qc-nodes") < worker_index
+    assert "--nodes=2" in captured_command
+
+
 def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A failed Slurm job leaves its input files in place and reports where to find them."""
 

--- a/test/python/test_offloader.py
+++ b/test/python/test_offloader.py
@@ -414,7 +414,7 @@ def test_sample_slurm_resolves_partition(
 
 
 def test_sample_slurm_requests_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """The `nodes` kwarg sets `--nodes` on `srun`, defaulting to a single node."""
+    """The `nodes` kwarg sizes the allocation while the worker stays a single task."""
     captured_command: list[str] = []
 
     class FakeCompletedProcess:
@@ -437,15 +437,35 @@ def test_sample_slurm_requests_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     circuit = QuantumCircuit(1)
     circuit.measure_all()
 
+    # Both options only reach Slurm if they precede the worker on the command
+    # line; after it they would be the worker's own arguments.
     offloader.sample(circuit, shots=7, local=False, simulator=True)
-    assert "--nodes=1" in captured_command
+    worker_index = captured_command.index("iqm-sampler")
+    assert captured_command.index("--nodes=1") < worker_index
+    assert captured_command.index("--ntasks=1") < worker_index
 
     offloader.sample(circuit, shots=7, local=False, simulator=True, nodes=4)
-    assert "--nodes=4" in captured_command
+    worker_index = captured_command.index("iqm-sampler")
+    assert captured_command.index("--nodes=4") < worker_index
+    assert captured_command.index("--ntasks=1") < worker_index
 
 
-def test_estimate_slurm_forwards_partition_and_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Mirrors `test_sample_slurm_resolves_partition` and `test_sample_slurm_requests_nodes` for `estimate()`."""
+@pytest.mark.parametrize(
+    ("partition", "partition_env", "expected"),
+    [
+        (None, None, "--partition=quantum"),
+        (None, "qc-nodes", "--partition=qc-nodes"),
+        ("qc-nodes", "ignored", "--partition=qc-nodes"),
+    ],
+)
+def test_estimate_slurm_resolves_partition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    partition: str | None,
+    partition_env: str | None,
+    expected: str,
+) -> None:
+    """`estimate()` walks the same resolution order as `test_sample_slurm_resolves_partition`."""
     captured_command: list[str] = []
 
     class FakeCompletedProcess:
@@ -463,18 +483,54 @@ def test_estimate_slurm_forwards_partition_and_nodes(monkeypatch: pytest.MonkeyP
         return FakeCompletedProcess()
 
     monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
-    monkeypatch.setenv("IQM_SLURM_PARTITION", "ignored")
+    if partition_env is None:
+        monkeypatch.delenv("IQM_SLURM_PARTITION", raising=False)
+    else:
+        monkeypatch.setenv("IQM_SLURM_PARTITION", partition_env)
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     ansatz = QuantumCircuit(1)
     operator = SparsePauliOp.from_list([("Z", 1.0)])
 
-    offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True, partition="qc-nodes", nodes=2)
+    offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True, partition=partition)
 
+    assert expected in captured_command
+    assert captured_command.index(expected) < captured_command.index("iqm-estimator")
+
+
+def test_estimate_slurm_requests_nodes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mirrors `test_sample_slurm_requests_nodes` for `estimate()`."""
+    captured_command: list[str] = []
+
+    class FakeCompletedProcess:
+        returncode = 0
+        stdout = base64.b64encode(pickle.dumps(FakeVQEResult({"theta": 0.125})))
+        stderr = b""
+
+    def fake_run(
+        command: list[str], *, capture_output: bool, check: bool, timeout: float | None
+    ) -> FakeCompletedProcess:
+        assert capture_output is True
+        assert check is False
+        assert timeout is None
+        captured_command[:] = command
+        return FakeCompletedProcess()
+
+    monkeypatch.setenv("IQM_JOBS_DIR", str(tmp_path))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ansatz = QuantumCircuit(1)
+    operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+    offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True)
     worker_index = captured_command.index("iqm-estimator")
-    assert "--partition=qc-nodes" in captured_command
-    assert captured_command.index("--partition=qc-nodes") < worker_index
-    assert "--nodes=2" in captured_command
+    assert captured_command.index("--nodes=1") < worker_index
+    assert captured_command.index("--ntasks=1") < worker_index
+
+    offloader.estimate(ansatz, operator, maxiter=3, local=False, simulator=True, nodes=2)
+    worker_index = captured_command.index("iqm-estimator")
+    assert captured_command.index("--nodes=2") < worker_index
+    assert captured_command.index("--ntasks=1") < worker_index
 
 
 def test_sample_slurm_failure_keeps_job_dir_for_debugging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

`iqm.qdmi.offloader`'s `sample()` and `estimate()` hardcoded `--partition=quantum` and `--nodes=1` on the `srun` command line, so a site whose quantum partition carries a different name could not use the offloader at all. Both now take `partition` and `nodes` keyword arguments, threaded through the way `licenses` already is. `partition` resolves in the order explicit argument, then `IQM_SLURM_PARTITION`, then `quantum` — the precedence the SPANK plugin's `IQM_BASE_URL`/`IQM_QC_ID`/`IQM_QC_ALIAS` variables already follow. `nodes` gets no environment fallback: a node count is a per-job resource request rather than a site-wide constant. Nothing changes for a cluster already using `quantum`.

`--ntasks=1` is pinned beside `--nodes`. Without it `srun --nodes=N` defaults to one task per node, so any node count above one would launch `iqm-sampler`/`iqm-estimator` once per node — each copy submitting its own hardware job and writing its own base64 payload into the one captured stdout, where `_decode_payload` dies with a bare `binascii.Error: Incorrect padding`. `nodes` therefore sizes the allocation for a partition that demands more than one node; it does not parallelize the workload.

`docs/python_package.md` spells out the resolution order and gives `nodes` its own section. The administrator guide now names both places a renamed partition has to reach: `IQM_SLURM_PARTITION` for the offloader, and the SPANK plugin's own `partitions=` option — miss that one and the plugin skips those jobs and injects no `IQM_BASE_URL`, `IQM_QC_ID`, or `IQM_QC_ALIAS`, with only a debug-level log line to show for it. `IQM_SLURM_PARTITION` is listed in `.env.example` too.

Tests cover the resolution order for both entry points, the default and an explicit node count, and `--ntasks=1`, asserting by index rather than by membership since an option landing after the worker becomes the worker's own argument. `uvx nox@latest -s tests-3.14` reports 58 passed, 7 skipped (the skips are the live IQM backend tests, which need credentials); `uvx nox@latest -s lint` passes. No live integration workflow was run. `main` is merged in; the v1.4.0 cut moved this branch's changelog entry under `## [Unreleased]`.
