### PR TITLE
🐛 Fix token expiry beyond 2038 and keep raw response bodies out of default logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ releases may include breaking changes.
 
 - 🔒️ Log raw HTTP error-response bodies at `DEBUG` instead of `ERROR`, so a
   response that echoes request contents no longer surfaces at the default log
-  level ([#205]) ([**@marcelwa**])
+  level, while still reporting the body's size and content type at `ERROR` so an
+  opaque upstream failure stays diagnosable ([#205]) ([**@marcelwa**])
 - 🐛 Keep authentication working past January 2038 by reading JWT expiry times
   as 64-bit values ([#205]) ([**@marcelwa**])
 - 🐛 Report a cancellation that the server refuses because the job already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,9 @@ releases may include breaking changes.
 
 ### Fixed
 
-- 🔒️ Log raw HTTP error-response bodies at `DEBUG` instead of `ERROR`, so a
-  response that echoes request contents no longer surfaces at the default log
-  level, while still reporting the body's size and content type at `ERROR` so an
-  opaque upstream failure stays diagnosable ([#205]) ([**@marcelwa**])
+- 🔒️ Log raw HTTP error-response bodies at `DEBUG` instead of `ERROR`, keeping
+  only their size and content type at the default log level ([#205])
+  ([**@marcelwa**])
 - 🐛 Keep authentication working past January 2038 by reading JWT expiry times
   as 64-bit values ([#205]) ([**@marcelwa**])
 - 🐛 Report a cancellation that the server refuses because the job already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🔒️ Log raw HTTP error-response bodies at `DEBUG` instead of `ERROR`, so a
+  response that echoes request contents no longer surfaces at the default log
+  level ([#205]) ([**@marcelwa**])
+- 🐛 Keep authentication working past January 2038 by reading JWT expiry times
+  as 64-bit values ([#205]) ([**@marcelwa**])
 - 🐛 Report the status the quantum computer is actually in, instead of pinning a
   session to busy from its first job submission onwards ([#190])
   ([**@marcelwa**])
@@ -179,6 +184,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#205]: https://github.com/iqm-finland/QDMI-on-IQM/pull/205
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/include/http_client.hpp
+++ b/include/http_client.hpp
@@ -68,24 +68,6 @@ cpr::Response Get(const cpr::Url &url,
                   std::chrono::milliseconds timeout = std::chrono::hours{1});
 
 /**
- * @brief Perform an optional HTTP GET request.
- *
- * Behaves like Get(), but downgrades non-success logging for capability
- * probes where missing endpoints are expected.
- *
- * @param url The target URL for the GET request.
- * @param bearer_token Bearer token used for authentication, if configured.
- * @param connection_pool Connection pool shared by the owning device session.
- * @param timeout Overall timeout for the request and any rate-limit retries.
- * @return CPR response object.
- */
-cpr::Response
-Get_optional(const cpr::Url &url,
-             const std::optional<cpr::Bearer> &bearer_token,
-             const cpr::ConnectionPool &connection_pool,
-             std::chrono::milliseconds timeout = std::chrono::hours{1});
-
-/**
  * @brief Perform an HTTP POST request.
  *
  * Sends an HTTP POST request to the specified URL with a JSON body. The

--- a/include/iqm_auth.hpp
+++ b/include/iqm_auth.hpp
@@ -32,7 +32,7 @@
 namespace iqm {
 
 // Constants
-constexpr auto REFRESH_MARGIN_SECONDS = 60;
+constexpr int64_t REFRESH_MARGIN_SECONDS = 60;
 
 /**
  * Authentication related errors.
@@ -62,7 +62,7 @@ public:
    * @param token JWT token
    * @return Time left on token in seconds
    */
-  static int time_left_seconds(const std::string &token);
+  static int64_t time_left_seconds(const std::string &token);
 
   /**
    * Constructor with explicit parameters.

--- a/src/internal/http_client.cpp
+++ b/src/internal/http_client.cpp
@@ -335,9 +335,13 @@ QDMI_STATUS Handle_response(const cpr::Response &response,
     }
   }
 
-  // Fall back to raw response if no structured errors are available
+  // The raw body is unvalidated server output that can echo request content,
+  // so it is confined to the DEBUG level.
   if (!logged_structured_error && !response.text.empty()) {
-    internal::Log_error(error_log_policy, "Response: " + response.text);
+    internal::Log_error(error_log_policy,
+                        "Response carries no structured error; the raw body is "
+                        "logged at DEBUG level");
+    LOG_DEBUG("Response: " + response.text);
   }
 
   // Log IQM messages if present (might contain additional context)

--- a/src/internal/http_client.cpp
+++ b/src/internal/http_client.cpp
@@ -336,11 +336,21 @@ QDMI_STATUS Handle_response(const cpr::Response &response,
   }
 
   // The raw body is unvalidated server output that can echo request content,
-  // so it is confined to the DEBUG level.
+  // so its content stays at DEBUG level. Its size and type are safe to report
+  // alongside the status, and are often all that separates an upstream proxy
+  // failure from one the device itself produced.
   if (!logged_structured_error && !response.text.empty()) {
-    internal::Log_error(error_log_policy,
-                        "Response carries no structured error; the raw body is "
-                        "logged at DEBUG level");
+    if (error_log_policy == ERROR_LOG_POLICY::LOG_AS_ERROR) {
+      const auto content_type = response.header.find("content-type");
+      internal::Log_error(error_log_policy,
+                          "Response carries no structured error: " +
+                              std::to_string(response.text.size()) +
+                              " byte(s) of " +
+                              (content_type == response.header.end()
+                                   ? std::string{"an unnamed content type"}
+                                   : content_type->second) +
+                              ", logged at DEBUG level");
+    }
     LOG_DEBUG("Response: " + response.text);
   }
 

--- a/src/internal/http_client.cpp
+++ b/src/internal/http_client.cpp
@@ -389,20 +389,6 @@ cpr::Response Get(const cpr::Url &url,
       });
 }
 
-cpr::Response Get_optional(const cpr::Url &url,
-                           const std::optional<cpr::Bearer> &bearer_token,
-                           const cpr::ConnectionPool &connection_pool,
-                           const std::chrono::milliseconds timeout) {
-  LOG_INFO("Performing GET request to " + url.str());
-  const auto &hooks = internal::Get_hooks();
-  const auto headers = internal::Make_headers();
-  return internal::Perform_with_retries(
-      url, timeout, [&](const auto remaining) {
-        return hooks.get(url, bearer_token, connection_pool, headers,
-                         remaining);
-      });
-}
-
 cpr::Response Post(const cpr::Url &url,
                    const std::optional<cpr::Bearer> &bearer_token,
                    const cpr::ConnectionPool &connection_pool,

--- a/src/internal/iqm_auth.cpp
+++ b/src/internal/iqm_auth.cpp
@@ -171,7 +171,7 @@ std::string Read_access_token_from_file(const std::string &path) {
 // TokenManager implementation
 //
 
-int TokenManager::time_left_seconds(const std::string &token) {
+int64_t TokenManager::time_left_seconds(const std::string &token) {
   if (token.empty()) {
     return 0;
   }
@@ -209,8 +209,9 @@ int TokenManager::time_left_seconds(const std::string &token) {
         nlohmann::json::parse(decoded); // NOLINT(misc-include-cleaner)
 
     // Get expiration time
-    const int exp_time = json.value("exp", 0);
-    return (std::max)(0, exp_time - static_cast<int>(std::time(nullptr)));
+    const auto exp_time = json.value("exp", int64_t{0});
+    return (std::max)(int64_t{0},
+                      exp_time - static_cast<int64_t>(std::time(nullptr)));
   } catch (const std::exception &e) {
     LOG_DEBUG("Failed to parse token body: " + std::string(e.what()));
     return 0;

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -146,10 +146,14 @@ struct IQM_QDMI_Device_Session_impl_d {
     size_t operator()(const std::pair<T1, T2> &p) const {
       const size_t hash1 = std::hash<T1>{}(p.first);
       const size_t hash2 = std::hash<T2>{}(p.second);
-      // Golden-ratio mixing as in boost::hash_combine. The shift terms keep
-      // (a, b) and (b, a) in different buckets, which matters because the
-      // two-qubit fidelity map is looked up in both orders.
-      return hash1 ^ (hash2 + 0x9e37'79b9U + (hash1 << 6U) + (hash1 >> 2U));
+      // Golden-ratio mixing as in boost::hash_combine, sized to the hash
+      // width. A plain XOR gives (a, b) and (b, a) the same hash, and the
+      // two-qubit fidelity map holds both orderings of neighbouring sites, so
+      // every such pair lands in one bucket. Key equality still tells them
+      // apart; this only keeps the buckets from degenerating into lists.
+      constexpr auto golden_ratio = static_cast<size_t>(
+          sizeof(size_t) >= 8 ? 0x9e37'79b9'7f4a'7c15ULL : 0x9e37'79b9ULL);
+      return hash1 ^ (hash2 + golden_ratio + (hash1 << 6U) + (hash1 >> 2U));
     }
   };
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -134,12 +134,21 @@ struct IQM_QDMI_Device_Session_impl_d {
                      std::unordered_map<IQM_QDMI_Site_impl_d *, double>>
       operations_single_qubit_fidelity_map_;
 
+  /// Hash for an ordered pair of sites.
   struct Pair_hash {
+    /**
+     * @brief Combine the hashes of both elements of a pair.
+     * @param p Pair to hash
+     * @return Hash value that depends on the order of the two elements
+     */
     template <class T1, class T2>
     size_t operator()(const std::pair<T1, T2> &p) const {
-      auto hash1 = std::hash<T1>{}(p.first);
-      auto hash2 = std::hash<T2>{}(p.second);
-      return hash1 ^ hash2;
+      const size_t hash1 = std::hash<T1>{}(p.first);
+      const size_t hash2 = std::hash<T2>{}(p.second);
+      // Golden-ratio mixing as in boost::hash_combine. The shift terms keep
+      // (a, b) and (b, a) in different buckets, which matters because the
+      // two-qubit fidelity map is looked up in both orders.
+      return hash1 ^ (hash2 + 0x9e37'79b9U + (hash1 << 6U) + (hash1 >> 2U));
     }
   };
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -747,7 +747,7 @@ int Initialize_device_session(IQM_QDMI_Device_Session session) {
   LOG_INFO("Checking whether calibration jobs are supported");
   const auto cocos_health_url =
       session->api_config_->url(iqm::API_ENDPOINT::COCOS_HEALTH);
-  const auto cocos_health_response = iqm::http::Get_optional(
+  const auto cocos_health_response = iqm::http::Get(
       cocos_health_url, session->token_manager_->get_bearer_token(),
       *session->connection_pool_, session->request_timeout_);
   const auto status = iqm::http::Handle_response(
@@ -2015,9 +2015,9 @@ Probe_quantum_computer(IQM_QDMI_Device_Session session,
 
   const auto url =
       session->api_config_->url(endpoint, *session->quantum_computer_id_);
-  const auto http_response = iqm::http::Get_optional(
-      url, session->token_manager_->get_bearer_token(),
-      *session->connection_pool_, session->request_timeout_);
+  const auto http_response =
+      iqm::http::Get(url, session->token_manager_->get_bearer_token(),
+                     *session->connection_pool_, session->request_timeout_);
   switch (iqm::http::Handle_response(
       http_response, iqm::http::ERROR_LOG_POLICY::LOG_AS_DEBUG)) {
   case QDMI_SUCCESS:

--- a/test/unit/http_stub.hpp
+++ b/test/unit/http_stub.hpp
@@ -52,7 +52,7 @@ struct Scripted_response {
 };
 
 /**
- * @brief Scripts HTTP responses so that iqm::http::Get/Get_optional/Post
+ * @brief Scripts HTTP responses so that iqm::http::Get/Post
  * (and everything built on top of them, up to and including the public
  * `IQM_QDMI_device_session_init`) can be exercised end-to-end without any
  * live network traffic or real time delays.

--- a/test/unit/test_http_client.cpp
+++ b/test/unit/test_http_client.cpp
@@ -45,11 +45,12 @@ class LoggerCapture {
 public:
   /**
    * @brief Redirect logger output to an internal string stream.
+   * @param level Level the logger runs at while the guard is alive.
    */
-  LoggerCapture()
+  explicit LoggerCapture(const iqm::LOG_LEVEL level = iqm::LOG_LEVEL::DEBUG)
       : logger_(&iqm::Logger::get_instance()),
         original_level_(logger_->get_level()) {
-    logger_->set_level(iqm::LOG_LEVEL::DEBUG);
+    logger_->set_level(level);
     logger_->set_output(log_stream_);
   }
 
@@ -121,6 +122,24 @@ TEST(HttpClientTest, InvalidJsonServerErrorFallsBackToRawResponse) {
   EXPECT_NE(logs.find("failed with HTTP 503 (Server Error)"),
             std::string::npos);
   EXPECT_NE(logs.find("Response: not-json"), std::string::npos);
+}
+
+TEST(HttpClientTest, RawResponseBodyStaysOutOfErrorLevelLogs) {
+  const LoggerCapture logger_capture{iqm::LOG_LEVEL::ERROR};
+
+  const auto ret = iqm::http::Handle_response(
+      Make_response(500, "https://example.test/jobs",
+                    R"({"access_token":"do-not-log-me"})"),
+      iqm::http::ERROR_LOG_POLICY::LOG_AS_ERROR);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+
+  const auto logs = logger_capture.str();
+  EXPECT_NE(logs.find("failed with HTTP 500 (Server Error)"),
+            std::string::npos);
+  EXPECT_NE(logs.find("the raw body is logged at DEBUG level"),
+            std::string::npos);
+  EXPECT_EQ(logs.find("do-not-log-me"), std::string::npos);
 }
 
 TEST(HttpClientTest, RedirectResponseLogsAdditionalMessages) {

--- a/test/unit/test_http_client.cpp
+++ b/test/unit/test_http_client.cpp
@@ -33,6 +33,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -83,11 +84,15 @@ private:
 };
 
 cpr::Response Make_response(const int64_t status_code, std::string url,
-                            std::string body) {
+                            std::string body,
+                            const std::string &content_type = "") {
   cpr::Response response;
   response.status_code = status_code;
   response.url = cpr::Url{std::move(url)};
   response.text = std::move(body);
+  if (!content_type.empty()) {
+    response.header["Content-Type"] = content_type;
+  }
   return response;
 }
 
@@ -126,10 +131,10 @@ TEST(HttpClientTest, InvalidJsonServerErrorFallsBackToRawResponse) {
 
 TEST(HttpClientTest, RawResponseBodyStaysOutOfErrorLevelLogs) {
   const LoggerCapture logger_capture{iqm::LOG_LEVEL::ERROR};
+  constexpr auto body = R"({"access_token":"do-not-log-me"})";
 
   const auto ret = iqm::http::Handle_response(
-      Make_response(500, "https://example.test/jobs",
-                    R"({"access_token":"do-not-log-me"})"),
+      Make_response(500, "https://example.test/jobs", body, "application/json"),
       iqm::http::ERROR_LOG_POLICY::LOG_AS_ERROR);
 
   EXPECT_EQ(ret, QDMI_ERROR_FATAL);
@@ -137,9 +142,38 @@ TEST(HttpClientTest, RawResponseBodyStaysOutOfErrorLevelLogs) {
   const auto logs = logger_capture.str();
   EXPECT_NE(logs.find("failed with HTTP 500 (Server Error)"),
             std::string::npos);
-  EXPECT_NE(logs.find("the raw body is logged at DEBUG level"),
-            std::string::npos);
   EXPECT_EQ(logs.find("do-not-log-me"), std::string::npos);
+
+  // The shape of the body still reaches the default log level, so an opaque
+  // upstream failure remains diagnosable without raising verbosity.
+  EXPECT_NE(logs.find("Response carries no structured error: " +
+                      std::to_string(std::string_view{body}.size()) +
+                      " byte(s) of application/json"),
+            std::string::npos);
+}
+
+TEST(HttpClientTest, UntypedResponseBodyIsReportedWithoutAContentType) {
+  const LoggerCapture logger_capture{iqm::LOG_LEVEL::ERROR};
+
+  const auto ret = iqm::http::Handle_response(
+      Make_response(502, "https://example.test/jobs", "<html>gateway</html>"),
+      iqm::http::ERROR_LOG_POLICY::LOG_AS_ERROR);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("20 byte(s) of an unnamed content type"),
+            std::string::npos);
+}
+
+TEST(HttpClientTest, RawResponseBodyReachesDebugLevelLogs) {
+  const LoggerCapture logger_capture{iqm::LOG_LEVEL::DEBUG};
+
+  const auto ret = iqm::http::Handle_response(
+      Make_response(500, "https://example.test/jobs", "opaque-upstream-detail"),
+      iqm::http::ERROR_LOG_POLICY::LOG_AS_ERROR);
+
+  EXPECT_EQ(ret, QDMI_ERROR_FATAL);
+  EXPECT_NE(logger_capture.str().find("Response: opaque-upstream-detail"),
+            std::string::npos);
 }
 
 TEST(HttpClientTest, RedirectResponseLogsAdditionalMessages) {

--- a/test/unit/test_http_client.cpp
+++ b/test/unit/test_http_client.cpp
@@ -200,13 +200,13 @@ TEST(HttpClientTest, BearerTokenIsPassedToHooks) {
 
   const auto get_response = iqm::http::Get("https://example.test/jobs",
                                            bearer_token, connection_pool);
-  const auto optional_get_response = iqm::http::Get_optional(
+  const auto probe_get_response = iqm::http::Get(
       "https://example.test/capability", bearer_token, connection_pool);
   const auto post_response = iqm::http::Post(
       "https://example.test/jobs", bearer_token, connection_pool, "{}");
 
   EXPECT_EQ(iqm::http::Handle_response(get_response), QDMI_SUCCESS);
-  EXPECT_EQ(iqm::http::Handle_response(optional_get_response), QDMI_SUCCESS);
+  EXPECT_EQ(iqm::http::Handle_response(probe_get_response), QDMI_SUCCESS);
   EXPECT_EQ(iqm::http::Handle_response(post_response), QDMI_SUCCESS);
 
   ASSERT_EQ(http_stub.get_bearer_tokens().size(), 2U);

--- a/test/unit/test_iqm_auth.cpp
+++ b/test/unit/test_iqm_auth.cpp
@@ -20,8 +20,10 @@
 #include "iqm_auth.hpp"
 
 #include <cpr/bearer.h>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <optional>
@@ -138,6 +140,22 @@ TEST(TokenManagerTest, TimeLeftSeconds) {
 
   // An empty token
   EXPECT_EQ(iqm::TokenManager::time_left_seconds(""), 0);
+}
+
+TEST(TokenManagerTest, TimeLeftSecondsHandlesExpiryBeyond2038) {
+  // "exp": 4102444800 is 2100-01-01T00:00:00Z, past the point where a signed
+  // 32-bit seconds count wraps.
+  constexpr int64_t expiry = 4'102'444'800;
+  const std::string token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                            "eyJleHAiOjQxMDI0NDQ4MDAsIm5iZiI6MTYyMDY3NTIwM"
+                            "CwiaWF0IjoxNjIwNjc1MjAwfQ.signature";
+
+  const auto before = static_cast<int64_t>(std::time(nullptr));
+  const auto time_left = iqm::TokenManager::time_left_seconds(token);
+  const auto after = static_cast<int64_t>(std::time(nullptr));
+
+  EXPECT_LE(expiry - after, time_left);
+  EXPECT_GE(expiry - before, time_left);
 }
 
 TEST(TokenManagerTest, ConstructorWithExplicitToken) {

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2281,6 +2281,66 @@ TEST_F(DeviceIntegrationMockTest, QualityMetricObservationsMayOmitInvalidFlag) {
   EXPECT_EQ(t1, 20U);
 }
 
+TEST_F(DeviceIntegrationMockTest, TwoQubitFidelityIsFoundInEitherSiteOrder) {
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+
+  size_t operations_size = 0;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_OPERATIONS, 0, nullptr,
+                &operations_size),
+            QDMI_SUCCESS);
+  std::vector<IQM_QDMI_Operation> operations(operations_size /
+                                             sizeof(IQM_QDMI_Operation));
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_OPERATIONS, operations_size,
+                static_cast<void *>(operations.data()), nullptr),
+            QDMI_SUCCESS);
+
+  const auto operation_name = [this](IQM_QDMI_Operation operation) {
+    size_t name_size = 0;
+    EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                  session, operation, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_NAME, 0, nullptr, &name_size),
+              QDMI_SUCCESS);
+    std::string name(name_size - 1, '\0');
+    EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                  session, operation, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_NAME, name_size, name.data(),
+                  nullptr),
+              QDMI_SUCCESS);
+    return name;
+  };
+  const auto cz =
+      std::ranges::find_if(operations, [&](IQM_QDMI_Operation operation) {
+        return operation_name(operation) == "cz";
+      });
+  ASSERT_NE(cz, operations.end());
+
+  std::vector<IQM_QDMI_Site> sites(2);
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_SITES,
+                sites.size() * sizeof(IQM_QDMI_Site),
+                static_cast<void *>(sites.data()), nullptr),
+            QDMI_SUCCESS);
+
+  const auto fidelity_for = [this,
+                             &cz](const std::array<IQM_QDMI_Site, 2> &locus) {
+    double fidelity = 0.0;
+    EXPECT_EQ(IQM_QDMI_device_session_query_operation_property(
+                  session, *cz, locus.size(), locus.data(), 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_FIDELITY, sizeof(fidelity), &fidelity,
+                  nullptr),
+              QDMI_SUCCESS);
+    return fidelity;
+  };
+
+  // The calibration set reports the CZ fidelity for the locus QB1__QB2 only,
+  // and both site orders name the same physical gate.
+  EXPECT_DOUBLE_EQ(fidelity_for({sites[0], sites[1]}), 0.97);
+  EXPECT_DOUBLE_EQ(fidelity_for({sites[1], sites[0]}), 0.97);
+}
+
 TEST_F(DeviceIntegrationMockTest, QueueLengthQueryContainsCxxExceptions) {
   queue_successful_initialization();
   ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);


### PR DESCRIPTION
🤖 *AI text below* 🤖

Four small, independent fixes, one commit each so any of them can be dropped without disturbing the rest — with one follow-up commit refining the log-level change, which travels with it. Two are bugs a user can hit — token expiry arithmetic and what a failed request writes to the log; the other two are a hash-quality improvement and the removal of a duplicated function, neither of which changes an answer.

**This PR originally carried a fifth change** — moving the log level to `IQM_LOG_LEVEL` — which pulled in seven workflow files, `pyproject.toml`, the SPANK plugin, and three documents. That was most of the diff and none of the substance, so it now lives in #206 and this PR is back to what it says on the tin.

## 🐛 JWT expiry arithmetic in 64-bit time

`TokenManager::time_left_seconds` read `exp` into an `int` and compared it against `static_cast<int>(std::time(nullptr))`. Both truncate in January 2038, after which a valid token reads as expired and authentication fails outright. It now returns `int64_t`, parses `exp` as `int64_t`, and compares against an `int64_t` clock; `REFRESH_MARGIN_SECONDS` follows so the comparison stays homogeneous.

`TimeLeftSecondsHandlesExpiryBeyond2038` pins a token expiring 2100-01-01 and brackets the result between two `std::time` reads. It fails against the previous behavior.

## 🩹 Site-pair hash depends on the order of its elements

`Pair_hash` combined the two site hashes with `hash1 ^ hash2`, which is symmetric, so `(a, b)` and `(b, a)` landed in the same bucket of `operations_two_qubit_fidelity_map_`. `operator==` kept lookups *correct*, so this was never a wrong-answer bug — but the map is deliberately queried in both orientations, which makes every two-qubit entry a guaranteed collision rather than an unlucky one. Replaced with a golden-ratio mix sized to the hash width — the 32-bit constant leaves the top half of a 64-bit `size_t` under-mixed, which would undercut the only thing the change is for.

**Stated plainly: the added test is a guard, not a regression test.** `TwoQubitFidelityIsFoundInEitherSiteOrder` passes before and after, because the old behavior was slow rather than wrong. It pins that both orders keep resolving.

## ♻️ Drop `Get_optional`, a verbatim copy of `Get`

The two functions had identical bodies. The `ERROR_LOG_POLICY` parameter that would justify the split is never consumed inside either one — callers apply it when they invoke `Handle_response`, not when they fetch. Deleted along with its declaration.

Three call sites, all updated: the CoCoS health probe and `Probe_quantum_computer` in `src/iqm_device.cpp`, plus one in `test/unit/test_http_client.cpp`. Both production callers pass `LOG_AS_DEBUG` to `Handle_response`, so the rationale holds for each. The stale `Get`/`Get_optional`/`Post` comment in `http_stub.hpp` is fixed too.

Not an API break: `include/` is not installed — only the generated prefixed QDMI headers ship — so no changelog entry.

## 🔒️ Keep raw HTTP response bodies out of ERROR-level logs

For an error response carrying no structured error field, `Handle_response` fell back to logging the whole body at ERROR, which is on by default. A server that echoes request contents therefore surfaced them without anyone opting in, and `AGENTS.md` requires never exposing token contents.

**Demotion to DEBUG rather than a redaction pass**, deliberately: redaction would be a heuristic over a body shape nobody specifies, where every miss is a silent leak, whereas the level boundary is exact and DEBUG already dumps raw POST payloads.

The default level *is* ERROR, though, so demoting the body alone would have made an opaque upstream failure — a proxy's HTML, a gateway's plain text — invisible without setting an environment variable and reproducing it. The ERROR line therefore reports the body's size and content type alongside the status. Neither carries request content, and together they are usually enough to tell an upstream failure from one the device produced.

`RawResponseBodyStaysOutOfErrorLevelLogs` asserts the secret stays out of ERROR while the size and type appear; `UntypedResponseBodyIsReportedWithoutAContentType` and `RawResponseBodyReachesDebugLevelLogs` cover the missing-header path and the body still reaching DEBUG.

## Testing

Full unit suite green at 129 tests on this branch. `uvx nox -s lint` clean. `clang-tidy` clean on every changed file. Live integration tests were not run.



