### PR TITLE
🐛 Free the device session when the FoMaC test helper throws

### DIFF
--- a/test/fomac/fomac.cpp
+++ b/test/fomac/fomac.cpp
@@ -29,12 +29,28 @@
 #include <iqm_qdmi/constants.h>
 #include <iqm_qdmi/device.h>
 #include <map>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
+
+namespace {
+/// @brief Frees a device session, for use as a `std::unique_ptr` deleter.
+struct Session_deleter {
+  void operator()(IQM_QDMI_Device_Session session) const noexcept {
+    IQM_QDMI_device_session_free(session);
+  }
+};
+
+/// A device session that frees itself when it goes out of scope.
+using Owned_session =
+    std::unique_ptr<std::remove_pointer_t<IQM_QDMI_Device_Session>,
+                    Session_deleter>;
+} // namespace
 
 auto FoMaC::throw_if_error(const int status, const std::string &message)
     -> void {
@@ -93,26 +109,29 @@ FoMaC::get_iqm_session(const std::string &base_url,
                        const std::optional<std::string> &tokens_file,
                        const std::optional<std::string> &qc_id,
                        const std::optional<std::string> &qc_alias) {
-  IQM_QDMI_Device_Session session = nullptr;
-  auto ret = IQM_QDMI_device_session_alloc(&session);
+  IQM_QDMI_Device_Session raw_session = nullptr;
+  auto ret = IQM_QDMI_device_session_alloc(&raw_session);
   throw_if_error(ret, "Failed to allocate IQM QDMI device session.");
+  // Every step below reports failure by throwing, and the caller has no handle
+  // to free until this function returns one.
+  Owned_session session{raw_session};
 
   // Set the session parameters
   ret = IQM_QDMI_device_session_set_parameter(
-      session, QDMI_DEVICE_SESSION_PARAMETER_BASEURL, base_url.size() + 1,
+      session.get(), QDMI_DEVICE_SESSION_PARAMETER_BASEURL, base_url.size() + 1,
       base_url.c_str());
   throw_if_error(ret, "Failed to set the base URL for the device session.");
 
   if (token.has_value()) {
     ret = IQM_QDMI_device_session_set_parameter(
-        session, QDMI_DEVICE_SESSION_PARAMETER_TOKEN, token->size() + 1,
+        session.get(), QDMI_DEVICE_SESSION_PARAMETER_TOKEN, token->size() + 1,
         token->c_str());
     throw_if_error(ret, "Failed to set the token for the device session.");
   }
 
   if (tokens_file.has_value()) {
     ret = IQM_QDMI_device_session_set_parameter(
-        session, QDMI_DEVICE_SESSION_PARAMETER_AUTHFILE,
+        session.get(), QDMI_DEVICE_SESSION_PARAMETER_AUTHFILE,
         tokens_file->size() + 1, tokens_file->c_str());
     throw_if_error(ret,
                    "Failed to set the tokens file for the device session.");
@@ -120,7 +139,7 @@ FoMaC::get_iqm_session(const std::string &base_url,
 
   if (qc_id.has_value()) {
     ret = IQM_QDMI_device_session_set_parameter(
-        session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1, qc_id->size() + 1,
+        session.get(), QDMI_DEVICE_SESSION_PARAMETER_CUSTOM1, qc_id->size() + 1,
         qc_id->c_str());
     throw_if_error(
         ret, "Failed to set the quantum computer ID for the device session.");
@@ -128,17 +147,17 @@ FoMaC::get_iqm_session(const std::string &base_url,
 
   if (qc_alias.has_value()) {
     ret = IQM_QDMI_device_session_set_parameter(
-        session, QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2, qc_alias->size() + 1,
-        qc_alias->c_str());
+        session.get(), QDMI_DEVICE_SESSION_PARAMETER_CUSTOM2,
+        qc_alias->size() + 1, qc_alias->c_str());
     throw_if_error(
         ret,
         "Failed to set the quantum computer alias for the device session.");
   }
 
-  ret = IQM_QDMI_device_session_init(session);
+  ret = IQM_QDMI_device_session_init(session.get());
   throw_if_error(ret, "Failed to initialize the device session.");
 
-  return session;
+  return session.release();
 }
 
 auto FoMaC::get_name() const -> std::string {


### PR DESCRIPTION
🤖 *AI text below* 🤖

`FoMaC::get_iqm_session` allocates a device session and then reports every subsequent failure by throwing — setting each parameter, and finally `IQM_QDMI_device_session_init`. The caller has no handle to free until the function returns one, so every one of those throws leaked the session. `QDMIIntegrationTest` does free the session in `TearDown`, but GoogleTest skips `TearDown` when `SetUp` throws, so that path never ran either.

This is invisible while the IQM Server is healthy, because `session_init` only throws when the server cannot be reached. It surfaced during a Resonance outage on #200, where the sanitizer job reported `675524 byte(s) leaked in 10254 allocation(s)` on top of the integration failure that caused it:

```
Direct leak of 680 byte(s) in 1 object(s) allocated from:
    #1 IQM_QDMI_device_session_alloc  src/iqm_device.cpp:335
    #2 FoMaC::get_iqm_session
    #3 SetUp  test/integration/test_iqm_device_integration.cpp:89
```

The leak report is the misleading part. An outage already fails the job on the test itself; the leak then fails it a second way, with an ASan diagnostic that looks like a memory bug in the device and is not one. Anyone reading that job has to rule the leak out before they can get to the real cause.

The session now goes into a `std::unique_ptr` with a deleter that calls `IQM_QDMI_device_session_free`, and is released on the successful return. Test-only; the device itself is untouched.

### Verification

Reproduced hermetically, no live backend involved — `IQM_BASE_URL=http://127.0.0.1:1` makes `session_init` fail the same way an outage does, under an ASan build:

- before: `ERROR: LeakSanitizer: detected memory leaks`, with the same `IQM_QDMI_device_session_alloc` frame as CI
- after: no leak report, same `Failed to initialize the device session.` exception in `SetUp`

The 140-test unit suite passes under the same ASan build.

No changelog entry: this is test-only, which this repository leaves out of the changelog.
