### PR TITLE
♻️ Adopt MQT Core's QDMI naming

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -210,6 +210,12 @@ target_link_libraries(my-application PRIVATE MQT::CoreFoMaC)
 mqt_copy_qdmi_runtime(my-application iqm-qdmi-device)
 ```
 
+:::{important}
+`MQT::CoreFoMaC` is the client target of the MQT Core 3.9 series this project
+requires. MQT Core 4 renames it to `MQT::CoreQDMI` and removes the old name.
+Link against `MQT::CoreQDMI` once you build against MQT Core 4.
+:::
+
 For dynamically linked consumers, automatic discovery searches beside the driver
 library rather than the executable. Such consumers must place the generated
 manifest in a discovered location or select a complete configuration with

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,12 +39,12 @@ To initiate a session with a particular endpoint and authentication method, the
 following code snippet can be used:
 
 ```cpp
-IQM_QDMI_Device_Session
-FoMaC::get_iqm_session(const std::string &base_url,
-                       const std::optional<std::string> &quantum_computer_id,
-                       const std::optional<std::string> &quantum_computer_alias,
-                       const std::optional<std::string> &token,
-                       const std::optional<std::string> &tokens_file) {
+IQM_QDMI_Device_Session QDMIClient::get_iqm_session(
+    const std::string &base_url,
+    const std::optional<std::string> &quantum_computer_id,
+    const std::optional<std::string> &quantum_computer_alias,
+    const std::optional<std::string> &token,
+    const std::optional<std::string> &tokens_file) {
   IQM_QDMI_Device_Session session = nullptr;
   auto ret = IQM_QDMI_device_session_alloc(&session);
 
@@ -387,7 +387,7 @@ returns `QDMI_ERROR_BADSTATE` when the refreshed job is not queued and
 position.
 
 ```cpp
-auto FoMaC::submit_job(
+auto QDMIClient::submit_job(
     const std::string &program, const QDMI_Program_Format format,
     const size_t num_shots, const std::string &heralding_mode,
     const std::string &move_validation_mode,
@@ -651,12 +651,12 @@ calibration job completes.
 Here's an example of submitting a calibration job:
 
 ```cpp
-auto *job = fomac.submit_job(TEST_CALIBRATION_CONFIG,
-                               QDMI_PROGRAM_FORMAT_CALIBRATION);
+auto *job = client.submit_job(TEST_CALIBRATION_CONFIG,
+                              QDMI_PROGRAM_FORMAT_CALIBRATION);
 IQM_QDMI_device_job_wait(job, 0);
 
 // Get the new calibration set ID
-const auto calibration_set_id = FoMaC::get_calibration_set_id(job);
+const auto calibration_set_id = QDMIClient::get_calibration_set_id(job);
 // The session is now updated with the new calibration data
 ```
 
@@ -679,7 +679,7 @@ When you check a job's status using {cpp:func}`IQM_QDMI_device_job_check()` and
 the job has failed, all errors and messages will be automatically logged:
 
 ```cpp
-auto *job = fomac.submit_job(TEST_PROGRAM, QDMI_PROGRAM_FORMAT_QIRBASESTRING);
+auto *job = client.submit_job(TEST_PROGRAM, QDMI_PROGRAM_FORMAT_QIRBASESTRING);
 IQM_QDMI_device_job_wait(job, 0);
 
 QDMI_Job_Status status;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_subdirectory(fomac)
+add_subdirectory(qdmi_client)
 add_subdirectory(integration)
 
 set(QDMI_PREFIX "IQM")

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(integration_tests test_iqm_device_integration.cpp)
 target_compile_features(integration_tests PRIVATE cxx_std_20)
 target_link_libraries(
   integration_tests PRIVATE GTest::gtest_main qdmi::qdmi_project_warnings
-                            qdmi::iqm_fomac)
+                            qdmi::iqm_client)
 add_dependencies(integration_tests qdmi_test_iqm_device_defs)
 
 if(WIN32)

--- a/test/integration/test_iqm_device_integration.cpp
+++ b/test/integration/test_iqm_device_integration.cpp
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
-#include "fomac.hpp"
 #include "iqm_qdmi/device.h"
+#include "qdmi_client.hpp"
 
 #include <algorithm>
 #include <array>
@@ -50,7 +50,7 @@ namespace {
 class QDMIIntegrationTest : public testing::Test {
 protected:
   IQM_QDMI_Device_Session session = nullptr;
-  FoMaC fomac{};
+  QDMIClient client{};
   std::optional<std::string> requested_qc_alias = std::nullopt;
 
   void SetUp() override {
@@ -85,9 +85,9 @@ protected:
             : std::nullopt;
     requested_qc_alias = qc_alias;
 
-    session =
-        FoMaC::get_iqm_session(base_url, token, tokens_file, qc_id, qc_alias);
-    fomac = FoMaC{session};
+    session = QDMIClient::get_iqm_session(base_url, token, tokens_file, qc_id,
+                                          qc_alias);
+    client = QDMIClient{session};
   }
 
   void TearDown() override {
@@ -101,8 +101,8 @@ protected:
 
   [[nodiscard]] auto get_qubit_sites() const -> std::vector<IQM_QDMI_Site> {
     std::vector<IQM_QDMI_Site> qubit_sites;
-    for (const auto &site : fomac.get_sites()) {
-      if (is_qubit_site_name(fomac.get_site_name(site))) {
+    for (const auto &site : client.get_sites()) {
+      if (is_qubit_site_name(client.get_site_name(site))) {
         qubit_sites.emplace_back(site);
       }
     }
@@ -110,18 +110,18 @@ protected:
   }
 
   [[nodiscard]] auto build_iqm_json_test_circuit() const -> std::string {
-    const auto ops = fomac.get_operation_map();
+    const auto ops = client.get_operation_map();
     const auto prx_it = ops.find("prx");
     const auto measure_it = ops.find("measure");
     if (prx_it == ops.end() || measure_it == ops.end()) {
       throw std::runtime_error("Missing mandatory operations (prx/measure).");
     }
 
-    const auto prx_sites = fomac.get_operation_sites(prx_it->second);
-    const auto measure_sites = fomac.get_operation_sites(measure_it->second);
+    const auto prx_sites = client.get_operation_sites(prx_it->second);
+    const auto measure_sites = client.get_operation_sites(measure_it->second);
     std::vector<IQM_QDMI_Site> eligible_single_sites;
     for (const auto &site : prx_sites) {
-      if (!is_qubit_site_name(fomac.get_site_name(site))) {
+      if (!is_qubit_site_name(client.get_site_name(site))) {
         continue;
       }
       if (std::ranges::find(measure_sites, site) != measure_sites.end()) {
@@ -133,7 +133,7 @@ protected:
     }
 
     auto *const q1 = eligible_single_sites.front();
-    const auto q1_name = fomac.get_site_name(q1);
+    const auto q1_name = client.get_site_name(q1);
 
     auto build_single_qubit = [&] {
       std::ostringstream circuit;
@@ -151,15 +151,15 @@ protected:
       return build_single_qubit();
     }
 
-    const auto cz_sites_flat = fomac.get_operation_sites(cz_it->second);
+    const auto cz_sites_flat = client.get_operation_sites(cz_it->second);
     std::vector<std::pair<IQM_QDMI_Site, IQM_QDMI_Site>> cz_pairs;
     for (size_t i = 0; i + 1 < cz_sites_flat.size(); i += 2) {
       cz_pairs.emplace_back(cz_sites_flat[i], cz_sites_flat[i + 1]);
     }
 
     for (const auto &[a, b] : cz_pairs) {
-      const auto a_name = fomac.get_site_name(a);
-      const auto b_name = fomac.get_site_name(b);
+      const auto a_name = client.get_site_name(a);
+      const auto b_name = client.get_site_name(b);
       if (!is_qubit_site_name(a_name) || !is_qubit_site_name(b_name)) {
         continue;
       }
@@ -189,7 +189,7 @@ protected:
     }
 
     if (const auto move_it = ops.find("move"); move_it != ops.end()) {
-      const auto move_sites_flat = fomac.get_operation_sites(move_it->second);
+      const auto move_sites_flat = client.get_operation_sites(move_it->second);
       std::vector<std::pair<IQM_QDMI_Site, IQM_QDMI_Site>> move_pairs;
       for (size_t i = 0; i + 1 < move_sites_flat.size(); i += 2) {
         move_pairs.emplace_back(move_sites_flat[i], move_sites_flat[i + 1]);
@@ -198,8 +198,8 @@ protected:
       for (const auto &[cz_first, cz_second] : cz_pairs) {
         IQM_QDMI_Site qubit = nullptr;
         IQM_QDMI_Site resonator = nullptr;
-        const auto first_name = fomac.get_site_name(cz_first);
-        const auto second_name = fomac.get_site_name(cz_second);
+        const auto first_name = client.get_site_name(cz_first);
+        const auto second_name = client.get_site_name(cz_second);
         if (is_qubit_site_name(first_name) &&
             !is_qubit_site_name(second_name)) {
           qubit = cz_first;
@@ -219,10 +219,10 @@ protected:
         for (const auto &[fst, snd] : move_pairs) {
           IQM_QDMI_Site second_qubit = nullptr;
           if (fst == resonator &&
-              is_qubit_site_name(fomac.get_site_name(snd))) {
+              is_qubit_site_name(client.get_site_name(snd))) {
             second_qubit = snd;
           } else if (snd == resonator &&
-                     is_qubit_site_name(fomac.get_site_name(fst))) {
+                     is_qubit_site_name(client.get_site_name(fst))) {
             second_qubit = fst;
           }
           if (second_qubit == nullptr || second_qubit == qubit ||
@@ -232,9 +232,9 @@ protected:
             continue;
           }
 
-          const auto qubit_name = fomac.get_site_name(qubit);
-          const auto second_qubit_name = fomac.get_site_name(second_qubit);
-          const auto resonator_name = fomac.get_site_name(resonator);
+          const auto qubit_name = client.get_site_name(qubit);
+          const auto second_qubit_name = client.get_site_name(second_qubit);
+          const auto resonator_name = client.get_site_name(resonator);
           std::ostringstream circuit;
           circuit << R"({"name":"test_circuit","instructions":[)";
           circuit << R"({"name":"prx","locus":[")" << qubit_name
@@ -344,44 +344,44 @@ attributes #1 = { "irreversible" }
 } // namespace
 
 TEST_F(QDMIIntegrationTest, QueryDeviceProperties) {
-  const auto device_name = fomac.get_name();
+  const auto device_name = client.get_name();
   ASSERT_FALSE(device_name.empty()) << "Device must provide a name";
   if (requested_qc_alias.has_value()) {
     EXPECT_EQ(device_name, *requested_qc_alias)
         << "Device name must match the selected QC alias";
   }
 
-  const auto version = fomac.get_version();
+  const auto version = client.get_version();
   ASSERT_FALSE(version.empty()) << "Device must provide a version";
 
-  const auto library_version = fomac.get_library_version();
+  const auto library_version = client.get_library_version();
   ASSERT_FALSE(library_version.empty())
       << "Device must provide a library version";
 
-  ASSERT_GT(fomac.get_qubits_num(), 0);
+  ASSERT_GT(client.get_qubits_num(), 0);
 
-  const auto gates = fomac.get_operation_map();
+  const auto gates = client.get_operation_map();
   ASSERT_GT(gates.size(), 0);
   for (const auto &[op_name, op] : gates) {
     ASSERT_FALSE(op_name.empty());
-    const auto name = fomac.get_operation_name(op);
+    const auto name = client.get_operation_name(op);
     EXPECT_EQ(op_name, name);
   }
 
-  const auto coupling_map = fomac.get_coupling_map();
-  if (const auto num_qubits = fomac.get_qubits_num(); num_qubits == 1) {
+  const auto coupling_map = client.get_coupling_map();
+  if (const auto num_qubits = client.get_qubits_num(); num_qubits == 1) {
     ASSERT_TRUE(coupling_map.empty());
   } else {
     ASSERT_GT(coupling_map.size(), 0);
   }
 
-  const auto duration_unit = fomac.get_duration_unit();
+  const auto duration_unit = client.get_duration_unit();
   ASSERT_FALSE(duration_unit.empty());
 
-  const auto duration_scale_factor = fomac.get_duration_scale_factor();
+  const auto duration_scale_factor = client.get_duration_scale_factor();
   ASSERT_GT(duration_scale_factor, 0.0);
 
-  const auto calibration_set_id = fomac.get_calibration_set_id();
+  const auto calibration_set_id = client.get_calibration_set_id();
   ASSERT_FALSE(calibration_set_id.empty())
       << "Device must provide a calibration set ID";
 
@@ -429,7 +429,7 @@ TEST_F(QDMIIntegrationTest, QueuePropertiesOnGarnetMock) {
   jobs.reserve(jobs_num);
   for (size_t i = 0; i < jobs_num; ++i) {
     jobs.emplace_back(
-        fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num));
+        client.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num));
   }
 
   // Poll the final job for as long as it plausibly sits in Garnet's queue.
@@ -481,25 +481,25 @@ TEST_F(QDMIIntegrationTest, QuerySiteProperties) {
   // The site list covers the qubits and, on Star-topology devices, the
   // computational resonators as well, so it is at least as long as the qubit
   // count and longer whenever the device has resonators.
-  const auto sites = fomac.get_sites();
-  const auto qubits_num = fomac.get_qubits_num();
+  const auto sites = client.get_sites();
+  const auto qubits_num = client.get_qubits_num();
   EXPECT_GE(sites.size(), qubits_num);
 
-  const auto duration_scale_factor = fomac.get_duration_scale_factor();
+  const auto duration_scale_factor = client.get_duration_scale_factor();
   ASSERT_GT(duration_scale_factor, 0.0);
 
   // Site IDs index the site list, so they are bounded by its size rather than
   // by the qubit count.
   for (const auto &site : sites) {
-    const auto site_id = fomac.get_site_index(site);
+    const auto site_id = client.get_site_index(site);
     EXPECT_LT(site_id, sites.size());
-    const auto site_name = fomac.get_site_name(site);
+    const auto site_name = client.get_site_name(site);
     EXPECT_FALSE(site_name.empty());
 
     // T1 and T2 properties are optional
     try {
       const auto t1 =
-          static_cast<double>(fomac.get_site_t1(site)) * duration_scale_factor;
+          static_cast<double>(client.get_site_t1(site)) * duration_scale_factor;
       EXPECT_GT(t1, 0.0) << "T1 should be positive when available";
     } catch (const std::runtime_error &) {
       // T1 property is not supported - this is acceptable
@@ -508,7 +508,7 @@ TEST_F(QDMIIntegrationTest, QuerySiteProperties) {
 
     try {
       const auto t2 =
-          static_cast<double>(fomac.get_site_t2(site)) * duration_scale_factor;
+          static_cast<double>(client.get_site_t2(site)) * duration_scale_factor;
       EXPECT_GT(t2, 0.0) << "T2 should be positive when available";
     } catch (const std::runtime_error &) {
       // T2 property is not supported - this is acceptable
@@ -545,13 +545,13 @@ TEST_F(QDMIIntegrationTest, QuerySiteProperties) {
 }
 
 TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
-  const auto ops = fomac.get_operation_map();
-  const auto coupling_map = fomac.get_coupling_map();
+  const auto ops = client.get_operation_map();
+  const auto coupling_map = client.get_coupling_map();
 
   for (const auto &op : ops | std::views::values) {
-    const auto gate_name = fomac.get_operation_name(op);
-    const auto gate_num_qubits = fomac.get_operation_operands_num(op);
-    const auto gate_num_params = fomac.get_operation_parameters_num(op);
+    const auto gate_name = client.get_operation_name(op);
+    const auto gate_num_qubits = client.get_operation_operands_num(op);
+    const auto gate_num_params = client.get_operation_parameters_num(op);
 
     if (gate_name == "prx_12") {
       continue; // The mock device does not expose calibration data for this
@@ -566,7 +566,7 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
     }
 
     // Query the supported sites for the operation
-    const auto supported_sites = fomac.get_operation_sites(op);
+    const auto supported_sites = client.get_operation_sites(op);
     EXPECT_FALSE(supported_sites.empty())
         << "Operation " + gate_name + " must support at least one site set";
 
@@ -575,7 +575,7 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
         // Fidelity property is optional
         try {
           const auto fidelity =
-              fomac.get_operation_fidelity(op, {site}, params);
+              client.get_operation_fidelity(op, {site}, params);
           EXPECT_GE(fidelity, 0.0)
               << "Fidelity should be between 0 and 1 when available";
           EXPECT_LE(fidelity, 1.0)
@@ -583,13 +583,13 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
         } catch (const std::invalid_argument &) {
           GTEST_LOG_(INFO) << "Fidelity property not available for operation " +
                                   gate_name + " on site " +
-                                  fomac.get_site_name(site);
+                                  client.get_site_name(site);
         } catch (const std::runtime_error &) {
           // Fidelity property is not supported - this is acceptable
           try {
             GTEST_LOG_(INFO)
                 << "Fidelity property not supported for operation " +
-                       gate_name + " on site " + fomac.get_site_name(site);
+                       gate_name + " on site " + client.get_site_name(site);
           } catch (...) {
             // If we can't get site names, just log without them
             GTEST_LOG_(INFO)
@@ -600,19 +600,19 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
         // Duration property is optional
         try {
           const auto duration =
-              fomac.get_operation_duration(op, {site}, params);
+              client.get_operation_duration(op, {site}, params);
           EXPECT_GT(duration, 0.0)
               << "Duration should be positive when available";
         } catch (const std::invalid_argument &) {
           GTEST_LOG_(INFO) << "Duration property not available for operation " +
                                   gate_name + " on site " +
-                                  fomac.get_site_name(site);
+                                  client.get_site_name(site);
         } catch (const std::runtime_error &) {
           // Duration property is not supported - this is acceptable
           try {
             GTEST_LOG_(INFO)
                 << "Duration property not supported for operation " +
-                       gate_name + " on site " + fomac.get_site_name(site);
+                       gate_name + " on site " + client.get_site_name(site);
           } catch (...) {
             // If we can't get site names, just log without them
             GTEST_LOG_(INFO)
@@ -638,8 +638,8 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
           // Try to get site names for better error message
           try {
             FAIL() << "Operation " + gate_name + " supports site pair (" +
-                          fomac.get_site_name(control) + ", " +
-                          fomac.get_site_name(target) +
+                          client.get_site_name(control) + ", " +
+                          client.get_site_name(target) +
                           ") which is not in the coupling map";
           } catch (...) {
             // If we can't get site names, fail without them
@@ -665,7 +665,7 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
         // Fidelity property is optional
         try {
           const auto fidelity =
-              fomac.get_operation_fidelity(op, {control, target}, params);
+              client.get_operation_fidelity(op, {control, target}, params);
           EXPECT_GE(fidelity, 0.0)
               << "Fidelity should be between 0 and 1 when available";
           EXPECT_LE(fidelity, 1.0)
@@ -678,8 +678,9 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
           try {
             GTEST_LOG_(INFO)
                 << "Fidelity property not supported for operation " +
-                       gate_name + " on sites " + fomac.get_site_name(control) +
-                       ", " + fomac.get_site_name(target);
+                       gate_name + " on sites " +
+                       client.get_site_name(control) + ", " +
+                       client.get_site_name(target);
           } catch (...) {
             // If we can't get site names, just log without them
             GTEST_LOG_(INFO)
@@ -699,7 +700,7 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
         // Duration property is optional
         try {
           const auto duration =
-              fomac.get_operation_duration(op, {control, target}, params);
+              client.get_operation_duration(op, {control, target}, params);
           EXPECT_GT(duration, 0.0)
               << "Duration should be positive when available";
         } catch (const std::invalid_argument &e) {
@@ -710,8 +711,9 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
           try {
             GTEST_LOG_(INFO)
                 << "Duration property not supported for operation " +
-                       gate_name + " on sites " + fomac.get_site_name(control) +
-                       ", " + fomac.get_site_name(target);
+                       gate_name + " on sites " +
+                       client.get_site_name(control) + ", " +
+                       client.get_site_name(target);
           } catch (...) {
             // If we can't get site names, just log without them
             GTEST_LOG_(INFO)
@@ -763,8 +765,9 @@ TEST_F(QDMIIntegrationTest, QueryGatePropertiesForEachGate) {
 TEST_F(QDMIIntegrationTest, JobCycle) {
   constexpr size_t shots_num = 64;
   const auto circuit = build_iqm_json_test_circuit();
-  auto *job = fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
-  const auto job_id = FoMaC::get_job_id(job);
+  auto *job =
+      client.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
+  const auto job_id = QDMIClient::get_job_id(job);
   const auto status = wait_for_done(job);
   if (should_skip_for_expected_mock_failure(status)) {
     IQM_QDMI_device_job_free(job);
@@ -775,7 +778,7 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
   }
   ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
 
-  const auto counts = FoMaC::get_histogram(job);
+  const auto counts = QDMIClient::get_histogram(job);
 
   size_t sum = 0;
   std::cout << "Counts: {\n";
@@ -865,10 +868,10 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
   ASSERT_EQ(IQM_QDMI_device_session_retrieve_device_job_by_id(
                 session, job_id.c_str(), &retrieved_job),
             QDMI_SUCCESS);
-  EXPECT_EQ(FoMaC::get_job_id(retrieved_job), job_id);
+  EXPECT_EQ(QDMIClient::get_job_id(retrieved_job), job_id);
   EXPECT_EQ(IQM_QDMI_device_job_submit(retrieved_job), QDMI_ERROR_BADSTATE);
   EXPECT_EQ(wait_for_done(retrieved_job), QDMI_JOB_STATUS_DONE);
-  const auto retrieved_counts = FoMaC::get_histogram(retrieved_job);
+  const auto retrieved_counts = QDMIClient::get_histogram(retrieved_job);
   const auto retrieved_sum =
       std::accumulate(retrieved_counts.begin(), retrieved_counts.end(),
                       size_t{0}, [](const size_t total, const auto &entry) {
@@ -895,7 +898,8 @@ TEST_F(QDMIIntegrationTest, JobCycle) {
 TEST_F(QDMIIntegrationTest, JobCancellation) {
   constexpr size_t shots_num = 64;
   const auto circuit = build_iqm_json_test_circuit();
-  auto *job = fomac.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
+  auto *job =
+      client.submit_job(circuit, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num);
 
   // A mock job of this size can reach a terminal status before the cancellation
   // request lands, and a job that is no longer running can no longer be
@@ -936,7 +940,7 @@ TEST_F(QDMIIntegrationTest, JobCycleCornerCases) {
                 sizeof(QDMI_Program_Format), &format),
             QDMI_ERROR_INVALIDARGUMENT);
 
-  for (const auto &program_format : fomac.get_supported_program_formats()) {
+  for (const auto &program_format : client.get_supported_program_formats()) {
     ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                   job, QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT,
                   sizeof(QDMI_Program_Format), &program_format),
@@ -998,8 +1002,8 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
   const std::string dd_mode = "enabled";
   const auto qubit_sites = get_qubit_sites();
   ASSERT_GE(qubit_sites.size(), 2U);
-  const auto first_qubit_name = fomac.get_site_name(qubit_sites[0]);
-  const auto second_qubit_name = fomac.get_site_name(qubit_sites[1]);
+  const auto first_qubit_name = client.get_site_name(qubit_sites[0]);
+  const auto second_qubit_name = client.get_site_name(qubit_sites[1]);
   const auto qubit_mapping = std::map<std::string, std::string>{
       {"alice", first_qubit_name}, {"bob", second_qubit_name}};
   constexpr double max_circuit_duration_over_t2 = 0;
@@ -1038,11 +1042,11 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
       pos += key.length();
     }
   }
-  auto *job = fomac.submit_job(program, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num,
-                               heralding_mode, move_validation_mode,
-                               move_gate_frame_tracking_mode, dd_mode,
-                               qubit_mapping, max_circuit_duration_over_t2,
-                               num_active_reset_cycles, dd_strategy);
+  auto *job = client.submit_job(program, QDMI_PROGRAM_FORMAT_IQMJSON, shots_num,
+                                heralding_mode, move_validation_mode,
+                                move_gate_frame_tracking_mode, dd_mode,
+                                qubit_mapping, max_circuit_duration_over_t2,
+                                num_active_reset_cycles, dd_strategy);
   const auto status = wait_for_done(job);
   if (should_skip_for_expected_mock_failure(status)) {
     IQM_QDMI_device_job_free(job);
@@ -1053,7 +1057,7 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
   }
   ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
 
-  const auto counts = FoMaC::get_histogram(job);
+  const auto counts = QDMIClient::get_histogram(job);
   IQM_QDMI_device_job_free(job);
   size_t sum = 0;
   std::cout << "Counts: {\n";
@@ -1071,8 +1075,8 @@ TEST_F(QDMIIntegrationTest, OptionalJobParameters) {
 TEST_F(QDMIIntegrationTest, DISABLED_JobCycleQIR) {
   constexpr size_t shots_num = 64;
   const auto qir_program = build_qir_test_circuit();
-  auto *job = fomac.submit_job(qir_program, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
-                               shots_num);
+  auto *job = client.submit_job(qir_program, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
+                                shots_num);
   const auto status = wait_for_done(job);
   if (should_skip_for_expected_mock_failure(status)) {
     IQM_QDMI_device_job_free(job);
@@ -1083,7 +1087,7 @@ TEST_F(QDMIIntegrationTest, DISABLED_JobCycleQIR) {
   }
   ASSERT_EQ(status, QDMI_JOB_STATUS_DONE);
 
-  const auto counts = FoMaC::get_histogram(job);
+  const auto counts = QDMIClient::get_histogram(job);
 
   size_t sum = 0;
   std::cout << "Counts: {\n";
@@ -1162,7 +1166,7 @@ TEST_F(QDMIIntegrationTest, CalibrationJob) {
   ASSERT_EQ(submit_result, QDMI_SUCCESS);
   EXPECT_EQ(IQM_QDMI_device_job_wait(job, DEFAULT_JOB_WAIT_TIMEOUT),
             QDMI_SUCCESS);
-  const auto calibration_set_id = FoMaC::get_calibration_set_id(job);
+  const auto calibration_set_id = QDMIClient::get_calibration_set_id(job);
   EXPECT_FALSE(calibration_set_id.empty())
       << "Calibration job must return a valid calibration set ID";
 

--- a/test/qdmi_client/CMakeLists.txt
+++ b/test/qdmi_client/CMakeLists.txt
@@ -15,13 +15,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(qdmi_iqm_fomac fomac.cpp)
+add_library(qdmi_iqm_client qdmi_client.cpp)
 target_link_libraries(
-  qdmi_iqm_fomac
+  qdmi_iqm_client
   PRIVATE qdmi::qdmi_project_warnings
   PUBLIC ${QDMI_TARGET_NAME})
 target_sources(
-  qdmi_iqm_fomac
+  qdmi_iqm_client
   PUBLIC FILE_SET
          public_headers
          TYPE
@@ -29,7 +29,7 @@ target_sources(
          BASE_DIRS
          ${CMAKE_CURRENT_SOURCE_DIR}
          FILES
-         fomac.hpp)
-set_target_properties(qdmi_iqm_fomac PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_compile_features(qdmi_iqm_fomac PUBLIC cxx_std_20)
-add_library(qdmi::iqm_fomac ALIAS qdmi_iqm_fomac)
+         qdmi_client.hpp)
+set_target_properties(qdmi_iqm_client PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_features(qdmi_iqm_client PUBLIC cxx_std_20)
+add_library(qdmi::iqm_client ALIAS qdmi_iqm_client)

--- a/test/qdmi_client/qdmi_client.cpp
+++ b/test/qdmi_client/qdmi_client.cpp
@@ -18,10 +18,10 @@
  */
 
 /** @file
- * @brief FoMaC Implementation for testing the IQM QDMI Device.
+ * @brief QDMI client implementation for testing the IQM QDMI Device.
  */
 
-#include "fomac.hpp"
+#include "qdmi_client.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-auto FoMaC::throw_if_error(const int status, const std::string &message)
+auto QDMIClient::throw_if_error(const int status, const std::string &message)
     -> void {
   if (status == QDMI_SUCCESS) {
     return;
@@ -88,11 +88,11 @@ auto FoMaC::throw_if_error(const int status, const std::string &message)
 }
 
 IQM_QDMI_Device_Session
-FoMaC::get_iqm_session(const std::string &base_url,
-                       const std::optional<std::string> &token,
-                       const std::optional<std::string> &tokens_file,
-                       const std::optional<std::string> &qc_id,
-                       const std::optional<std::string> &qc_alias) {
+QDMIClient::get_iqm_session(const std::string &base_url,
+                            const std::optional<std::string> &token,
+                            const std::optional<std::string> &tokens_file,
+                            const std::optional<std::string> &qc_id,
+                            const std::optional<std::string> &qc_alias) {
   IQM_QDMI_Device_Session session = nullptr;
   auto ret = IQM_QDMI_device_session_alloc(&session);
   throw_if_error(ret, "Failed to allocate IQM QDMI device session.");
@@ -141,7 +141,7 @@ FoMaC::get_iqm_session(const std::string &base_url,
   return session;
 }
 
-auto FoMaC::get_name() const -> std::string {
+auto QDMIClient::get_name() const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_NAME, 0, nullptr, &size);
@@ -153,7 +153,7 @@ auto FoMaC::get_name() const -> std::string {
   return name;
 }
 
-auto FoMaC::get_version() const -> std::string {
+auto QDMIClient::get_version() const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_VERSION, 0, nullptr, &size);
@@ -165,7 +165,7 @@ auto FoMaC::get_version() const -> std::string {
   return version;
 }
 
-auto FoMaC::get_library_version() const -> std::string {
+auto QDMIClient::get_library_version() const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_LIBRARYVERSION, 0, nullptr, &size);
@@ -178,7 +178,7 @@ auto FoMaC::get_library_version() const -> std::string {
   return version;
 }
 
-auto FoMaC::get_qubits_num() const -> size_t {
+auto QDMIClient::get_qubits_num() const -> size_t {
   size_t num_qubits = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(size_t), &num_qubits,
@@ -187,7 +187,7 @@ auto FoMaC::get_qubits_num() const -> size_t {
   return num_qubits;
 }
 
-auto FoMaC::get_operation_map() const
+auto QDMIClient::get_operation_map() const
     -> std::map<std::string, IQM_QDMI_Operation> {
   size_t ops_size = 0;
   int ret = IQM_QDMI_device_session_query_device_property(
@@ -215,7 +215,7 @@ auto FoMaC::get_operation_map() const
   return ops_map;
 }
 
-auto FoMaC::get_coupling_map() const
+auto QDMIClient::get_coupling_map() const
     -> std::vector<std::pair<IQM_QDMI_Site, IQM_QDMI_Site>> {
   size_t size = 0;
   int ret = IQM_QDMI_device_session_query_device_property(
@@ -238,7 +238,7 @@ auto FoMaC::get_coupling_map() const
   return coupling_pairs;
 }
 
-auto FoMaC::get_sites() const -> std::vector<IQM_QDMI_Site> {
+auto QDMIClient::get_sites() const -> std::vector<IQM_QDMI_Site> {
   size_t sites_size = 0;
   int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_SITES, 0, nullptr, &sites_size);
@@ -251,7 +251,7 @@ auto FoMaC::get_sites() const -> std::vector<IQM_QDMI_Site> {
   return sites;
 }
 
-auto FoMaC::get_duration_unit() const -> std::string {
+auto QDMIClient::get_duration_unit() const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_DURATIONUNIT, 0, nullptr, &size);
@@ -263,7 +263,7 @@ auto FoMaC::get_duration_unit() const -> std::string {
   return unit;
 }
 
-auto FoMaC::get_duration_scale_factor() const -> double {
+auto QDMIClient::get_duration_scale_factor() const -> double {
   double scale_factor = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR, sizeof(double),
@@ -272,7 +272,7 @@ auto FoMaC::get_duration_scale_factor() const -> double {
   return scale_factor;
 }
 
-auto FoMaC::get_calibration_set_id() const -> std::string {
+auto QDMIClient::get_calibration_set_id() const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_device_property(
       session_, QDMI_DEVICE_PROPERTY_CUSTOM1, 0, nullptr, &size);
@@ -285,7 +285,7 @@ auto FoMaC::get_calibration_set_id() const -> std::string {
   return calibration_set_id;
 }
 
-auto FoMaC::get_site_index(IQM_QDMI_Site site) const -> uint64_t {
+auto QDMIClient::get_site_index(IQM_QDMI_Site site) const -> uint64_t {
   uint64_t site_id = 0;
   const int ret = IQM_QDMI_device_session_query_site_property(
       session_, site, QDMI_SITE_PROPERTY_INDEX, sizeof(uint64_t), &site_id,
@@ -294,7 +294,7 @@ auto FoMaC::get_site_index(IQM_QDMI_Site site) const -> uint64_t {
   return site_id;
 }
 
-auto FoMaC::get_site_t1(IQM_QDMI_Site site) const -> uint64_t {
+auto QDMIClient::get_site_t1(IQM_QDMI_Site site) const -> uint64_t {
   uint64_t t1 = 0;
   const int ret = IQM_QDMI_device_session_query_site_property(
       session_, site, QDMI_SITE_PROPERTY_T1, sizeof(uint64_t), &t1, nullptr);
@@ -302,7 +302,7 @@ auto FoMaC::get_site_t1(IQM_QDMI_Site site) const -> uint64_t {
   return t1;
 }
 
-auto FoMaC::get_site_t2(IQM_QDMI_Site site) const -> uint64_t {
+auto QDMIClient::get_site_t2(IQM_QDMI_Site site) const -> uint64_t {
   uint64_t t2 = 0;
   const int ret = IQM_QDMI_device_session_query_site_property(
       session_, site, QDMI_SITE_PROPERTY_T2, sizeof(uint64_t), &t2, nullptr);
@@ -310,7 +310,7 @@ auto FoMaC::get_site_t2(IQM_QDMI_Site site) const -> uint64_t {
   return t2;
 }
 
-auto FoMaC::get_site_name(IQM_QDMI_Site site) const -> std::string {
+auto QDMIClient::get_site_name(IQM_QDMI_Site site) const -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_session_query_site_property(
       session_, site, QDMI_SITE_PROPERTY_NAME, 0, nullptr, &size);
@@ -322,7 +322,7 @@ auto FoMaC::get_site_name(IQM_QDMI_Site site) const -> std::string {
   return custom;
 }
 
-auto FoMaC::get_operation_name(const IQM_QDMI_Operation &op) const
+auto QDMIClient::get_operation_name(const IQM_QDMI_Operation &op) const
     -> std::string {
   size_t name_length = 0;
   const int ret = IQM_QDMI_device_session_query_operation_property(
@@ -337,7 +337,7 @@ auto FoMaC::get_operation_name(const IQM_QDMI_Operation &op) const
   return name;
 }
 
-auto FoMaC::get_operation_operands_num(const IQM_QDMI_Operation &op) const
+auto QDMIClient::get_operation_operands_num(const IQM_QDMI_Operation &op) const
     -> size_t {
   size_t operands_num = 0;
   const int ret = IQM_QDMI_device_session_query_operation_property(
@@ -348,8 +348,8 @@ auto FoMaC::get_operation_operands_num(const IQM_QDMI_Operation &op) const
   return operands_num;
 }
 
-auto FoMaC::get_operation_parameters_num(const IQM_QDMI_Operation &op) const
-    -> size_t {
+auto QDMIClient::get_operation_parameters_num(
+    const IQM_QDMI_Operation &op) const -> size_t {
   size_t parameters_num = 0;
   const int ret = IQM_QDMI_device_session_query_operation_property(
       session_, op, 0, nullptr, 0, nullptr,
@@ -360,9 +360,9 @@ auto FoMaC::get_operation_parameters_num(const IQM_QDMI_Operation &op) const
   return parameters_num;
 }
 
-auto FoMaC::get_operation_fidelity(const IQM_QDMI_Operation &op,
-                                   const std::vector<IQM_QDMI_Site> &sites,
-                                   const std::vector<double> &params) const
+auto QDMIClient::get_operation_fidelity(const IQM_QDMI_Operation &op,
+                                        const std::vector<IQM_QDMI_Site> &sites,
+                                        const std::vector<double> &params) const
     -> double {
   double fidelity = 0;
   const int ret = IQM_QDMI_device_session_query_operation_property(
@@ -373,9 +373,9 @@ auto FoMaC::get_operation_fidelity(const IQM_QDMI_Operation &op,
   return fidelity;
 }
 
-auto FoMaC::get_operation_duration(const IQM_QDMI_Operation &op,
-                                   const std::vector<IQM_QDMI_Site> &sites,
-                                   const std::vector<double> &params) const
+auto QDMIClient::get_operation_duration(const IQM_QDMI_Operation &op,
+                                        const std::vector<IQM_QDMI_Site> &sites,
+                                        const std::vector<double> &params) const
     -> double {
   double duration = 0;
   const int ret = IQM_QDMI_device_session_query_operation_property(
@@ -386,7 +386,7 @@ auto FoMaC::get_operation_duration(const IQM_QDMI_Operation &op,
   return duration;
 }
 
-auto FoMaC::get_operation_sites(const IQM_QDMI_Operation &op) const
+auto QDMIClient::get_operation_sites(const IQM_QDMI_Operation &op) const
     -> std::vector<IQM_QDMI_Site> {
   size_t size = 0;
   int ret = IQM_QDMI_device_session_query_operation_property(
@@ -403,7 +403,7 @@ auto FoMaC::get_operation_sites(const IQM_QDMI_Operation &op) const
   return sites;
 }
 
-auto FoMaC::get_supported_program_formats() const
+auto QDMIClient::get_supported_program_formats() const
     -> std::vector<QDMI_Program_Format> {
   size_t size = 0;
   int ret = IQM_QDMI_device_session_query_device_property(
@@ -450,7 +450,7 @@ private:
 };
 } // namespace
 
-auto FoMaC::submit_job(
+auto QDMIClient::submit_job(
     const std::string &program, const QDMI_Program_Format format,
     const size_t num_shots, const std::string &heralding_mode,
     const std::string &move_validation_mode,
@@ -538,24 +538,24 @@ auto FoMaC::submit_job(
   return guard.release();
 }
 
-auto FoMaC::get_status(IQM_QDMI_Device_Job job) -> QDMI_Job_Status {
+auto QDMIClient::get_status(IQM_QDMI_Device_Job job) -> QDMI_Job_Status {
   QDMI_Job_Status status{};
   const int ret = IQM_QDMI_device_job_check(job, &status);
   throw_if_error(ret, "Failed to check the job status");
   return status;
 }
 
-auto FoMaC::wait(IQM_QDMI_Device_Job job, const size_t timeout) -> void {
+auto QDMIClient::wait(IQM_QDMI_Device_Job job, const size_t timeout) -> void {
   const int ret = IQM_QDMI_device_job_wait(job, timeout);
   throw_if_error(ret, "Failed to wait for the job");
 }
 
-auto FoMaC::cancel(IQM_QDMI_Device_Job job) -> void {
+auto QDMIClient::cancel(IQM_QDMI_Device_Job job) -> void {
   const int ret = IQM_QDMI_device_job_cancel(job);
   throw_if_error(ret, "Failed to cancel the job");
 }
 
-auto FoMaC::get_job_id(IQM_QDMI_Device_Job job) -> std::string {
+auto QDMIClient::get_job_id(IQM_QDMI_Device_Job job) -> std::string {
   size_t job_id_size = 0;
   const int ret = IQM_QDMI_device_job_query_property(
       job, QDMI_DEVICE_JOB_PROPERTY_ID, 0, nullptr, &job_id_size);
@@ -567,7 +567,7 @@ auto FoMaC::get_job_id(IQM_QDMI_Device_Job job) -> std::string {
   return job_id;
 }
 
-auto FoMaC::get_job_shots_num(IQM_QDMI_Device_Job job) -> size_t {
+auto QDMIClient::get_job_shots_num(IQM_QDMI_Device_Job job) -> size_t {
   size_t num_shots = 0;
   const int ret =
       IQM_QDMI_device_job_query_property(job, QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM,
@@ -576,7 +576,7 @@ auto FoMaC::get_job_shots_num(IQM_QDMI_Device_Job job) -> size_t {
   return num_shots;
 }
 
-auto FoMaC::get_histogram(IQM_QDMI_Device_Job job)
+auto QDMIClient::get_histogram(IQM_QDMI_Device_Job job)
     -> std::map<std::string, size_t> {
   size_t size = 0;
   const int ret = IQM_QDMI_device_job_get_results(
@@ -608,7 +608,8 @@ auto FoMaC::get_histogram(IQM_QDMI_Device_Job job)
   }
   return results;
 }
-auto FoMaC::get_calibration_set_id(IQM_QDMI_Device_Job job) -> std::string {
+auto QDMIClient::get_calibration_set_id(IQM_QDMI_Device_Job job)
+    -> std::string {
   size_t size = 0;
   const int ret = IQM_QDMI_device_job_get_results(job, QDMI_JOB_RESULT_CUSTOM1,
                                                   0, nullptr, &size);

--- a/test/qdmi_client/qdmi_client.hpp
+++ b/test/qdmi_client/qdmi_client.hpp
@@ -18,7 +18,7 @@
  */
 
 /** @file
- * @brief FoMaC Implementation for testing the IQM QDMI Device.
+ * @brief QDMI client implementation for testing the IQM QDMI Device.
  */
 
 #pragma once
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-class FoMaC {
+class QDMIClient {
   IQM_QDMI_Device_Session session_;
 
   static auto throw_if_error(int status, const std::string &message) -> void;
@@ -47,8 +47,8 @@ public:
                   const std::optional<std::string> &qc_id = std::nullopt,
                   const std::optional<std::string> &qc_alias = std::nullopt);
 
-  FoMaC() = default;
-  explicit FoMaC(IQM_QDMI_Device_Session session) : session_(session) {
+  QDMIClient() = default;
+  explicit QDMIClient(IQM_QDMI_Device_Session session) : session_(session) {
     assert(session_ != nullptr);
   }
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

MQT Core retired the FoMaC name for its QDMI client surface: `fomac::` is now `qdmi::`, `fomac/FoMaC.hpp` is now `qdmi/Client.hpp`, and `MQT::CoreFoMaC` becomes `MQT::CoreQDMI` in MQT Core 4. This repo's integration-test helper only borrowed the word — it links and imports nothing FoMaC-related — but it kept teaching a name upstream no longer uses. This PR adopts the current vocabulary.

`test/fomac/` becomes `test/qdmi_client/`, `class FoMaC` becomes `QDMIClient`, and the CMake target `qdmi_iqm_fomac` becomes `qdmi_iqm_client` with the alias `qdmi::iqm_client`. I picked `QDMIClient` over `qdmi::Client` because this repo puts no test helper in a namespace and already spells the acronym out in class names — `QDMIIntegrationTest` sits in the same file and passes `.clang-tidy`'s `ClassCase: CamelCase`. The file name follows the repo's snake_case convention (`http_stub.hpp`, `test_iqm_device.cpp`) rather than MQT Core's `Client.hpp`. Method and function names are untouched, matching MQT Core, where only the namespace, header, and target moved. The usage guide's C++ snippets are lifted from that helper, so they follow the rename.

One scope correction worth flagging. `MQT::CoreFoMaC` in `docs/usage.md` cannot be flipped to `MQT::CoreQDMI` yet. MQT Core's `UPGRADING.md` renames the Python module in 3.9 but states the C++ namespace, headers, library, and `MQT::CoreFoMaC` target do not change in that release, and `v3.9.1:src/fomac/CMakeLists.txt` confirms `FoMaC` is the only alias there. This project requires `mqt-core~=3.9.1` and the snippet says `find_package(mqt-core 3.9 CONFIG REQUIRED)`, so naming the new target would document one that does not exist and fail to configure. The snippet keeps the working target and gains an admonition pointing at `MQT::CoreQDMI` for the MQT Core 4 bump. The word therefore still appears in the tree, so the `"FoMaC"` entry in `[tool.typos] default.extend-ignore-re` stays; it can go when this repo moves to MQT Core 4.

No changelog entry: the rename is test-internal and the docs change is a clarification, not a behavior change.

Verified with a Release Ninja build outside the worktree: `unit_tests` and `integration_tests` both compile, all 140 unit tests pass, and `prek run -a` is clean. Integration tests were not run — they hit the live rate-limited endpoint.
