### PR TITLE
✨ Accept iqm-client's canonical environment names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@
 # URL of the IQM quantum server
 # Examples:
 #   - Resonance:  https://resonance.iqm.tech
-#IQM_BASE_URL=
+#IQM_SERVER_URL=
+# Legacy alias: IQM_BASE_URL
 
 # -------------------------------------------
 # Quantum Computer Selection
@@ -29,8 +30,9 @@
 # Examples:
 #   - emerald:mock      # IQM Emerald mock device
 #   - garnet            # IQM Garnet production device
-# Example: IQM_QC_ALIAS=emerald:mock
-#IQM_QC_ALIAS=
+# Example: IQM_QUANTUM_COMPUTER=emerald:mock
+#IQM_QUANTUM_COMPUTER=
+# Legacy alias: IQM_QC_ALIAS
 
 # -------------------------------------------
 # Authentication Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Accept `IQM_SERVER_URL` and `IQM_QUANTUM_COMPUTER` as the canonical
+  environment variables for IQM Server and quantum computer selection, while
+  keeping `IQM_BASE_URL` and `IQM_QC_ALIAS` as aliases ([#217])
+  ([**@burgholzer**])
 - ✨ Add `partition` and `nodes` keyword arguments to `iqm.qdmi.offloader`'s
   `sample`/`estimate`, with the partition also resolvable from
   `IQM_SLURM_PARTITION`, so a site whose quantum partition is not named
@@ -218,6 +222,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#217]: https://github.com/iqm-finland/QDMI-on-IQM/pull/217
 [#206]: https://github.com/iqm-finland/QDMI-on-IQM/pull/206
 [#205]: https://github.com/iqm-finland/QDMI-on-IQM/pull/205
 [#204]: https://github.com/iqm-finland/QDMI-on-IQM/pull/204

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -265,7 +265,7 @@ Before running the integration tests, make sure you have set the necessary
 environment variables:
 
 ```console
-export IQM_BASE_URL="https://desired-iqm-server.com"
+export IQM_SERVER_URL="https://desired-iqm-server.com"
 export IQM_TOKEN="your-api-key"
 ctest -C Release --test-dir build/test/integration --output-on-failure
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -42,10 +42,13 @@ The IQM-backed path relies on a small environment-variable contract to
 authenticate and route your jobs. Before running any of the examples, make sure
 the following variables are set as needed:
 
-- `IQM_BASE_URL`: The endpoint of the IQM server you are targeting (e.g.,
+- `IQM_SERVER_URL`: The endpoint of the IQM server you are targeting (e.g.,
   `https://resonance.iqm.tech` for IQM Resonance).
 - `IQM_TOKEN`: Your authentication token.
-- `IQM_QC_ALIAS`: Optional explicit selection of the target quantum computer.
+- `IQM_QUANTUM_COMPUTER`: Optional explicit selection of the target quantum
+  computer.
+
+`IQM_BASE_URL` and `IQM_QC_ALIAS` remain supported as legacy aliases.
 
 For the full set of authentication options available when configuring C++
 sessions directly, see [Authentication Methods](usage.md#authentication-methods)

--- a/docs/qiskit.md
+++ b/docs/qiskit.md
@@ -44,10 +44,11 @@ result = backend.run(transpiled_qc, shots=128).result()
 print(result.get_counts())
 ```
 
-Explicit arguments to `IQMBackend(...)` take precedence over `IQM_BASE_URL`,
-`IQM_TOKEN`, `IQM_TOKENS_FILE`, `IQM_QC_ID`, and `IQM_QC_ALIAS` from the
-environment. For the endpoint, an explicit argument takes precedence over
-`IQM_BASE_URL`, which takes precedence over the registered device default.
+Explicit arguments to `IQMBackend(...)` take precedence over `IQM_SERVER_URL`,
+`IQM_TOKEN`, `IQM_TOKENS_FILE`, `IQM_QC_ID`, and `IQM_QUANTUM_COMPUTER` from the
+environment. `IQM_BASE_URL` and `IQM_QC_ALIAS` remain supported as legacy
+aliases. Canonical variables take precedence over their legacy aliases, which
+take precedence over the registered device default.
 
 The wrapper registers the packaged IQM QDMI device as a fallback under the
 stable ID `iqm.default` with the standard Resonance endpoint as its default. An

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,7 +132,10 @@ If neither quantum computer ID nor alias is specified, the first available
 quantum computer from the server will be used.
 
 If the base URL is not specified explicitly, the session initialization path
-falls back to `IQM_BASE_URL` before using the standard Resonance endpoint.
+falls back to `IQM_SERVER_URL`, then its `IQM_BASE_URL` alias, before using the
+standard Resonance endpoint. A quantum computer alias similarly falls back to
+`IQM_QUANTUM_COMPUTER`, then its `IQM_QC_ALIAS` alias. `IQM_QC_ID` remains a
+separate quantum computer ID selector.
 
 The session is initialized with {cpp:func}`IQM_QDMI_device_session_init`, which:
 

--- a/python/iqm/qdmi/qiskit.py
+++ b/python/iqm/qdmi/qiskit.py
@@ -55,12 +55,13 @@ class IQMBackend(QDMIBackend):
     exposes it through MQT Core's Qiskit-compatible QDMI backend.
 
     Args:
-        base_url: Base URL of the IQM service. Overrides `IQM_BASE_URL` and
-            the registered device default when provided.
+        base_url: Base URL of the IQM service. Overrides `IQM_SERVER_URL`, its
+            `IQM_BASE_URL` alias, and the registered device default when provided.
         token: Authentication token. Defaults to `IQM_TOKEN`.
         tokens_file: Path to an authentication file. Defaults to `IQM_TOKENS_FILE`.
         qc_id: Optional IQM quantum computer identifier. Defaults to `IQM_QC_ID`.
-        qc_alias: Optional IQM quantum computer alias. Defaults to `IQM_QC_ALIAS`.
+        qc_alias: Optional IQM quantum computer alias. Defaults to
+            `IQM_QUANTUM_COMPUTER`, then its `IQM_QC_ALIAS` alias.
     """
 
     #: MOVE is native to IQM's star-topology devices but absent from Qiskit's
@@ -77,12 +78,12 @@ class IQMBackend(QDMIBackend):
         qc_alias: str | None = None,
     ) -> None:
         """Initialize the IQM Qiskit backend."""
-        resolved_base_url = base_url or os.getenv("IQM_BASE_URL") or None
+        resolved_base_url = base_url or os.getenv("IQM_SERVER_URL") or os.getenv("IQM_BASE_URL") or None
         resolved_token = token or os.getenv("IQM_TOKEN")
         tokens_file_value = tokens_file or os.getenv("IQM_TOKENS_FILE")
         resolved_tokens_file = Path(tokens_file_value) if tokens_file_value else None
         resolved_qc_id = qc_id or os.getenv("IQM_QC_ID")
-        resolved_qc_alias = qc_alias or os.getenv("IQM_QC_ALIAS")
+        resolved_qc_alias = qc_alias or os.getenv("IQM_QUANTUM_COMPUTER") or os.getenv("IQM_QC_ALIAS")
 
         register_device_if_absent(
             DeviceDefinition(

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -332,8 +332,11 @@ std::optional<std::string> Get_nonempty_env_var(const char *name) {
 }
 
 void Apply_environment_session_defaults(IQM_QDMI_Device_Session session) {
-  const auto env_base_url = Get_nonempty_env_var("IQM_BASE_URL");
-  LOG_DEBUG(std::string("IQM_BASE_URL environment default is ") +
+  auto env_base_url = Get_nonempty_env_var("IQM_SERVER_URL");
+  if (!env_base_url.has_value()) {
+    env_base_url = Get_nonempty_env_var("IQM_BASE_URL");
+  }
+  LOG_DEBUG(std::string("IQM_SERVER_URL/IQM_BASE_URL environment default is ") +
             (env_base_url.has_value() ? "set" : "unset"));
   if (session->base_url_.empty() && env_base_url.has_value()) {
     session->base_url_ = *env_base_url;
@@ -346,9 +349,13 @@ void Apply_environment_session_defaults(IQM_QDMI_Device_Session session) {
     session->quantum_computer_id_ = env_qc_id;
   }
 
-  const auto env_qc_alias = Get_nonempty_env_var("IQM_QC_ALIAS");
-  LOG_DEBUG(std::string("IQM_QC_ALIAS environment default is ") +
-            (env_qc_alias.has_value() ? "set" : "unset"));
+  auto env_qc_alias = Get_nonempty_env_var("IQM_QUANTUM_COMPUTER");
+  if (!env_qc_alias.has_value()) {
+    env_qc_alias = Get_nonempty_env_var("IQM_QC_ALIAS");
+  }
+  LOG_DEBUG(
+      std::string("IQM_QUANTUM_COMPUTER/IQM_QC_ALIAS environment default is ") +
+      (env_qc_alias.has_value() ? "set" : "unset"));
   if (!session->quantum_computer_alias_.has_value() &&
       env_qc_alias.has_value()) {
     session->quantum_computer_alias_ = env_qc_alias;

--- a/test/python/test_qiskit_backend.py
+++ b/test/python/test_qiskit_backend.py
@@ -92,11 +92,13 @@ def _expected_definition() -> dict[str, str | os.PathLike[str]]:
 def test_iqm_backend_uses_environment_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """The backend should forward the canonical IQM environment variables."""
     captured = _stub_backend_construction(monkeypatch)
-    monkeypatch.setenv("IQM_BASE_URL", "https://environment.example")
+    monkeypatch.setenv("IQM_SERVER_URL", "https://canonical.example")
+    monkeypatch.setenv("IQM_BASE_URL", "https://legacy.example")
     monkeypatch.setenv("IQM_TOKEN", "environment-token")
     monkeypatch.setenv("IQM_TOKENS_FILE", str(ENVIRONMENT_TOKENS_FILE))
     monkeypatch.setenv("IQM_QC_ID", "environment-qc-id")
-    monkeypatch.setenv("IQM_QC_ALIAS", "environment-qc-alias")
+    monkeypatch.setenv("IQM_QUANTUM_COMPUTER", "canonical-qc-alias")
+    monkeypatch.setenv("IQM_QC_ALIAS", "legacy-qc-alias")
     environment_token = "environment-token"  # ruff:ignore[hardcoded-password-string]
 
     IQMBackend()
@@ -106,12 +108,26 @@ def test_iqm_backend_uses_environment_defaults(monkeypatch: pytest.MonkeyPatch) 
     assert captured["definition_kwargs"] == _expected_definition()
     assert captured["opened_id"] == iqm_qiskit.IQM_QDMI_DEVICE_ID
     assert captured["session"] == {
-        "base_url": "https://environment.example",
+        "base_url": "https://canonical.example",
         "token": environment_token,
         "auth_file": ENVIRONMENT_TOKENS_FILE,
         "custom1": "environment-qc-id",
-        "custom2": "environment-qc-alias",
+        "custom2": "canonical-qc-alias",
     }
+
+
+def test_iqm_backend_supports_legacy_environment_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The former routing variables should remain supported aliases."""
+    captured = _stub_backend_construction(monkeypatch)
+    monkeypatch.delenv("IQM_SERVER_URL", raising=False)
+    monkeypatch.delenv("IQM_QUANTUM_COMPUTER", raising=False)
+    monkeypatch.setenv("IQM_BASE_URL", "https://legacy.example")
+    monkeypatch.setenv("IQM_QC_ALIAS", "legacy-qc-alias")
+
+    IQMBackend()
+
+    assert captured["session"]["base_url"] == "https://legacy.example"
+    assert captured["session"]["custom2"] == "legacy-qc-alias"
 
 
 def test_iqm_backend_prefers_explicit_arguments_over_environment(
@@ -119,11 +135,13 @@ def test_iqm_backend_prefers_explicit_arguments_over_environment(
 ) -> None:
     """Explicit backend arguments should override inherited environment values."""
     captured = _stub_backend_construction(monkeypatch)
-    monkeypatch.setenv("IQM_BASE_URL", "https://environment.example")
+    monkeypatch.setenv("IQM_SERVER_URL", "https://canonical.example")
+    monkeypatch.setenv("IQM_BASE_URL", "https://legacy.example")
     monkeypatch.setenv("IQM_TOKEN", "environment-token")
     monkeypatch.setenv("IQM_TOKENS_FILE", str(ENVIRONMENT_TOKENS_FILE))
     monkeypatch.setenv("IQM_QC_ID", "environment-qc-id")
-    monkeypatch.setenv("IQM_QC_ALIAS", "environment-qc-alias")
+    monkeypatch.setenv("IQM_QUANTUM_COMPUTER", "canonical-qc-alias")
+    monkeypatch.setenv("IQM_QC_ALIAS", "legacy-qc-alias")
     explicit_token = "explicit-token"  # ruff:ignore[hardcoded-password-string]
 
     IQMBackend(
@@ -146,6 +164,7 @@ def test_iqm_backend_prefers_explicit_arguments_over_environment(
 def test_iqm_backend_preserves_existing_registration(monkeypatch: pytest.MonkeyPatch) -> None:
     """An existing configured definition should win over the packaged fallback."""
     captured = _stub_backend_construction(monkeypatch)
+    monkeypatch.delenv("IQM_SERVER_URL", raising=False)
     monkeypatch.delenv("IQM_BASE_URL", raising=False)
 
     def existing_registration(_definition: object) -> bool:
@@ -174,9 +193,10 @@ def test_iqm_backend_treats_empty_base_url_as_unset(
     """An empty endpoint should not override the registered device default."""
     captured = _stub_backend_construction(monkeypatch)
     if environment_base_url is None:
-        monkeypatch.delenv("IQM_BASE_URL", raising=False)
+        monkeypatch.delenv("IQM_SERVER_URL", raising=False)
     else:
-        monkeypatch.setenv("IQM_BASE_URL", environment_base_url)
+        monkeypatch.setenv("IQM_SERVER_URL", environment_base_url)
+    monkeypatch.delenv("IQM_BASE_URL", raising=False)
 
     IQMBackend(base_url=base_url)
 

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -130,11 +130,13 @@ protected:
   IQM_QDMI_Device_Session session = nullptr;
 
 private:
+  ScopedUnsetEnvVar server_url_env_{"IQM_SERVER_URL"};
   ScopedUnsetEnvVar base_url_env_{"IQM_BASE_URL"};
   ScopedUnsetEnvVar token_env_{"IQM_TOKEN"};
   ScopedUnsetEnvVar tokens_file_env_{"IQM_TOKENS_FILE"};
   ScopedUnsetEnvVar qc_id_env_{"IQM_QC_ID"};
   ScopedUnsetEnvVar qc_alias_env_{"IQM_QC_ALIAS"};
+  ScopedUnsetEnvVar quantum_computer_env_{"IQM_QUANTUM_COMPUTER"};
 
 protected:
   void SetUp() override {
@@ -157,11 +159,13 @@ protected:
   iqm::test_support::HttpStub http_stub;
 
 private:
+  ScopedUnsetEnvVar server_url_env_{"IQM_SERVER_URL"};
   ScopedUnsetEnvVar base_url_env_{"IQM_BASE_URL"};
   ScopedUnsetEnvVar token_env_{"IQM_TOKEN"};
   ScopedUnsetEnvVar tokens_file_env_{"IQM_TOKENS_FILE"};
   ScopedUnsetEnvVar qc_id_env_{"IQM_QC_ID"};
   ScopedUnsetEnvVar qc_alias_env_{"IQM_QC_ALIAS"};
+  ScopedUnsetEnvVar quantum_computer_env_{"IQM_QUANTUM_COMPUTER"};
 
 protected:
   const std::string list_quantum_computers_response = R"({
@@ -576,10 +580,53 @@ TEST_F(DeviceIntegrationEnvMockTest,
             "https://environment.example/api/v1/quantum-computers");
 }
 
+TEST_F(DeviceIntegrationEnvMockTest,
+       SessionInitializationPrefersCanonicalServerUrlEnvironment) {
+  const ScopedEnvVar server_url_env("IQM_SERVER_URL");
+  const ScopedEnvVar base_url_env("IQM_BASE_URL");
+  ASSERT_EQ(Set_env_var_raw("IQM_SERVER_URL", "https://canonical.example"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_BASE_URL", "https://legacy.example"), 0);
+
+  queue_successful_initialization();
+
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  ASSERT_FALSE(http_stub.get_urls().empty());
+  EXPECT_EQ(http_stub.get_urls().front(),
+            "https://canonical.example/api/v1/quantum-computers");
+}
+
+TEST_F(DeviceIntegrationEnvMockTest,
+       SessionInitializationPrefersCanonicalQuantumComputerEnvironment) {
+  const ScopedEnvVar server_url_env("IQM_SERVER_URL");
+  const ScopedEnvVar quantum_computer_env("IQM_QUANTUM_COMPUTER");
+  const ScopedEnvVar qc_alias_env("IQM_QC_ALIAS");
+  ASSERT_EQ(Set_env_var_raw("IQM_SERVER_URL", "https://localhost"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_QUANTUM_COMPUTER", "default"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_QC_ALIAS", "missing"), 0);
+
+  queue_successful_initialization();
+
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+}
+
+TEST_F(DeviceIntegrationEnvMockTest,
+       SessionInitializationUsesLegacyQuantumComputerEnvironment) {
+  const ScopedEnvVar server_url_env("IQM_SERVER_URL");
+  const ScopedEnvVar qc_alias_env("IQM_QC_ALIAS");
+  ASSERT_EQ(Set_env_var_raw("IQM_SERVER_URL", "https://localhost"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_QC_ALIAS", "default"), 0);
+
+  queue_successful_initialization();
+
+  EXPECT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+}
+
 TEST_F(DeviceIntegrationMockTest,
        SessionInitializationPrefersExplicitBaseUrlOverEnvironment) {
+  const ScopedEnvVar server_url_env("IQM_SERVER_URL");
   const ScopedEnvVar base_url_env("IQM_BASE_URL");
-  ASSERT_EQ(Set_env_var_raw("IQM_BASE_URL", "https://environment.example"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_SERVER_URL", "https://canonical.example"), 0);
+  ASSERT_EQ(Set_env_var_raw("IQM_BASE_URL", "https://legacy.example"), 0);
 
   queue_successful_initialization();
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Use `IQM_SERVER_URL` and `IQM_QUANTUM_COMPUTER` as the canonical environment variables used by iqm-client. Retain `IQM_BASE_URL` and `IQM_QC_ALIAS` as backward-compatible aliases, and keep `IQM_QC_ID` as the separate identifier selector.

Explicit API arguments take precedence over canonical environment variables, which take precedence over legacy aliases and registered defaults. The SPANK plugin remains unchanged and continues to work through the retained aliases.

## Validation

- `uvx nox -s lint`
- focused Python 3.14 environment-resolution tests
- focused native environment-resolution tests

AI assistance: Codex implemented and locally validated the focused change under human direction.