### PR TITLE
🔖 Prepare release of v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-25
+
 ### Added
 
 - ✨ Take over the IQM JSON serialization and the `MoveGate` from MQT Core,
@@ -198,7 +200,8 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- Version links -->
 
-[Unreleased]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/iqm-finland/QDMI-on-IQM/compare/v1.1.0...v1.1.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.24...4.4)
 project(
   iqm-qdmi-device
   LANGUAGES C CXX
-  VERSION 1.3.0
+  VERSION 1.4.0
   DESCRIPTION "Implementation of a QDMI device for IQM Quantum Computers")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "iqm-qdmi"
-version = "1.3.0"
+version = "1.4.0"
 requires-python = ">=3.10"
 
 description = "Implementation of a QDMI device for IQM Quantum Computers"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "iqm-qdmi"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- curate the current Unreleased changelog entries into the 1.4.0 release dated 2026-08-25
- bump the CMake and Python package versions, and synchronize the lockfile

## Validation

- `uvx nox -s lint`
- `ctest -C Release --test-dir build-release/test/unit --output-on-failure` (140 passed)
- `uvx nox -s tests-3.13` (50 passed, 7 skipped)
- `uv build`
- `git diff --check`

`uvx nox -s docs` fails locally: `docs/qiskit.md` executes against Resonance and gets HTTP 401 without credentials. No live IQM, Slurm, or Resonance integration tests were run.
