### PR TITLE
✅ Cover a quantum computer entry that names no alias

### DIFF
--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2159,6 +2159,32 @@ TEST_F(DeviceIntegrationMockTest,
 }
 
 TEST_F(DeviceIntegrationMockTest,
+       SessionInitializationRejectsQuantumComputersWithoutAnAlias) {
+  // Every endpoint the device reaches after the listing is addressed by alias,
+  // so an entry that names an ID but no alias cannot be used.
+  const std::string qc_list_without_aliases =
+      R"({"quantum_computers":[{"id":"01966208-f3ec-73b7-890d-100000000000","display_name":"x"}]})";
+  const auto requests_before = http_stub.get_urls().size();
+
+  // No selection criteria: the first entry is used.
+  http_stub.queue_get(200, qc_list_without_aliases);
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+  // Initialization stops at the listing instead of requesting an architecture
+  // for an empty alias.
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before + 1);
+
+  // Selection by ID: the matching entry still has to name its alias.
+  const std::string qc_id = "01966208-f3ec-73b7-890d-100000000000";
+  ASSERT_EQ(IQM_QDMI_device_session_set_parameter(
+                session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1,
+                qc_id.size() + 1, qc_id.c_str()),
+            QDMI_SUCCESS);
+  http_stub.queue_get(200, qc_list_without_aliases);
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_ERROR_FATAL);
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before + 2);
+}
+
+TEST_F(DeviceIntegrationMockTest,
        SessionInitializationSelectsQuantumComputerByAliasOrId) {
   const auto device_name = [](IQM_QDMI_Device_Session device_session) {
     size_t name_size = 0;


### PR DESCRIPTION
🤖 *AI text below* 🤖

A local fuzzing pass over the device's JSON response parsers produced a set of minimal reproducers, ten of which target the escaping exceptions and const-`operator[]` UB that #188 fixed. The plan was to land all ten as ordinary GoogleTest cases against `HttpStub` — they are deterministic and sub-millisecond, so they belong in the unit suite rather than under a fuzzer. Checking that plan before executing it changed it: nine of the ten are already in `test/unit/test_iqm_device.cpp`, several of them character-for-character, because #188 shipped its own regression tests alongside its fix. Re-adding them would be noise, so this PR adds the one case that is genuinely uncovered and reports the rest instead.

`SessionInitializationRejectsQuantumComputersWithoutAnAlias` scripts a quantum-computer listing whose entry carries an `id` but no `alias`. Every endpoint the device reaches after the listing is addressed by alias, so such an entry cannot be used and initialization has to stop there. The neighbouring `SessionInitializationRejectsQuantumComputersWithoutIdentifiers` drops both fields at once, so the `id` lookup fails before the alias is ever read — which leaves both `at("alias")` calls, the one in the select-by-ID branch and the one in the no-criteria branch, never reached with the key missing. The new test covers both branches, and asserts on the request count as well as on the return code: `HttpStub` never verifies that a queued response was consumed, so a return code alone would also pass if initialization had gone on to request an architecture for an empty alias.

That the other nine are regression guards rather than live bugs is a claim, so it was measured rather than asserted. All ten were translated, built against `9b4710d` — #188's parent — and run there. The build is Debug so that nlohmann's and libstdc++'s assertions are live; in Release the same expressions are silent out-of-bounds reads, which is the point of #188. All ten fail against `9b4710d` and all ten pass on `main`.

| reproducer | behaviour at `9b4710d` | covered on `main` by |
| --- | --- | --- |
| `qc_entry_without_alias` | abort — nlohmann const `operator[]` assertion | nothing; added here |
| `connectivity_edge_empty` | abort — `std::vector::operator[]` assertion | `SessionInitializationRejectsIncompleteStaticArchitecture`, `"connectivity":[[]]` |
| `connectivity_edge_too_short` | abort — `std::vector::operator[]` assertion | the same test, `"connectivity":[["QB1"]]` |
| `submission_without_id` | abort — nlohmann const `operator[]` assertion | `JobSubmissionRejectsResponsesWithoutJobId`, `{"queue_position": 3}` |
| `submission_id_not_a_string` | uncaught `json.exception.type_error.302` | the same test, `{"id": 5}` |
| `status_not_a_string` | uncaught `json.exception.type_error.302` | `JobStatusRejectsResponsesWithoutStatus`, `{"status": []}` |
| `status_response_not_json` | uncaught `json.exception.parse_error.101` | the same test, via the truncated `{"status": ` body |
| `counts_response_empty_array` | abort — `std::vector::operator[]` assertion | `HistogramResultsRejectMalformedCountsResponses`, `[]` |
| `counts_value_not_a_number` | uncaught `json.exception.type_error.302` | the same test, `"counts":{"0":"many"}` |
| `measurement_keys_not_strings` | uncaught `json.exception.type_error.302` | the same test, `"measurement_keys":[0]` |

The histogram cases are listed against `QDMI_JOB_RESULT_HIST_KEYS` only because `HIST_VALUES` shares the same parse and `QDMI_JOB_RESULT_SHOTS` reaches it through `IQM_QDMI_device_job_get_results_hist`, whose status it propagates — so the three result kinds do not give three distinct parse sites.

No `CHANGELOG.md` entry: a unit test covers no user-facing behaviour, and the behaviour it pins was already released with #188. Flagging that as a judgment call rather than leaving it silent.

The libFuzzer harness that produced the corpus is deliberately not part of this PR. Whether this repo wants a fuzzing target in tree is a separate question from whether these particular inputs are worth a test, and the answer here is mostly "already answered".

Unit suite green at 120 tests. `uvx nox -s lint` clean, and `clang-tidy` clean on the changed file. No integration test was run.
