### PR TITLE
🩹 Fail a job whose submission response carries no job ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ releases may include breaking changes.
 ### Fixed
 
 - 🩹 Fail a job whose submission the IQM Server accepted but whose response
-  carried no readable job ID, instead of leaving the handle submittable. A retry
-  would have queued a second job while the first ran untracked ([#213])
+  carried no readable job ID, instead of leaving the handle submittable ([#213])
   ([**@marcelwa**])
 
 ## [1.4.0] - 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🩹 Fail a job whose submission the IQM Server accepted but whose response
+  carried no readable job ID, instead of leaving the handle submittable. A retry
+  would have queued a second job while the first ran untracked ([#213])
+  ([**@marcelwa**])
+
 ## [1.4.0] - 2026-08-25
 
 ### Added
@@ -211,6 +218,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#213]: https://github.com/iqm-finland/QDMI-on-IQM/pull/213
 [#206]: https://github.com/iqm-finland/QDMI-on-IQM/pull/206
 [#205]: https://github.com/iqm-finland/QDMI-on-IQM/pull/205
 [#204]: https://github.com/iqm-finland/QDMI-on-IQM/pull/204

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1052,12 +1052,10 @@ Submission_queue_position(const nlohmann::json &response) {
 /**
  * @brief Fail a job whose submission response could not be read.
  * @details @ref iqm::http::Handle_response only reports success for HTTP 2xx,
- *          so by this point the IQM Server has accepted the request and a job
- *          is queued remotely. A response this client cannot read costs it the
- *          job ID, and with it every way to poll, cancel, or collect that job.
- *          Failing the handle keeps @ref IQM_QDMI_device_job_submit from
- *          accepting it a second time, because a retry would queue a duplicate
- *          job onto the hardware while the first one still runs untracked.
+ *          so the server has accepted the request and a job is queued
+ *          remotely. Without its ID there is no way to poll, cancel, or
+ *          collect it, and leaving the handle submittable invites a retry that
+ *          queues a duplicate.
  * @param job The job whose submission response was unreadable.
  */
 void Fail_unreadable_submission(IQM_QDMI_Device_Job job) {

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -1048,6 +1048,23 @@ Submission_queue_position(const nlohmann::json &response) {
   }
   return position->get<size_t>();
 }
+
+/**
+ * @brief Fail a job whose submission response could not be read.
+ * @details @ref iqm::http::Handle_response only reports success for HTTP 2xx,
+ *          so by this point the IQM Server has accepted the request and a job
+ *          is queued remotely. A response this client cannot read costs it the
+ *          job ID, and with it every way to poll, cancel, or collect that job.
+ *          Failing the handle keeps @ref IQM_QDMI_device_job_submit from
+ *          accepting it a second time, because a retry would queue a duplicate
+ *          job onto the hardware while the first one still runs untracked.
+ * @param job The job whose submission response was unreadable.
+ */
+void Fail_unreadable_submission(IQM_QDMI_Device_Job job) {
+  LOG_ERROR("The submission was accepted but its response carried no usable "
+            "job ID; the job may be running and cannot be tracked");
+  job->status_ = QDMI_JOB_STATUS_FAILED;
+}
 } // namespace
 
 int IQM_QDMI_device_session_retrieve_device_job_by_id(
@@ -1361,11 +1378,18 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
       nlohmann::json::parse(job_submission_response.text, nullptr, false);
   if (job_submission_json_response.is_discarded()) {
     LOG_ERROR("Failed to parse the job submission response");
+    Fail_unreadable_submission(job);
     return QDMI_ERROR_FATAL;
   }
   LOG_DEBUG("Job submission response:\n" + job_submission_json_response.dump());
 
-  job->job_id_ = job_submission_json_response.at("id").get<std::string>();
+  const auto job_id = job_submission_json_response.find("id");
+  if (job_id == job_submission_json_response.end() || !job_id->is_string()) {
+    LOG_ERROR("The job submission response carries no job ID");
+    Fail_unreadable_submission(job);
+    return QDMI_ERROR_FATAL;
+  }
+  job->job_id_ = job_id->get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
   // Log queue position if available
@@ -1402,12 +1426,19 @@ int IQM_QDMI_device_job_submit_calibration(IQM_QDMI_Device_Job job) {
       nlohmann::json::parse(job_submission_response.text, nullptr, false);
   if (job_submission_json_response.is_discarded()) {
     LOG_ERROR("Failed to parse the calibration job submission response");
+    Fail_unreadable_submission(job);
     return QDMI_ERROR_FATAL;
   }
   LOG_DEBUG("Calibration job submission response:\n" +
             job_submission_json_response.dump());
 
-  job->job_id_ = job_submission_json_response.at("id").get<std::string>();
+  const auto job_id = job_submission_json_response.find("id");
+  if (job_id == job_submission_json_response.end() || !job_id->is_string()) {
+    LOG_ERROR("The calibration job submission response carries no job ID");
+    Fail_unreadable_submission(job);
+    return QDMI_ERROR_FATAL;
+  }
+  job->job_id_ = job_id->get<std::string>();
   job->status_ = QDMI_JOB_STATUS_SUBMITTED;
 
   // Log queue position if available

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2034,6 +2034,29 @@ TEST_F(DeviceJobMockTest,
   EXPECT_EQ(http_stub.get_urls().size(), gets_after_submission + 1);
 }
 
+TEST_F(DeviceJobMockTest, CalibrationSubmissionWithoutAJobIdFailsTheJob) {
+  // The calibration path reads the submission response the same way the circuit
+  // path does, so an accepted submission this client cannot name must fail the
+  // job there too rather than invite a duplicate calibration run.
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CALIBRATION_CONFIG) + 1, TEST_CALIBRATION_CONFIG),
+            QDMI_SUCCESS);
+  constexpr auto format = QDMI_PROGRAM_FORMAT_CALIBRATION;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(format),
+                &format),
+            QDMI_SUCCESS);
+
+  http_stub.queue_post(200, R"({"queue_position": 2})");
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+
+  QDMI_Job_Status status{};
+  EXPECT_EQ(IQM_QDMI_device_job_check(job, &status), QDMI_SUCCESS);
+  EXPECT_EQ(status, QDMI_JOB_STATUS_FAILED);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_BADSTATE);
+}
+
 TEST_F(DeviceJobMockTest, FullLifecycleCalibration) {
   // Job submission
   auto ret = IQM_QDMI_device_job_set_parameter(
@@ -2856,18 +2879,33 @@ TEST_F(DeviceJobMockTest, JobSubmissionRejectsResponsesWithoutJobId) {
                 job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
 
-  http_stub.queue_post(200, R"({"queue_position": 3})");
-  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+  // The server accepted every one of these, so each leaves a job queued that
+  // this client cannot name. The handle is failed rather than left
+  // resubmittable, so a retry cannot queue a duplicate onto the hardware.
+  for (const auto *const response : {R"({"queue_position": 3})",
+                                     // A job ID of the wrong type must be
+                                     // reported, not retyped.
+                                     R"({"id": 5})", R"({"id": )"}) {
+    IQM_QDMI_Device_Job unreadable = nullptr;
+    ASSERT_EQ(IQM_QDMI_device_session_create_device_job(session, &unreadable),
+              QDMI_SUCCESS);
+    ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                  unreadable, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                  strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+              QDMI_SUCCESS);
 
-  // A job ID of the wrong type must be reported, not retyped.
-  http_stub.queue_post(200, R"({"id": 5})");
-  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+    http_stub.queue_post(200, response);
+    EXPECT_EQ(IQM_QDMI_device_job_submit(unreadable), QDMI_ERROR_FATAL);
 
-  http_stub.queue_post(200, R"({"id": )");
-  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
+    QDMI_Job_Status status{};
+    EXPECT_EQ(IQM_QDMI_device_job_check(unreadable, &status), QDMI_SUCCESS);
+    EXPECT_EQ(status, QDMI_JOB_STATUS_FAILED);
+    // A second submission would duplicate the job the server already took.
+    EXPECT_EQ(IQM_QDMI_device_job_submit(unreadable), QDMI_ERROR_BADSTATE);
 
-  // An unreadable submission response says nothing about the remote job, so
-  // the handle stays usable and can be submitted again.
+    IQM_QDMI_device_job_free(unreadable);
+  }
+
   http_stub.queue_post(200, R"({"id": "job-123"})");
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 }
@@ -3041,8 +3079,6 @@ TEST_F(DeviceJobMockTest, CalibrationResultsRejectMalformedStatusResponses) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT, sizeof(format),
                 &format),
             QDMI_SUCCESS);
-  http_stub.queue_post(200, R"({"id": )");
-  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
   http_stub.queue_post(200, R"({"id": "job-123"})");
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
   http_stub.queue_get(200, R"({"status": "ready"})");

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -2036,8 +2036,7 @@ TEST_F(DeviceJobMockTest,
 
 TEST_F(DeviceJobMockTest, CalibrationSubmissionWithoutAJobIdFailsTheJob) {
   // The calibration path reads the submission response the same way the circuit
-  // path does, so an accepted submission this client cannot name must fail the
-  // job there too rather than invite a duplicate calibration run.
+  // path does, so it must fail the job there too.
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CALIBRATION_CONFIG) + 1, TEST_CALIBRATION_CONFIG),
@@ -2880,12 +2879,9 @@ TEST_F(DeviceJobMockTest, JobSubmissionRejectsResponsesWithoutJobId) {
             QDMI_SUCCESS);
 
   // The server accepted every one of these, so each leaves a job queued that
-  // this client cannot name. The handle is failed rather than left
-  // resubmittable, so a retry cannot queue a duplicate onto the hardware.
-  for (const auto *const response : {R"({"queue_position": 3})",
-                                     // A job ID of the wrong type must be
-                                     // reported, not retyped.
-                                     R"({"id": 5})", R"({"id": )"}) {
+  // this client cannot name. A wrongly typed ID is reported, not retyped.
+  for (const auto *const response :
+       {R"({"queue_position": 3})", R"({"id": 5})", R"({"id": )"}) {
     IQM_QDMI_Device_Job unreadable = nullptr;
     ASSERT_EQ(IQM_QDMI_device_session_create_device_job(session, &unreadable),
               QDMI_SUCCESS);


### PR DESCRIPTION
🤖 *AI text below* 🤖

`Handle_response` reports success only for HTTP 2xx. So by the time a submit path parses the submission response, the IQM Server has accepted the request and a job is queued remotely. If that response then turns out to be unreadable — not JSON, or JSON without a string `id` — this client has lost the job ID, and with it every way to poll, cancel, or collect that job.

What happened next is the part worth looking at. `job->status_` was left at `QDMI_JOB_STATUS_CREATED`, which is exactly the state `IQM_QDMI_device_job_submit` requires, so the same handle accepted a second submission. A caller doing the natural thing on `QDMI_ERROR_FATAL` — retry — queues a duplicate job onto the hardware while the first one still runs untracked. On a shared, rate-limited quantum computer where submission is the most expensive request there is, that is the wrong direction to fail in.

This is a deliberate reversal, not an oversight being corrected. `JobSubmissionRejectsResponsesWithoutJobId` pinned the old behaviour explicitly:

```cpp
// An unreadable submission response says nothing about the remote job, so
// the handle stays usable and can be submitted again.
```

That premise does not hold at that point in the code. A 2xx *is* the server saying it took the job; the ambiguity the comment describes belongs to the branch above it, where `Handle_response` failed and the request may never have arrived. The two cases were treated as one. This PR splits them: a transport or HTTP failure keeps failing the job as before, and an accepted-but-unreadable submission now fails it too, for the opposite reason — not because the job probably does not exist, but because it probably does and cannot be reached.

If you would rather keep the handle retryable, the alternative is to say so in the docs and accept the duplicate-submission risk; I did not take that route because the caller has no way to detect the orphan and nothing to cancel it with. Happy to flip it if you read the trade-off the other way.

Also here: the job ID is now read through a `find` and an `is_string()` check rather than `at("id")`, so a wrongly typed ID is handled where it happens instead of unwinding into the entry point's catch-all.

### Tests

- `JobSubmissionRejectsResponsesWithoutJobId` drives a fresh job per malformed response and asserts each reports `QDMI_JOB_STATUS_FAILED` and refuses a retry with `QDMI_ERROR_BADSTATE`.
- `CalibrationSubmissionWithoutAJobIdFailsTheJob` covers the calibration submit path, which reads its response the same way.
- `CalibrationResultsRejectMalformedStatusResponses` opened by submitting an unreadable response and then resubmitting the same handle. That is incidental to the malformed *status* responses it exists to cover, and it relied on the behaviour being changed here, so it is gone.

141 unit tests pass locally.

### Note for #200

`IQM_QDMI_device_job_submit_run` on the pulse-level branch copies this same shape, so #200 will want the same treatment once whichever of the two lands second catches up.
