### PR TITLE
🐛 Stop a malformed calibration set from crashing or misdescribing the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,8 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Survive a calibration set whose gate loci or coherence times have an
-  unexpected shape: drop a gate whose loci are absent, site-less, or of
-  differing sizes rather than advertising more sites than its reported arity
-  accounts for, and ignore a coherence time that no site property can represent
-  ([#204]) ([**@marcelwa**])
+  unexpected shape, dropping the affected gate or metric instead of crashing or
+  misreporting it ([#204]) ([**@marcelwa**])
 - 🐛 Report a cancellation that the server refuses because the job already
   finished as `QDMI_ERROR_INVALIDARGUMENT` rather than
   `QDMI_ERROR_PERMISSIONDENIED`, which said the session was not allowed to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ releases may include breaking changes.
 ### Fixed
 
 - 🐛 Survive a calibration set whose gate loci or coherence times have an
-  unexpected shape, instead of reading past the reported sites or converting an
-  out-of-range value ([#204]) ([**@marcelwa**])
+  unexpected shape: drop a gate whose loci are absent, site-less, or of
+  differing sizes rather than advertising more sites than its reported arity
+  accounts for, and ignore a coherence time that no site property can represent
+  ([#204]) ([**@marcelwa**])
 - 🐛 Report a cancellation that the server refuses because the job already
   finished as `QDMI_ERROR_INVALIDARGUMENT` rather than
   `QDMI_ERROR_PERMISSIONDENIED`, which said the session was not allowed to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Survive a calibration set whose gate loci or coherence times have an
+  unexpected shape, instead of reading past the reported sites or converting an
+  out-of-range value ([#204]) ([**@marcelwa**])
 - 🐛 Report the status the quantum computer is actually in, instead of pinning a
   session to busy from its first job submission onwards ([#190])
   ([**@marcelwa**])
@@ -179,6 +182,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#204]: https://github.com/iqm-finland/QDMI-on-IQM/pull/204
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -501,6 +501,42 @@ int Process_static_quantum_architecture(IQM_QDMI_Device_Session session) {
   return QDMI_SUCCESS;
 }
 
+/**
+ * @brief Check that a gate's loci can be described through QDMI.
+ *
+ * The operation property interface reports a single arity for the whole gate
+ * and flattens every locus into one site list, so loci that disagree on their
+ * size cannot be sliced apart again by a caller, and a gate without loci has
+ * no arity to report at all.
+ *
+ * @param gate_name The gate the loci belong to.
+ * @param loci The loci taken from the dynamic quantum architecture.
+ * @return True when every locus holds the same non-zero number of sites.
+ */
+bool Loci_are_describable(
+    const std::string &gate_name,
+    const std::vector<std::vector<IQM_QDMI_Site_impl_d *>> &loci) {
+  if (loci.empty()) {
+    LOG_ERROR("Gate '" + gate_name + "' reports no loci; skipping the gate");
+    return false;
+  }
+  const auto arity = loci.front().size();
+  if (arity == 0) {
+    LOG_ERROR("Gate '" + gate_name +
+              "' reports a locus without sites; skipping the gate");
+    return false;
+  }
+  if (std::ranges::any_of(
+          loci, [arity](const auto &locus) { return locus.size() != arity; })) {
+    LOG_ERROR("Gate '" + gate_name +
+              "' reports loci of differing sizes where " +
+              std::to_string(arity) +
+              " site(s) are expected throughout; skipping the gate");
+    return false;
+  }
+  return true;
+}
+
 int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
   LOG_INFO("Processing calibrated gates");
   const auto bearer_token = session->token_manager_->get_bearer_token();
@@ -537,24 +573,18 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
       continue; // Skip unsupported gates
     }
     LOG_DEBUG("Processing gate: " + gate_name);
-    auto &operation = session->operations_.emplace_back(
-        std::make_unique<IQM_QDMI_Operation_impl_d>());
-    operation->name_ = gate_name;
-    session->operations_ptr_.emplace_back(operation.get());
-    session->operations_map_[gate_name] = operation.get();
 
     const auto default_implementation =
         gate_details.at("default_implementation").get<std::string>();
-    operation->implementation_ = default_implementation;
     const auto &qubit_lists = gate_details.at("implementations")
                                   .at(default_implementation)
                                   .at("loci");
-    auto &operation_qubit_lists =
-        session->operations_sites_map_[operation.get()];
-    operation_qubit_lists.reserve(qubit_lists.size());
+
+    std::vector<std::vector<IQM_QDMI_Site_impl_d *>> loci;
+    loci.reserve(qubit_lists.size());
     for (const auto &qubit_list : qubit_lists) {
-      auto &qubit_list_vec = operation_qubit_lists.emplace_back();
-      qubit_list_vec.reserve(qubit_list.size());
+      auto &locus = loci.emplace_back();
+      locus.reserve(qubit_list.size());
       for (const auto &qubit : qubit_list) {
         const auto site_name = qubit.get<std::string>();
         const auto site_it = session->sites_map_.find(site_name);
@@ -567,9 +597,23 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
           LOG_ERROR(msg);
           return QDMI_ERROR_FATAL;
         }
-        qubit_list_vec.emplace_back(site_it->second);
+        locus.emplace_back(site_it->second);
       }
     }
+
+    // The operation is only registered once its loci can be reported, so that
+    // the property interface never sees a gate it cannot describe.
+    if (!Loci_are_describable(gate_name, loci)) {
+      continue;
+    }
+
+    auto &operation = session->operations_.emplace_back(
+        std::make_unique<IQM_QDMI_Operation_impl_d>());
+    operation->name_ = gate_name;
+    operation->implementation_ = default_implementation;
+    session->operations_ptr_.emplace_back(operation.get());
+    session->operations_map_[gate_name] = operation.get();
+    session->operations_sites_map_[operation.get()] = std::move(loci);
   }
   return QDMI_SUCCESS;
 }
@@ -586,7 +630,9 @@ std::optional<uint64_t> Coherence_time_in_microseconds(const std::string &key,
   const auto microseconds = seconds * 1e6;
   const auto upper_bound =
       static_cast<double>(std::numeric_limits<uint64_t>::max());
-  if (!std::isfinite(microseconds) || microseconds < 0.0 ||
+  // A value below one microsecond truncates to zero, which the site property
+  // interface already uses to mean that no coherence time was reported.
+  if (!std::isfinite(microseconds) || microseconds < 1.0 ||
       microseconds >= upper_bound) {
     LOG_ERROR("Metric '" + key +
               "' reports a value no coherence time can represent; ignoring it");
@@ -596,22 +642,26 @@ std::optional<uint64_t> Coherence_time_in_microseconds(const std::string &key,
 }
 
 /**
- * @brief Check that a calibrated locus holds the number of sites its gate acts
- * on.
- * @param gate_name The gate the locus belongs to.
- * @param locus The locus taken from the dynamic quantum architecture.
+ * @brief Check that a gate's loci hold the number of sites the gate acts on.
+ *
+ * Every locus of a registered gate holds the same number of sites, so the
+ * first one speaks for all of them.
+ *
+ * @param gate_name The gate the loci belong to.
+ * @param loci The loci taken from the dynamic quantum architecture.
  * @param arity The number of sites the gate acts on.
- * @return True when the locus holds exactly @p arity sites.
+ * @return True when the loci hold exactly @p arity sites each.
  */
-bool Locus_has_arity(const std::string &gate_name,
-                     const std::vector<IQM_QDMI_Site_impl_d *> &locus,
-                     size_t arity) {
-  if (locus.size() == arity) [[likely]] {
+bool Gate_has_arity(
+    const std::string &gate_name,
+    const std::vector<std::vector<IQM_QDMI_Site_impl_d *>> &loci,
+    size_t arity) {
+  if (!loci.empty() && loci.front().size() == arity) [[likely]] {
     return true;
   }
-  LOG_ERROR("Gate '" + gate_name + "' reports a locus of " +
-            std::to_string(locus.size()) + " site(s) where " +
-            std::to_string(arity) +
+  LOG_ERROR("Gate '" + gate_name + "' reports loci of " +
+            std::to_string(loci.empty() ? 0 : loci.front().size()) +
+            " site(s) where " + std::to_string(arity) +
             " are expected; skipping its quality metrics");
   return false;
 }
@@ -675,15 +725,15 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
     const auto &name = operation->name_;
     const auto &qubit_lists = session->operations_sites_map_[operation.get()];
     if (name == "measure") {
+      if (!Gate_has_arity(name, qubit_lists, 1)) {
+        continue;
+      }
       auto &single_qubit_fidelity_map =
           session->operations_single_qubit_fidelity_map_[operation.get()];
       const std::string measure_key =
           "metrics.ssro.measure." + operation->implementation_ + ".";
       single_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        if (!Locus_has_arity(name, qubit_list, 1)) {
-          continue;
-        }
         const auto &qubit = qubit_list[0];
         const auto measure_qubit_key = measure_key + qubit->name_ + ".fidelity";
         if (const auto metric = metrics.find(measure_qubit_key);
@@ -693,15 +743,15 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
       }
     }
     if (name == "prx") {
+      if (!Gate_has_arity(name, qubit_lists, 1)) {
+        continue;
+      }
       auto &single_qubit_fidelity_map =
           session->operations_single_qubit_fidelity_map_[operation.get()];
       const std::string prx_key =
           "metrics.rb.prx." + operation->implementation_ + ".";
       single_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        if (!Locus_has_arity(name, qubit_list, 1)) {
-          continue;
-        }
         const auto &qubit = qubit_list[0];
         const auto measure_qubit_key =
             prx_key + qubit->name_ + ".fidelity:par=d2";
@@ -712,15 +762,15 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
       }
     }
     if (name == "cz") {
+      if (!Gate_has_arity(name, qubit_lists, 2)) {
+        continue;
+      }
       auto &two_qubit_fidelity_map =
           session->operations_two_qubit_fidelity_map_[operation.get()];
       const std::string cz_key =
           "metrics.irb.cz." + operation->implementation_ + ".";
       two_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        if (!Locus_has_arity(name, qubit_list, 2)) {
-          continue;
-        }
         const auto &qubit1 = qubit_list[0];
         const auto &qubit2 = qubit_list[1];
         const auto cz_qubit_key =
@@ -2351,7 +2401,8 @@ int IQM_QDMI_device_session_query_operation_property(
        prop != QDMI_OPERATION_PROPERTY_CUSTOM3 &&
        prop != QDMI_OPERATION_PROPERTY_CUSTOM4 &&
        prop != QDMI_OPERATION_PROPERTY_CUSTOM5) ||
-      !session->operations_sites_map_.contains(operation)) {
+      !session->operations_sites_map_.contains(operation) ||
+      session->operations_sites_map_.at(operation).empty()) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   // General properties
@@ -2360,7 +2411,6 @@ int IQM_QDMI_device_session_query_operation_property(
 
   const auto &available_sites_for_op =
       session->operations_sites_map_.at(operation);
-  assert(!available_sites_for_op.empty());
   const auto num_op_sites = available_sites_for_op.front().size();
   ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t,
                             num_op_sites, prop, size, value, size_ret)

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <cpr/connection_pool.h>
 #include <cstdint>
 #include <cstdlib>
@@ -572,6 +573,48 @@ int Process_calibrated_gates(IQM_QDMI_Device_Session session) {
   return QDMI_SUCCESS;
 }
 
+/**
+ * @brief Convert a coherence time reported in seconds to whole microseconds.
+ * @param key The quality metric the value came from.
+ * @param seconds The value the server reported for that metric.
+ * @return The value in microseconds, or `std::nullopt` when it is negative,
+ * not finite, or too large for a `uint64_t`.
+ */
+std::optional<uint64_t> Coherence_time_in_microseconds(const std::string &key,
+                                                       double seconds) {
+  const auto microseconds = seconds * 1e6;
+  const auto upper_bound =
+      static_cast<double>(std::numeric_limits<uint64_t>::max());
+  if (!std::isfinite(microseconds) || microseconds < 0.0 ||
+      microseconds >= upper_bound) {
+    LOG_ERROR("Metric '" + key + "' reports " + std::to_string(seconds) +
+              " s, which no coherence time can represent; ignoring it");
+    return std::nullopt;
+  }
+  return static_cast<uint64_t>(microseconds);
+}
+
+/**
+ * @brief Check that a calibrated locus holds the number of sites its gate acts
+ * on.
+ * @param gate_name The gate the locus belongs to.
+ * @param locus The locus taken from the dynamic quantum architecture.
+ * @param arity The number of sites the gate acts on.
+ * @return True when the locus holds exactly @p arity sites.
+ */
+bool Locus_has_arity(const std::string &gate_name,
+                     const std::vector<IQM_QDMI_Site_impl_d *> &locus,
+                     size_t arity) {
+  if (locus.size() == arity) [[likely]] {
+    return true;
+  }
+  LOG_ERROR("Gate '" + gate_name + "' reports a locus of " +
+            std::to_string(locus.size()) + " site(s) where " +
+            std::to_string(arity) +
+            " are expected; skipping its quality metrics");
+  return false;
+}
+
 int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
   LOG_INFO(
       "Processing calibration set quality metrics for calibration set ID: " +
@@ -612,14 +655,18 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
     const std::string t1_key =
         "characterization.model." + qubit->name_ + ".t1_time";
     if (const auto t1_value = metrics.find(t1_key); t1_value != metrics.end()) {
-      // convert from seconds to us
-      qubit->t1_ = static_cast<uint64_t>(t1_value->second * 1e6);
+      if (const auto t1 =
+              Coherence_time_in_microseconds(t1_key, t1_value->second)) {
+        qubit->t1_ = *t1;
+      }
     }
     const std::string t2_key =
         "characterization.model." + qubit->name_ + ".t2_time";
     if (const auto t2_value = metrics.find(t2_key); t2_value != metrics.end()) {
-      // convert from seconds to us
-      qubit->t2_ = static_cast<uint64_t>(t2_value->second * 1e6);
+      if (const auto t2 =
+              Coherence_time_in_microseconds(t2_key, t2_value->second)) {
+        qubit->t2_ = *t2;
+      }
     }
   }
 
@@ -633,7 +680,9 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
           "metrics.ssro.measure." + operation->implementation_ + ".";
       single_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        assert(qubit_list.size() == 1);
+        if (!Locus_has_arity(name, qubit_list, 1)) {
+          continue;
+        }
         const auto &qubit = qubit_list[0];
         const auto measure_qubit_key = measure_key + qubit->name_ + ".fidelity";
         if (const auto metric = metrics.find(measure_qubit_key);
@@ -649,7 +698,9 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
           "metrics.rb.prx." + operation->implementation_ + ".";
       single_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        assert(qubit_list.size() == 1);
+        if (!Locus_has_arity(name, qubit_list, 1)) {
+          continue;
+        }
         const auto &qubit = qubit_list[0];
         const auto measure_qubit_key =
             prx_key + qubit->name_ + ".fidelity:par=d2";
@@ -666,7 +717,9 @@ int Process_calibration_metrics(IQM_QDMI_Device_Session session) {
           "metrics.irb.cz." + operation->implementation_ + ".";
       two_qubit_fidelity_map.reserve(qubit_lists.size());
       for (const auto &qubit_list : qubit_lists) {
-        assert(qubit_list.size() == 2);
+        if (!Locus_has_arity(name, qubit_list, 2)) {
+          continue;
+        }
         const auto &qubit1 = qubit_list[0];
         const auto &qubit2 = qubit_list[1];
         const auto cz_qubit_key =

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -587,8 +587,8 @@ std::optional<uint64_t> Coherence_time_in_microseconds(const std::string &key,
       static_cast<double>(std::numeric_limits<uint64_t>::max());
   if (!std::isfinite(microseconds) || microseconds < 0.0 ||
       microseconds >= upper_bound) {
-    LOG_ERROR("Metric '" + key + "' reports " + std::to_string(seconds) +
-              " s, which no coherence time can represent; ignoring it");
+    LOG_ERROR("Metric '" + key +
+              "' reports a value no coherence time can represent; ignoring it");
     return std::nullopt;
   }
   return static_cast<uint64_t>(microseconds);

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2553,7 +2553,7 @@ TEST_F(DeviceIntegrationMockTest, TwoQubitGateLocusWithOneSiteIsSkipped) {
   http_stub.queue_get(200, cocos_health_response);
 
   ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
-  EXPECT_NE(log_capture.str().find("Gate 'cz' reports a locus of 1 site(s)"),
+  EXPECT_NE(log_capture.str().find("Gate 'cz' reports loci of 1 site(s)"),
             std::string::npos);
 
   // The well-formed gate in the same response keeps its fidelity.
@@ -2592,9 +2592,8 @@ TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithTwoSitesIsSkipped) {
   http_stub.queue_get(200, cocos_health_response);
 
   ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
-  EXPECT_NE(
-      log_capture.str().find("Gate 'measure' reports a locus of 2 site(s)"),
-      std::string::npos);
+  EXPECT_NE(log_capture.str().find("Gate 'measure' reports loci of 2 site(s)"),
+            std::string::npos);
 
   const auto sites = Query_sites(session);
   ASSERT_EQ(sites.size(), 2U);
@@ -2604,7 +2603,7 @@ TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithTwoSitesIsSkipped) {
   EXPECT_DOUBLE_EQ(fidelity, 0.99);
 }
 
-TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithNoSitesIsSkipped) {
+TEST_F(DeviceIntegrationMockTest, GateWithASiteLessLocusIsNotRegistered) {
   const ScopedLogCapture log_capture;
   http_stub.queue_get(200, list_quantum_computers_response);
   http_stub.queue_get(200, get_static_quantum_architectures_response);
@@ -2629,8 +2628,11 @@ TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithNoSitesIsSkipped) {
   http_stub.queue_get(200, cocos_health_response);
 
   ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
-  EXPECT_NE(log_capture.str().find("Gate 'prx' reports a locus of 0 site(s)"),
+  EXPECT_NE(log_capture.str().find("Gate 'prx' reports a locus without sites"),
             std::string::npos);
+
+  // The gate is gone rather than advertised with an arity of zero.
+  EXPECT_EQ(Query_operation(session, "prx"), nullptr);
 
   const auto sites = Query_sites(session);
   ASSERT_EQ(sites.size(), 2U);
@@ -2638,6 +2640,109 @@ TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithNoSitesIsSkipped) {
   EXPECT_EQ(Query_fidelity(session, "measure", {sites.front()}, fidelity),
             QDMI_SUCCESS);
   EXPECT_DOUBLE_EQ(fidelity, 0.96);
+}
+
+/// The flattened site list an operation reports, and its declared arity.
+struct Operation_sites {
+  size_t arity;
+  size_t total_sites;
+};
+
+Operation_sites Query_operation_sites(IQM_QDMI_Device_Session session,
+                                      IQM_QDMI_Operation operation) {
+  Operation_sites result{};
+  EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                session, operation, 0, nullptr, 0, nullptr,
+                QDMI_OPERATION_PROPERTY_QUBITSNUM, sizeof(result.arity),
+                &result.arity, nullptr),
+            QDMI_SUCCESS);
+  size_t sites_size = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                session, operation, 0, nullptr, 0, nullptr,
+                QDMI_OPERATION_PROPERTY_SITES, 0, nullptr, &sites_size),
+            QDMI_SUCCESS);
+  result.total_sites = sites_size / sizeof(IQM_QDMI_Site);
+  return result;
+}
+
+TEST_F(DeviceIntegrationMockTest, GateWithLociOfDifferingSizesIsNotRegistered) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2"],
+      "computational_resonators": [],
+      "gates": {
+        "cz": {
+          "implementations": {"tgss": {"loci": [["QB1", "QB2"], ["QB1"]]}},
+          "default_implementation": "tgss",
+          "override_default_implementation": {}
+        },
+        "prx": {
+          "implementations": {
+            "drag_gaussian": {"loci": [["QB1"], ["QB2"]]}
+          },
+          "default_implementation": "drag_gaussian",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, SINGLE_QUBIT_QUALITY_METRICS);
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(log_capture.str().find("Gate 'cz' reports loci of differing sizes"),
+            std::string::npos);
+
+  // Reporting the gate would flatten three sites under an arity of two, which
+  // no caller can slice back into loci.
+  EXPECT_EQ(Query_operation(session, "cz"), nullptr);
+
+  auto *const prx = Query_operation(session, "prx");
+  ASSERT_NE(prx, nullptr);
+  const auto sites = Query_operation_sites(session, prx);
+  EXPECT_EQ(sites.arity, 1U);
+  EXPECT_EQ(sites.total_sites, 2U);
+}
+
+TEST_F(DeviceIntegrationMockTest, GateWithoutAnyLocusIsNotRegistered) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2"],
+      "computational_resonators": [],
+      "gates": {
+        "prx": {
+          "implementations": {"drag_gaussian": {"loci": []}},
+          "default_implementation": "drag_gaussian",
+          "override_default_implementation": {}
+        },
+        "measure": {
+          "implementations": {"constant": {"loci": [["QB1"], ["QB2"]]}},
+          "default_implementation": "constant",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, SINGLE_QUBIT_QUALITY_METRICS);
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(log_capture.str().find("Gate 'prx' reports no loci"),
+            std::string::npos);
+
+  // Reporting the gate would leave the property interface without an arity to
+  // read off its first locus.
+  EXPECT_EQ(Query_operation(session, "prx"), nullptr);
+
+  auto *const measure = Query_operation(session, "measure");
+  ASSERT_NE(measure, nullptr);
+  const auto sites = Query_operation_sites(session, measure);
+  EXPECT_EQ(sites.arity, 1U);
+  EXPECT_EQ(sites.total_sites, 2U);
 }
 
 TEST_F(DeviceIntegrationMockTest, CoherenceTimesOutsideUint64RangeAreIgnored) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2281,6 +2281,281 @@ TEST_F(DeviceIntegrationMockTest, QualityMetricObservationsMayOmitInvalidFlag) {
   EXPECT_EQ(t1, 20U);
 }
 
+/// Redirects logger output into a buffer the test can inspect, and restores
+/// the previous level and stream on destruction.
+class ScopedLogCapture {
+public:
+  ScopedLogCapture()
+      : previous_level_(iqm::Logger::get_instance().get_level()) {
+    auto &logger = iqm::Logger::get_instance();
+    logger.set_level(iqm::LOG_LEVEL::ERROR);
+    logger.set_output(stream_);
+  }
+
+  ~ScopedLogCapture() {
+    auto &logger = iqm::Logger::get_instance();
+    logger.set_output(std::cerr);
+    logger.set_level(previous_level_);
+  }
+
+  ScopedLogCapture(const ScopedLogCapture &) = delete;
+  ScopedLogCapture &operator=(const ScopedLogCapture &) = delete;
+  ScopedLogCapture(ScopedLogCapture &&) = delete;
+  ScopedLogCapture &operator=(ScopedLogCapture &&) = delete;
+
+  [[nodiscard]] std::string str() const { return stream_.str(); }
+
+private:
+  std::stringstream stream_;
+  iqm::LOG_LEVEL previous_level_;
+};
+
+/// The site handles an initialized session reports, in device order.
+std::vector<IQM_QDMI_Site> Query_sites(IQM_QDMI_Device_Session session) {
+  size_t sites_size = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES, 0, nullptr, &sites_size),
+            QDMI_SUCCESS);
+  std::vector<IQM_QDMI_Site> sites(sites_size / sizeof(IQM_QDMI_Site));
+  EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES, sites_size,
+                static_cast<void *>(sites.data()), nullptr),
+            QDMI_SUCCESS);
+  return sites;
+}
+
+/// The operation an initialized session reports under @p name, or nullptr.
+IQM_QDMI_Operation Query_operation(IQM_QDMI_Device_Session session,
+                                   const std::string &name) {
+  size_t operations_size = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_OPERATIONS, 0, nullptr,
+                &operations_size),
+            QDMI_SUCCESS);
+  std::vector<IQM_QDMI_Operation> operations(operations_size /
+                                             sizeof(IQM_QDMI_Operation));
+  EXPECT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_OPERATIONS, operations_size,
+                static_cast<void *>(operations.data()), nullptr),
+            QDMI_SUCCESS);
+  for (auto *const operation : operations) {
+    size_t name_size = 0;
+    EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                  session, operation, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_NAME, 0, nullptr, &name_size),
+              QDMI_SUCCESS);
+    std::string operation_name(name_size, '\0');
+    EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                  session, operation, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_NAME, name_size,
+                  operation_name.data(), nullptr),
+              QDMI_SUCCESS);
+    // The queried size includes the terminator that the property writes.
+    operation_name.resize(name_size - 1);
+    if (operation_name == name) {
+      return operation;
+    }
+  }
+  return nullptr;
+}
+
+/// The fidelity an initialized session reports for @p name on @p sites.
+int Query_fidelity(IQM_QDMI_Device_Session session, const std::string &name,
+                   const std::vector<IQM_QDMI_Site> &sites, double &fidelity) {
+  auto *const operation = Query_operation(session, name);
+  EXPECT_NE(operation, nullptr);
+  return IQM_QDMI_device_session_query_operation_property(
+      session, operation, sites.size(), sites.data(), 0, nullptr,
+      QDMI_OPERATION_PROPERTY_FIDELITY, sizeof(fidelity), &fidelity, nullptr);
+}
+
+/// Quality metrics for QB1 covering the measure, prx, and cz gates.
+constexpr auto SINGLE_QUBIT_QUALITY_METRICS = R"({
+    "observations": [
+      {
+        "dut_field": "metrics.ssro.measure.constant.QB1.fidelity",
+        "invalid": false,
+        "value": 0.96
+      },
+      {
+        "dut_field": "metrics.rb.prx.drag_gaussian.QB1.fidelity:par=d2",
+        "invalid": false,
+        "value": 0.99
+      },
+      {
+        "dut_field": "metrics.irb.cz.tgss.QB1__QB2.fidelity:par=d2",
+        "invalid": false,
+        "value": 0.97
+      }
+    ]
+  })";
+
+TEST_F(DeviceIntegrationMockTest, TwoQubitGateLocusWithOneSiteIsSkipped) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2"],
+      "computational_resonators": [],
+      "gates": {
+        "cz": {
+          "implementations": {"tgss": {"loci": [["QB1"]]}},
+          "default_implementation": "tgss",
+          "override_default_implementation": {}
+        },
+        "prx": {
+          "implementations": {
+            "drag_gaussian": {"loci": [["QB1"], ["QB2"]]}
+          },
+          "default_implementation": "drag_gaussian",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, SINGLE_QUBIT_QUALITY_METRICS);
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(log_capture.str().find("Gate 'cz' reports a locus of 1 site(s)"),
+            std::string::npos);
+
+  // The well-formed gate in the same response keeps its fidelity.
+  const auto sites = Query_sites(session);
+  ASSERT_EQ(sites.size(), 2U);
+  double fidelity = 0.0;
+  EXPECT_EQ(Query_fidelity(session, "prx", {sites.front()}, fidelity),
+            QDMI_SUCCESS);
+  EXPECT_DOUBLE_EQ(fidelity, 0.99);
+}
+
+TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithTwoSitesIsSkipped) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2"],
+      "computational_resonators": [],
+      "gates": {
+        "measure": {
+          "implementations": {"constant": {"loci": [["QB1", "QB2"]]}},
+          "default_implementation": "constant",
+          "override_default_implementation": {}
+        },
+        "prx": {
+          "implementations": {
+            "drag_gaussian": {"loci": [["QB1"], ["QB2"]]}
+          },
+          "default_implementation": "drag_gaussian",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, SINGLE_QUBIT_QUALITY_METRICS);
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(
+      log_capture.str().find("Gate 'measure' reports a locus of 2 site(s)"),
+      std::string::npos);
+
+  const auto sites = Query_sites(session);
+  ASSERT_EQ(sites.size(), 2U);
+  double fidelity = 0.0;
+  EXPECT_EQ(Query_fidelity(session, "prx", {sites.front()}, fidelity),
+            QDMI_SUCCESS);
+  EXPECT_DOUBLE_EQ(fidelity, 0.99);
+}
+
+TEST_F(DeviceIntegrationMockTest, SingleQubitGateLocusWithNoSitesIsSkipped) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "calibration_set_id": "f0fb4be5-e913-4a04-8c94-18d1bd842def",
+      "qubits": ["QB1", "QB2"],
+      "computational_resonators": [],
+      "gates": {
+        "measure": {
+          "implementations": {"constant": {"loci": [["QB1"], ["QB2"]]}},
+          "default_implementation": "constant",
+          "override_default_implementation": {}
+        },
+        "prx": {
+          "implementations": {"drag_gaussian": {"loci": [[]]}},
+          "default_implementation": "drag_gaussian",
+          "override_default_implementation": {}
+        }
+      }
+    })");
+  http_stub.queue_get(200, SINGLE_QUBIT_QUALITY_METRICS);
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(log_capture.str().find("Gate 'prx' reports a locus of 0 site(s)"),
+            std::string::npos);
+
+  const auto sites = Query_sites(session);
+  ASSERT_EQ(sites.size(), 2U);
+  double fidelity = 0.0;
+  EXPECT_EQ(Query_fidelity(session, "measure", {sites.front()}, fidelity),
+            QDMI_SUCCESS);
+  EXPECT_DOUBLE_EQ(fidelity, 0.96);
+}
+
+TEST_F(DeviceIntegrationMockTest, CoherenceTimesOutsideUint64RangeAreIgnored) {
+  const ScopedLogCapture log_capture;
+  http_stub.queue_get(200, list_quantum_computers_response);
+  http_stub.queue_get(200, get_static_quantum_architectures_response);
+  http_stub.queue_get(200, get_dynamic_quantum_architectures_response);
+  http_stub.queue_get(200, R"({
+      "observations": [
+        {
+          "dut_field": "characterization.model.QB1.t1_time",
+          "invalid": false,
+          "value": 2e111
+        },
+        {
+          "dut_field": "characterization.model.QB1.t2_time",
+          "invalid": false,
+          "value": -0.00001
+        },
+        {
+          "dut_field": "characterization.model.QB2.t1_time",
+          "invalid": false,
+          "value": 0.00002
+        }
+      ]
+    })");
+  http_stub.queue_get(200, cocos_health_response);
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  EXPECT_NE(log_capture.str().find("characterization.model.QB1.t1_time"),
+            std::string::npos);
+  EXPECT_NE(log_capture.str().find("characterization.model.QB1.t2_time"),
+            std::string::npos);
+
+  const auto sites = Query_sites(session);
+  ASSERT_EQ(sites.size(), 2U);
+  uint64_t coherence_time = 0;
+  EXPECT_EQ(IQM_QDMI_device_session_query_site_property(
+                session, sites.front(), QDMI_SITE_PROPERTY_T1,
+                sizeof(coherence_time), &coherence_time, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+  EXPECT_EQ(IQM_QDMI_device_session_query_site_property(
+                session, sites.front(), QDMI_SITE_PROPERTY_T2,
+                sizeof(coherence_time), &coherence_time, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+
+  // A representable value on another site is still reported.
+  EXPECT_EQ(IQM_QDMI_device_session_query_site_property(
+                session, sites.back(), QDMI_SITE_PROPERTY_T1,
+                sizeof(coherence_time), &coherence_time, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(coherence_time, 20U);
+}
+
 TEST_F(DeviceIntegrationMockTest, QueueLengthQueryContainsCxxExceptions) {
   queue_successful_initialization();
   ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);


### PR DESCRIPTION
🤖 *AI text below* 🤖

`Process_calibration_metrics` treated the dynamic architecture's `loci` arity as a programmer invariant and checked it with `assert()`. The project's default `CMAKE_BUILD_TYPE` is `Release`, so `NDEBUG` removes those checks from the configuration that actually ships, and the function goes on to index the locus and dereference what it finds. Server data was deciding whether the driver stayed inside its own memory.

Three shapes were reachable, all confirmed against an `-DNDEBUG` ASan/UBSan build: a `cz` entry with a one-element locus read past the vector (heap-buffer-overflow), and a `prx` or `measure` entry with an empty locus bound a reference to a null pointer and then dereferenced it for the site name. In a plain Release build the empty-locus case is a segfault during session initialization.

The same function converted `characterization.model.<qubit>.t1_time` and `.t2_time` with `static_cast<uint64_t>(value * 1e6)`. A value of `2e111`, or any negative one, is a `float-cast-overflow`. These values parse fine and have the right JSON type — they are the wrong magnitude — so the JSON access hardening in #188 does not reach them.

## The property interface trusted the same data

Guarding the metrics loop alone left the shape of `loci` unchecked where it decides how a caller reads a result. `QDMI_OPERATION_PROPERTY_QUBITSNUM` reports `available_sites_for_op.front().size()` — the arity of the *first* locus — while `QDMI_OPERATION_PROPERTY_SITES` flattens every locus into one list regardless of size. A `cz` reporting `[["QB1", "QB2"], ["QB1"]]` therefore advertises an arity of 2 over a list of 3 sites, and a caller slicing that list back into loci reads one element past the buffer it was handed. A gate reporting `"loci": []` has no first locus at all: the `assert` guarding `front()` is compiled out in Release, so querying its arity segfaults after initialization has already returned `QDMI_SUCCESS`.

## Validating the shape where it enters

Loci are now validated while the dynamic quantum architecture is parsed, and an operation is registered only once they hold the same non-zero number of sites. A gate whose loci are absent, site-less, or of differing sizes is dropped and named in the log, so the property interface never sees a gate it cannot describe. Because every registered gate then has a uniform arity, the arity check runs once per gate instead of once per locus, and the property interface rejects an empty site list rather than dereferencing past it.

A coherence time that is negative, not finite, larger than a `uint64_t` can hold, or below one microsecond is dropped and the metric named. That last case truncated to `0`, which `QDMI_SITE_PROPERTY_T1` already uses to mean "not reported", so an unusably small value was indistinguishable from an absent one.

Everything else in the calibration set is still processed, so one malformed entry no longer costs the whole session — the same degrade-rather-than-fail behavior this driver already applies to an absent optional endpoint. `assert` stays for invariants the server cannot influence.

Six regression tests drive the payloads through the existing `HttpStub`. Each asserts that initialization still succeeds, that the skipped entry appears in the log, and that the well-formed entries beside it keep their fidelity or coherence time; the two covering the property interface also assert that the malformed gate is absent and that a surviving gate's arity and site count stay consistent. Against the previous code the empty-locus case crashes with SIGSEGV, the one-element `cz` case ends in `QDMI_ERROR_FATAL`, and the mixed-arity case hands back three sites under an advertised arity of two. The ASan/UBSan job from #173 covers them a second way.

## Testing

Full unit suite green at 130 tests on this branch. `clang-tidy` clean on every changed file. Live integration tests were not run.
