### PR TITLE
✨ Accept `IQM_LOG_LEVEL` as the log level environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,16 @@
 #IQM_TOKENS_FILE=
 
 # -------------------------------------------
+# Logging
+# -------------------------------------------
+
+# Verbosity of the QDMI device log, written to stderr
+# One of NONE, ERROR, INFO, DEBUG; any other value disables logging
+# DEBUG logs raw request and response bodies, so keep it off shared logs
+# Default: ERROR
+#IQM_LOG_LEVEL=
+
+# -------------------------------------------
 # Offloader Configuration
 # -------------------------------------------
 

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -75,7 +75,7 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
         run: ctest -C Debug --output-on-failure --test-dir build --timeout 600 --repeat until-pass:3
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/cpp-install-tests.yml
+++ b/.github/workflows/cpp-install-tests.yml
@@ -92,5 +92,5 @@ jobs:
         env:
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
         run: ctest -C Release --output-on-failure --test-dir build --timeout 600 --repeat until-pass:3

--- a/.github/workflows/cpp-sanitizers.yml
+++ b/.github/workflows/cpp-sanitizers.yml
@@ -54,7 +54,7 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
           ASAN_OPTIONS: "detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1"
           UBSAN_OPTIONS: "print_stacktrace=1"
         run: ctest --output-on-failure --test-dir build --timeout 900

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -58,5 +58,5 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
         run: ctest --output-on-failure --test-dir build --timeout 600 --repeat until-pass:3

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -63,5 +63,5 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
         run: ctest --output-on-failure --test-dir build --timeout 600 --repeat until-pass:3

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -59,5 +59,5 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: ${{ inputs.iqm-qc-alias }}
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
         run: ctest -C $env:CONFIG --output-on-failure --test-dir build --timeout 600 --repeat until-pass:3

--- a/.github/workflows/python-packaging-cibuildwheel.yml
+++ b/.github/workflows/python-packaging-cibuildwheel.yml
@@ -41,7 +41,7 @@ jobs:
           IQM_BASE_URL: "https://resonance.iqm.tech"
           IQM_QC_ALIAS: "emerald:mock"
           IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
-          IQM_CPP_API_LOG_LEVEL: "DEBUG"
+          IQM_LOG_LEVEL: "DEBUG"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Accept `IQM_LOG_LEVEL` as the environment variable that selects the log
+  level, and let the SPANK plugin inject it through `iqm_log_level` and
+  `--iqm-log-level`. `IQM_CPP_API_LOG_LEVEL` still works as a deprecated alias
+  ([#206]) ([**@marcelwa**])
 - 👷 Add an `IQM_QDMI_SANITIZERS` CMake option for building with
   AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer, or
   MemorySanitizer, and run the C++ test suite under ASan and UBSan in CI
@@ -179,6 +183,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#206]: https://github.com/iqm-finland/QDMI-on-IQM/pull/206
 [#190]: https://github.com/iqm-finland/QDMI-on-IQM/pull/190
 [#188]: https://github.com/iqm-finland/QDMI-on-IQM/pull/188
 [#187]: https://github.com/iqm-finland/QDMI-on-IQM/pull/187

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Accept `IQM_LOG_LEVEL` as the environment variable that selects the log
-  level, and let the SPANK plugin inject it through `iqm_log_level` and
-  `--iqm-log-level`, rejecting a value that names no level rather than silencing
-  the compute node. `IQM_CPP_API_LOG_LEVEL` still works as a deprecated alias,
-  now logging a notice when it is read; either variable counts as unset when it
-  is empty ([#206]) ([**@marcelwa**])
+  level, injected by the SPANK plugin through `iqm_log_level` and
+  `--iqm-log-level`. `IQM_CPP_API_LOG_LEVEL` still works as a deprecated alias
+  ([#206]) ([**@marcelwa**])
 - ✅ Cover the device's queue length, a queued job's position, retrieval of an
   existing job by ID, and its advertised program formats through MQT Core's
   Python QDMI API ([#195]) ([**@marcelwa**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ releases may include breaking changes.
 
 - ✨ Accept `IQM_LOG_LEVEL` as the environment variable that selects the log
   level, and let the SPANK plugin inject it through `iqm_log_level` and
-  `--iqm-log-level`. `IQM_CPP_API_LOG_LEVEL` still works as a deprecated alias
-  ([#206]) ([**@marcelwa**])
+  `--iqm-log-level`, rejecting a value that names no level rather than silencing
+  the compute node. `IQM_CPP_API_LOG_LEVEL` still works as a deprecated alias,
+  now logging a notice when it is read; either variable counts as unset when it
+  is empty ([#206]) ([**@marcelwa**])
 - ✅ Cover the device's queue length, a queued job's position, retrieval of an
   existing job by ID, and its advertised program formats through MQT Core's
   Python QDMI API ([#195]) ([**@marcelwa**])

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -22,6 +22,7 @@ job tasks.
 | `--iqm-tokens-file` | `IQM_TOKENS_FILE`    | Path to the file containing your access tokens.       |
 | `--iqm-qc-id`       | `IQM_QC_ID`          | The unique identifier of the target quantum computer. |
 | `--iqm-qc-alias`    | `IQM_QC_ALIAS`       | The alias of the target quantum computer.             |
+| `--iqm-log-level`   | `IQM_LOG_LEVEL`      | Verbosity of the QDMI device log on the compute node. |
 
 ### Credential Security
 

--- a/docs/spank_plugin.md
+++ b/docs/spank_plugin.md
@@ -16,13 +16,13 @@ job tasks.
 
 ### Supported Options
 
-| Option              | Environment Variable | Description                                           |
-| :------------------ | :------------------- | :---------------------------------------------------- |
-| `--iqm-base-url`    | `IQM_BASE_URL`       | The endpoint URL of the IQM service.                  |
-| `--iqm-tokens-file` | `IQM_TOKENS_FILE`    | Path to the file containing your access tokens.       |
-| `--iqm-qc-id`       | `IQM_QC_ID`          | The unique identifier of the target quantum computer. |
-| `--iqm-qc-alias`    | `IQM_QC_ALIAS`       | The alias of the target quantum computer.             |
-| `--iqm-log-level`   | `IQM_LOG_LEVEL`      | Verbosity of the QDMI device log on the compute node. |
+| Option              | Environment Variable | Description                                                                                                             |
+| :------------------ | :------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `--iqm-base-url`    | `IQM_BASE_URL`       | The endpoint URL of the IQM service.                                                                                    |
+| `--iqm-tokens-file` | `IQM_TOKENS_FILE`    | Path to the file containing your access tokens.                                                                         |
+| `--iqm-qc-id`       | `IQM_QC_ID`          | The unique identifier of the target quantum computer.                                                                   |
+| `--iqm-qc-alias`    | `IQM_QC_ALIAS`       | The alias of the target quantum computer.                                                                               |
+| `--iqm-log-level`   | `IQM_LOG_LEVEL`      | Verbosity of the QDMI device log on the compute node: `NONE`, `ERROR`, `INFO`, or `DEBUG`. Any other value is rejected. |
 
 ### Credential Security
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -691,13 +691,21 @@ IQM_QDMI_device_job_check(job, &status);
 ## Logging
 
 The project provides a simple logging mechanism to help you debug your
-application. You can control the logging level by setting the
-`IQM_CPP_API_LOG_LEVEL` environment variable. The following logging levels are
-available:
+application. You can control the logging level by setting the `IQM_LOG_LEVEL`
+environment variable. The following logging levels are available:
 
 - `NONE`: No logging.
 - `ERROR`: Log only errors.
 - `INFO`: Log errors and info messages.
 - `DEBUG`: Log errors, info, and debug messages.
 
-By default, the logging level is set to `ERROR`.
+By default, the logging level is set to `ERROR`. Any other value disables
+logging entirely.
+
+`DEBUG` logs raw request and response bodies, including the bodies of failed
+requests. Treat that output as sensitive and avoid it in shared logs.
+
+:::{note}
+`IQM_CPP_API_LOG_LEVEL` is a deprecated alias for `IQM_LOG_LEVEL`. It is only
+read when `IQM_LOG_LEVEL` is unset, and it will be removed in a future release.
+:::

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -707,5 +707,6 @@ requests. Treat that output as sensitive and avoid it in shared logs.
 
 :::{note}
 `IQM_CPP_API_LOG_LEVEL` is a deprecated alias for `IQM_LOG_LEVEL`. It is only
-read when `IQM_LOG_LEVEL` is unset, and it will be removed in a future release.
+read when `IQM_LOG_LEVEL` is unset or empty, and using it logs a notice at
+`ERROR` level. It will be removed in a future release.
 :::

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -63,6 +63,19 @@ public:
   static Logger &get_instance();
 
   /**
+   * Resolve the logging level configured in the environment.
+   *
+   * `IQM_LOG_LEVEL` names the level. `IQM_CPP_API_LOG_LEVEL` is a deprecated
+   * alias that is only consulted when `IQM_LOG_LEVEL` is unset. Recognized
+   * values are `NONE`, `ERROR`, `INFO`, and `DEBUG`; any other value disables
+   * logging.
+   *
+   * @return The configured level, or LOG_LEVEL::ERROR if neither variable is
+   * set.
+   */
+  static LOG_LEVEL level_from_environment();
+
+  /**
    * Get the current logging level.
    * @return The current logging level.
    */

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -66,9 +66,9 @@ public:
    * Resolve the logging level configured in the environment.
    *
    * `IQM_LOG_LEVEL` names the level. `IQM_CPP_API_LOG_LEVEL` is a deprecated
-   * alias that is only consulted when `IQM_LOG_LEVEL` is unset. Recognized
-   * values are `NONE`, `ERROR`, `INFO`, and `DEBUG`; any other value disables
-   * logging.
+   * alias that is only consulted when `IQM_LOG_LEVEL` is unset or empty.
+   * Recognized values are `NONE`, `ERROR`, `INFO`, and `DEBUG`; any other
+   * value disables logging.
    *
    * @return The configured level, or LOG_LEVEL::ERROR if neither variable is
    * set.

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -76,6 +76,14 @@ public:
   static LOG_LEVEL level_from_environment();
 
   /**
+   * The notice to emit about a deprecated log level variable.
+   *
+   * @return The notice, or an empty string when the level did not come from a
+   * deprecated variable.
+   */
+  static std::string deprecation_notice();
+
+  /**
    * Get the current logging level.
    * @return The current logging level.
    */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,7 @@ environment-pass = [
   "IQM_BASE_URL",
   "IQM_QC_ALIAS",
   "IQM_TOKEN",
+  "IQM_LOG_LEVEL",
   "IQM_CPP_API_LOG_LEVEL",
 ]
 

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -134,7 +134,27 @@ struct Config_mapping {
   const char *option_name;
   /// srun option usage description.
   const char *option_usage;
+  /// Check for the value, or nullptr when every non-empty value is accepted.
+  bool (*validate)(std::string_view) = nullptr;
 };
+
+/// Log level names the QDMI device library recognizes.
+constexpr std::array<std::string_view, 4> K_LOG_LEVELS = {"NONE", "ERROR",
+                                                          "INFO", "DEBUG"};
+
+/**
+ * @brief Check that a value names a log level the device library understands.
+ *
+ * The library maps every name it does not recognize onto "no logging at all",
+ * so an unchecked typo would silence the compute node instead of raising the
+ * verbosity that was asked for.
+ *
+ * @param value The value given for the log level.
+ * @return True when @p value names a recognized level.
+ */
+bool Is_valid_log_level(const std::string_view value) {
+  return std::ranges::find(K_LOG_LEVELS, value) != K_LOG_LEVELS.end();
+}
 
 /// A SPANK environment variable and its corresponding QDMI session parameter.
 struct Session_parameter_mapping {
@@ -175,7 +195,8 @@ constexpr std::array<Config_mapping, 5> K_CONFIG_MAPPINGS = {{
     {.key = "iqm_log_level",
      .env_var = "IQM_LOG_LEVEL",
      .option_name = "iqm-log-level",
-     .option_usage = "QDMI log level: NONE, ERROR, INFO, or DEBUG"},
+     .option_usage = "QDMI log level: NONE, ERROR, INFO, or DEBUG",
+     .validate = &Is_valid_log_level},
 }};
 
 /// Effective job values passed explicitly to the validation session.
@@ -297,11 +318,20 @@ public:
 
       bool matched = false;
       for (std::size_t j = 0; j < K_CONFIG_MAPPINGS.size(); ++j) {
-        if (key == K_CONFIG_MAPPINGS[j].key) {
-          plugstack_values_[j] = std::string{value};
-          matched = true;
-          break;
+        if (key != K_CONFIG_MAPPINGS[j].key) {
+          continue;
         }
+        const auto &validate = K_CONFIG_MAPPINGS[j].validate;
+        if (validate != nullptr && !validate(value)) {
+          slurm_spank_log("[iqm_spank_plugin] warning: ignoring invalid "
+                          "plugstack value for %s (expected %s)",
+                          std::string{key}.c_str(),
+                          K_CONFIG_MAPPINGS[j].option_usage);
+        } else {
+          plugstack_values_[j] = std::string{value};
+        }
+        matched = true;
+        break;
       }
 
       // Handle the partition filter argument.
@@ -1098,10 +1128,16 @@ int IQMSpankConfigManager::option_callback(const int val, const char *optarg,
     slurm_spank_log("[iqm_spank_plugin] error: invalid option id %d", val);
     return -1;
   }
+  const auto &mapping = K_CONFIG_MAPPINGS[static_cast<std::size_t>(val)];
   if (optarg == nullptr || optarg[0] == '\0') {
-    slurm_spank_log(
-        "[iqm_spank_plugin] error: empty value for --%s",
-        K_CONFIG_MAPPINGS[static_cast<std::size_t>(val)].option_name);
+    slurm_spank_log("[iqm_spank_plugin] error: empty value for --%s",
+                    mapping.option_name);
+    return -1;
+  }
+  if (mapping.validate != nullptr && !mapping.validate(optarg)) {
+    slurm_spank_log("[iqm_spank_plugin] error: invalid value '%s' for --%s "
+                    "(expected %s)",
+                    optarg, mapping.option_name, mapping.option_usage);
     return -1;
   }
   g_config.srun_values_[static_cast<std::size_t>(val)] = std::string{optarg};

--- a/spank/iqm_spank_plugin.cpp
+++ b/spank/iqm_spank_plugin.cpp
@@ -47,6 +47,7 @@
  *   - iqm_tokens_file  /  --iqm-tokens-file  → IQM_TOKENS_FILE
  *   - iqm_qc_id        /  --iqm-qc-id        → IQM_QC_ID
  *   - iqm_qc_alias     /  --iqm-qc-alias     → IQM_QC_ALIAS
+ *   - iqm_log_level    /  --iqm-log-level    → IQM_LOG_LEVEL
  *
  * Additional plugstack-only arguments:
  *   - partitions=quantum,quantum-dev (comma-separated, restricts activation)
@@ -154,7 +155,7 @@ struct Validation_state {
 };
 
 /// All recognized configuration entries and their mappings.
-constexpr std::array<Config_mapping, 4> K_CONFIG_MAPPINGS = {{
+constexpr std::array<Config_mapping, 5> K_CONFIG_MAPPINGS = {{
     {.key = "iqm_base_url",
      .env_var = "IQM_BASE_URL",
      .option_name = "iqm-base-url",
@@ -171,6 +172,10 @@ constexpr std::array<Config_mapping, 4> K_CONFIG_MAPPINGS = {{
      .env_var = "IQM_QC_ALIAS",
      .option_name = "iqm-qc-alias",
      .option_usage = "Quantum computer alias"},
+    {.key = "iqm_log_level",
+     .env_var = "IQM_LOG_LEVEL",
+     .option_name = "iqm-log-level",
+     .option_usage = "QDMI log level: NONE, ERROR, INFO, or DEBUG"},
 }};
 
 /// Effective job values passed explicitly to the validation session.

--- a/src/internal/logging.cpp
+++ b/src/internal/logging.cpp
@@ -89,15 +89,22 @@ LOG_LEVEL Logger::level_from_environment() {
   return LOG_LEVEL::ERROR;
 }
 
+std::string Logger::deprecation_notice() {
+  if (Non_empty_env(LOG_LEVEL_VARIABLE) != nullptr ||
+      Non_empty_env(DEPRECATED_LOG_LEVEL_VARIABLE) == nullptr) {
+    return {};
+  }
+  return std::string{DEPRECATED_LOG_LEVEL_VARIABLE} +
+         " is deprecated and will be removed in a future release; set " +
+         LOG_LEVEL_VARIABLE + " instead";
+}
+
 Logger::Logger()
     : current_level_(level_from_environment()), output_stream_(&std::cerr) {
   // Reported through this instance rather than the LOG_ERROR macro, which
   // would re-enter get_instance() while it is still constructing.
-  if (Non_empty_env(LOG_LEVEL_VARIABLE) == nullptr &&
-      Non_empty_env(DEPRECATED_LOG_LEVEL_VARIABLE) != nullptr) {
-    error(std::string{DEPRECATED_LOG_LEVEL_VARIABLE} +
-          " is deprecated and will be removed in a future release; set " +
-          LOG_LEVEL_VARIABLE + " instead");
+  if (const auto notice = deprecation_notice(); !notice.empty()) {
+    error(notice);
   }
 }
 

--- a/src/internal/logging.cpp
+++ b/src/internal/logging.cpp
@@ -34,18 +34,29 @@ Logger &Logger::get_instance() {
   return instance;
 }
 
-Logger::Logger()
-    : current_level_(LOG_LEVEL::ERROR), output_stream_(&std::cerr) {
-  if (const char *level_str = std::getenv("IQM_CPP_API_LOG_LEVEL")) {
-    if (const std::string level = level_str; level == "INFO") {
-      current_level_ = LOG_LEVEL::INFO;
-    } else if (level == "DEBUG") {
-      current_level_ = LOG_LEVEL::DEBUG;
-    } else if (level != "ERROR") {
-      current_level_ = LOG_LEVEL::NONE;
-    }
+LOG_LEVEL Logger::level_from_environment() {
+  const char *level_str = std::getenv("IQM_LOG_LEVEL");
+  if (level_str == nullptr) {
+    level_str = std::getenv("IQM_CPP_API_LOG_LEVEL");
   }
+  if (level_str == nullptr) {
+    return LOG_LEVEL::ERROR;
+  }
+  const std::string level = level_str;
+  if (level == "ERROR") {
+    return LOG_LEVEL::ERROR;
+  }
+  if (level == "INFO") {
+    return LOG_LEVEL::INFO;
+  }
+  if (level == "DEBUG") {
+    return LOG_LEVEL::DEBUG;
+  }
+  return LOG_LEVEL::NONE;
 }
+
+Logger::Logger()
+    : current_level_(level_from_environment()), output_stream_(&std::cerr) {}
 
 LOG_LEVEL Logger::get_level() const { return current_level_; }
 

--- a/src/internal/logging.cpp
+++ b/src/internal/logging.cpp
@@ -34,29 +34,72 @@ Logger &Logger::get_instance() {
   return instance;
 }
 
-LOG_LEVEL Logger::level_from_environment() {
-  const char *level_str = std::getenv("IQM_LOG_LEVEL");
-  if (level_str == nullptr) {
-    level_str = std::getenv("IQM_CPP_API_LOG_LEVEL");
+namespace {
+
+/// The environment variable that names the log level.
+constexpr auto LOG_LEVEL_VARIABLE = "IQM_LOG_LEVEL";
+/// The variable LOG_LEVEL_VARIABLE replaced, still read as a fallback.
+constexpr auto DEPRECATED_LOG_LEVEL_VARIABLE = "IQM_CPP_API_LOG_LEVEL";
+
+/**
+ * @brief Read an environment variable, treating an empty value as unset.
+ *
+ * Job schedulers and container runtimes routinely export a variable with an
+ * empty value, which must not count as a level the caller asked for.
+ *
+ * @param key Name of the environment variable.
+ * @return The value, or `nullptr` when it is unset or empty.
+ */
+const char *Non_empty_env(const char *key) {
+  const char *value = std::getenv(key);
+  if (value == nullptr || *value == '\0') {
+    return nullptr;
   }
-  if (level_str == nullptr) {
+  return value;
+}
+
+/**
+ * @brief Map a level name onto the level it selects.
+ * @param name The name given in the environment.
+ * @return The level, or LOG_LEVEL::NONE when @p name matches no level.
+ */
+LOG_LEVEL Level_from_name(const std::string &name) {
+  if (name == "ERROR") {
     return LOG_LEVEL::ERROR;
   }
-  const std::string level = level_str;
-  if (level == "ERROR") {
-    return LOG_LEVEL::ERROR;
-  }
-  if (level == "INFO") {
+  if (name == "INFO") {
     return LOG_LEVEL::INFO;
   }
-  if (level == "DEBUG") {
+  if (name == "DEBUG") {
     return LOG_LEVEL::DEBUG;
   }
   return LOG_LEVEL::NONE;
 }
 
+} // namespace
+
+LOG_LEVEL Logger::level_from_environment() {
+  if (const char *level = Non_empty_env(LOG_LEVEL_VARIABLE); level != nullptr) {
+    return Level_from_name(level);
+  }
+  if (const char *level = Non_empty_env(DEPRECATED_LOG_LEVEL_VARIABLE);
+      level != nullptr) {
+    return Level_from_name(level);
+  }
+  return LOG_LEVEL::ERROR;
+}
+
 Logger::Logger()
-    : current_level_(level_from_environment()), output_stream_(&std::cerr) {}
+    : current_level_(level_from_environment()), output_stream_(&std::cerr) {
+  // Reported through this instance rather than the LOG_ERROR macro, which
+  // would re-enter get_instance() while it is still constructing.
+  if (Non_empty_env(LOG_LEVEL_VARIABLE) == nullptr &&
+      Non_empty_env(DEPRECATED_LOG_LEVEL_VARIABLE) != nullptr) {
+    error(std::string{DEPRECATED_LOG_LEVEL_VARIABLE} +
+          " is deprecated and will be removed in a future release; set " +
+          LOG_LEVEL_VARIABLE + " instead");
+  }
+}
 
 LOG_LEVEL Logger::get_level() const { return current_level_; }
 

--- a/test/unit/test_logging.cpp
+++ b/test/unit/test_logging.cpp
@@ -19,21 +19,70 @@
 
 #include "logging.hpp"
 
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <optional>
 #include <sstream>
+#include <stdlib.h> // NOLINT(modernize-deprecated-headers)
 #include <string>
 
-// NOTE: The logger is a singleton, and its log level is set on the first call
-// to get_instance() based on the IQM_CPP_API_LOG_LEVEL environment variable.
-// Because gtest runs all tests in a single process, it's not possible to test
-// different log levels by setting the environment variable in different tests,
-// as the logger will only be initialized once.
-//
-// This test checks the default behavior, where the log level is ERROR.
-// To test other log levels, you would need to run tests in separate processes,
-// for example by using ctest with the --repeat-until-fail option and setting
-// the environment variable before running the test executable.
+namespace {
+int Set_env_var_raw(const char *key, const char *value) {
+#ifdef _WIN32
+  return _putenv_s(key, value);
+#else
+  return setenv(key, value, 1);
+#endif
+}
+
+int Unset_env_var_raw(const char *key) {
+#ifdef _WIN32
+  return _putenv_s(key, "");
+#else
+  return unsetenv(key);
+#endif
+}
+
+class ScopedEnvVar {
+public:
+  ScopedEnvVar(const char *key, const char *value) : key_(key) {
+    if (const char *existing_value = std::getenv(key);
+        existing_value != nullptr) {
+      previous_value_ = existing_value;
+    }
+    if (value != nullptr) {
+      EXPECT_EQ(Set_env_var_raw(key, value), 0);
+    } else {
+      EXPECT_EQ(Unset_env_var_raw(key), 0);
+    }
+  }
+
+  ScopedEnvVar(const ScopedEnvVar &) = delete;
+  ScopedEnvVar &operator=(const ScopedEnvVar &) = delete;
+  ScopedEnvVar(ScopedEnvVar &&) = delete;
+  ScopedEnvVar &operator=(ScopedEnvVar &&) = delete;
+
+  ~ScopedEnvVar() {
+    // Restore original process env var state for test isolation.
+    if (previous_value_.has_value()) {
+      static_cast<void>(
+          Set_env_var_raw(key_.c_str(), previous_value_->c_str()));
+    } else {
+      static_cast<void>(Unset_env_var_raw(key_.c_str()));
+    }
+  }
+
+private:
+  std::string key_;
+  std::optional<std::string> previous_value_;
+};
+} // namespace
+
+// NOTE: The logger is a singleton, and its own level is set on the first call
+// to get_instance(). Because gtest runs all tests in a single process, the
+// environment is exercised through level_from_environment() rather than
+// through repeated construction of the singleton.
 
 TEST(LoggingTest, DefaultLogLevel) {
   std::stringstream log_stream{};
@@ -54,4 +103,31 @@ TEST(LoggingTest, DefaultLogLevel) {
 
   // Restore original output stream
   logger.set_output(std::cerr);
+}
+
+TEST(LoggingTest, LogLevelIsReadFromTheEnvironment) {
+  const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", nullptr);
+  const auto level_for = [](const char *value) {
+    const ScopedEnvVar variable("IQM_LOG_LEVEL", value);
+    return iqm::Logger::level_from_environment();
+  };
+
+  EXPECT_EQ(level_for(nullptr), iqm::LOG_LEVEL::ERROR);
+  EXPECT_EQ(level_for("ERROR"), iqm::LOG_LEVEL::ERROR);
+  EXPECT_EQ(level_for("INFO"), iqm::LOG_LEVEL::INFO);
+  EXPECT_EQ(level_for("DEBUG"), iqm::LOG_LEVEL::DEBUG);
+  EXPECT_EQ(level_for("verbose"), iqm::LOG_LEVEL::NONE);
+}
+
+TEST(LoggingTest,
+     DeprecatedLogLevelVariableOnlyAppliesWhenTheCurrentOneIsUnset) {
+  const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", "DEBUG");
+
+  {
+    const ScopedEnvVar variable("IQM_LOG_LEVEL", nullptr);
+    EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::DEBUG);
+  }
+
+  const ScopedEnvVar variable("IQM_LOG_LEVEL", "INFO");
+  EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::INFO);
 }

--- a/test/unit/test_logging.cpp
+++ b/test/unit/test_logging.cpp
@@ -131,3 +131,24 @@ TEST(LoggingTest,
   const ScopedEnvVar variable("IQM_LOG_LEVEL", "INFO");
   EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::INFO);
 }
+
+TEST(LoggingTest, AnEmptyLogLevelVariableCountsAsUnset) {
+  // Schedulers and container runtimes export empty variables routinely, so an
+  // empty value must neither select a level nor hide the deprecated alias.
+  const ScopedEnvVar variable("IQM_LOG_LEVEL", "");
+
+  {
+    const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", nullptr);
+    EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::ERROR);
+  }
+
+  const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", "DEBUG");
+  EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::DEBUG);
+}
+
+TEST(LoggingTest, AnEmptyDeprecatedLogLevelVariableCountsAsUnset) {
+  const ScopedEnvVar variable("IQM_LOG_LEVEL", nullptr);
+  const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", "");
+
+  EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::ERROR);
+}

--- a/test/unit/test_logging.cpp
+++ b/test/unit/test_logging.cpp
@@ -152,3 +152,21 @@ TEST(LoggingTest, AnEmptyDeprecatedLogLevelVariableCountsAsUnset) {
 
   EXPECT_EQ(iqm::Logger::level_from_environment(), iqm::LOG_LEVEL::ERROR);
 }
+
+TEST(LoggingTest, TheDeprecatedVariableIsAnnouncedOnlyWhenItSuppliesTheLevel) {
+  const auto notice_for = [](const char *current, const char *deprecated) {
+    const ScopedEnvVar variable("IQM_LOG_LEVEL", current);
+    const ScopedEnvVar deprecated_variable("IQM_CPP_API_LOG_LEVEL", deprecated);
+    return iqm::Logger::deprecation_notice();
+  };
+
+  EXPECT_TRUE(notice_for(nullptr, nullptr).empty());
+  EXPECT_TRUE(notice_for("INFO", nullptr).empty());
+  EXPECT_TRUE(notice_for("INFO", "DEBUG").empty());
+  EXPECT_TRUE(notice_for(nullptr, "").empty());
+
+  const auto notice = notice_for(nullptr, "DEBUG");
+  EXPECT_NE(notice.find("IQM_CPP_API_LOG_LEVEL is deprecated"),
+            std::string::npos);
+  EXPECT_NE(notice.find("set IQM_LOG_LEVEL instead"), std::string::npos);
+}


### PR DESCRIPTION
🤖 *AI text below* 🤖

Split out of #205, which grew too large to review in one pass. That PR keeps the four small correctness fixes; this one carries the environment-variable change, which is where all of its breadth came from.

`IQM_CPP_API_LOG_LEVEL` is the odd one out in this package's environment family. Everything else a user sets is `IQM_BASE_URL`, `IQM_QC_ID`, `IQM_QC_ALIAS`, `IQM_TOKEN`, `IQM_TOKENS_FILE`, `IQM_JOBS_DIR` — and then the log level carries a `CPP_API` infix that describes an internal layer rather than anything the user picked. It is also the one variable the SPANK plugin does not inject, so a user on a Slurm cluster has no documented way to raise the log level of a job they just submitted. Those two facts compound: the variable is both hard to guess and unreachable where you most want it.

`IQM_LOG_LEVEL` becomes the primary name. `IQM_CPP_API_LOG_LEVEL` still works and is read only when the new name is unset or empty, so nothing that sets it today changes behavior. Empty counts as unset on purpose: schedulers and container runtimes export empty variables routinely, and since a name the parser does not recognize selects `NONE`, an exported-but-empty `IQM_LOG_LEVEL` would otherwise disable logging outright *and* hide a correctly set `IQM_CPP_API_LOG_LEVEL` — precisely the migration case the alias exists to cover. Reading the deprecated name now also logs a notice, so the alias does not quietly outlive its deprecation.

## The enabling change

Level resolution moved out of the `Logger` constructor into `Logger::level_from_environment()`. The singleton reads its level once per process, so the old code could not be exercised from a single test binary — the first test to touch the logger fixed the level for every test after it. Pulling the resolution into a static function makes the precedence rule directly testable, which is what the new tests in `test/unit/test_logging.cpp` do.

The deprecation notice went the same way, for the same reason: it started out inside the constructor, where a coverage run that sets the current variable never reaches it. `Logger::deprecation_notice()` decides and returns the text, the constructor only emits it, and the decision is covered directly.

## The SPANK side

The plugin now maps `iqm_log_level` in `plugstack.conf` and `--iqm-log-level` on the command line to `IQM_LOG_LEVEL`, through the same generic option table the other variables already use. An administrator can set a site default and a user can override it per job.

The value is checked against the levels the library accepts rather than passed straight through. Every name the library does not recognize means "no logging at all", so `--iqm-log-level=Debug` would otherwise silence the compute node for a user who asked for the opposite — and there is no way to warn them afterwards, because warning requires logging. The option table gained an optional per-entry validator for this, so `--iqm-log-level` fails at submission with the accepted names, and an invalid `plugstack.conf` value warns and is ignored instead of taking effect.

**Not covered by an automated test.** The SPANK plugin is compile-checked here against the local Slurm headers; the smoke and Docker suites were not run.

## Breadth, and why

Renaming a variable that CI passes through means touching every place that passes it: seven workflow files, `pyproject.toml`'s `environment-pass` for the wheel builds, `.env.example`, `docs/usage.md`, and `docs/spank_plugin.md`. That is mechanical, but it is most of the diff, and it is why this is worth reviewing on its own rather than alongside four unrelated fixes.

`docs/usage.md` also gains a warning that `DEBUG` logs raw request and response bodies. That was already true and undocumented; making the level easier to reach makes it worth saying out loud.

## Testing

Full unit suite green at 140 tests with `main` merged in. `uvx nox -s lint` clean. `clang-tidy` clean on every changed C++ file including `spank/iqm_spank_plugin.cpp`. Live integration tests were not run.




