### PR TITLE
⬆️ Require compatible Qiskit releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ releases may include breaking changes.
   `IQM_SLURM_PARTITION`, so a site whose quantum partition is not named
   `quantum` can use the offloader ([#202]) ([**@marcelwa**])
 
+### Fixed
+
+- ⬆️ Require Qiskit 2.0 on Python 3.10–3.13 and Qiskit 2.1 on Python 3.14 and
+  newer so the supported minimum environments install and run ([#218])
+  ([**@burgholzer**])
+
 ## [1.4.0] - 2026-08-25
 
 ### Added
@@ -218,6 +224,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#218]: https://github.com/iqm-finland/QDMI-on-IQM/pull/218
 [#206]: https://github.com/iqm-finland/QDMI-on-IQM/pull/206
 [#205]: https://github.com/iqm-finland/QDMI-on-IQM/pull/205
 [#204]: https://github.com/iqm-finland/QDMI-on-IQM/pull/204

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ classifiers = [
 [project.optional-dependencies]
 qiskit = [
   "mqt-core~=3.9.1",
-  "qiskit[qasm3-import]>=1.1",
+  "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
+  "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",
   "numpy>=2.3.2; python_version >= '3.14'",
@@ -79,7 +80,8 @@ IQM_JSON = "iqm.qdmi.serializers:qiskit_to_iqm_json"
 [dependency-groups]
 qiskit = [
   "mqt-core~=3.9.1",
-  "qiskit[qasm3-import]>=1.1",
+  "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
+  "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",
   "numpy>=2.3.2; python_version >= '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,8 @@ requires-dist = [
     { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.9.1" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'qiskit'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.3.2" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.1" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.1" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14' and extra == 'qiskit'", specifier = ">=2.0" },
     { name = "qiskit-algorithms", marker = "extra == 'qiskit'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["qiskit"]
@@ -1031,7 +1032,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.1" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 docs = [
@@ -1048,7 +1050,8 @@ qiskit = [
     { name = "mqt-core", specifier = "~=3.9.1" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
-    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.1" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 test = [
@@ -1060,7 +1063,8 @@ test = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.1" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Raise the direct Qiskit floor to 2.0 on Python 3.10–3.13 and 2.1 on Python 3.14 and newer.

`qiskit-algorithms` 0.4 cannot import against the previous Qiskit 1.1 floor. Qiskit 1.3 fixes that import but still crashes while transpiling against MQT Core 3.9.1 global target operations. Qiskit 2.0 is the first tested release where the complete minimum suite passes. Python 3.14 needs Qiskit 2.1 because the older dependency set has no usable `symengine` wheel.

## Validation

- `uvx nox -s lint`
- `uvx nox -s minimums` (Python 3.10–3.14: 58 passed and 7 credential-gated skips per version)

AI assistance: Codex isolated both dependency failures, found the first passing floors, and validated the full minimum matrix under human direction.