### PR TITLE
🩹 Handle QDMI jobs that omit the shot count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🩹 Reject a circuit job that carries no shot count instead of asking the IQM
+  Server to run zero shots, and report an unset shot count as absent rather than
+  as zero, now that MQT Core 3.9.2 lets a client omit it ([#219])
+  ([**@marcelwa**])
 - ⬆️ Require Qiskit 2.0 on Python 3.10–3.13 and Qiskit 2.1 on Python 3.14 and
   newer so the supported minimum environments install and run ([#218])
   ([**@burgholzer**])
@@ -228,6 +232,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#219]: https://github.com/iqm-finland/QDMI-on-IQM/pull/219
 [#218]: https://github.com/iqm-finland/QDMI-on-IQM/pull/218
 [#217]: https://github.com/iqm-finland/QDMI-on-IQM/pull/217
 [#206]: https://github.com/iqm-finland/QDMI-on-IQM/pull/206

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -356,7 +356,10 @@ including the
   {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_PROGRAMFORMAT`,
 - **number of shots**: The number of shots to execute for a quantum circuit job,
   set via
-  {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM`,
+  {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM`.
+  A circuit job that sets none is rejected with
+  {cpp:enumerator}`~QDMI_STATUS::QDMI_ERROR_INVALIDARGUMENT`, while a
+  calibration job runs no circuit and carries none,
 - **heralding mode**: Controls heralding behavior (valid values: "none",
   "zeros"), set via
   {cpp:enumerator}`~QDMI_DEVICE_JOB_PARAMETER_T::QDMI_DEVICE_JOB_PARAMETER_CUSTOM1`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 qiskit = [
-  "mqt-core~=3.9.1",
+  "mqt-core~=3.9.2",
   "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
   "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
   "qiskit-algorithms>=0.4.0",
@@ -79,7 +79,7 @@ IQM_JSON = "iqm.qdmi.serializers:qiskit_to_iqm_json"
 
 [dependency-groups]
 qiskit = [
-  "mqt-core~=3.9.1",
+  "mqt-core~=3.9.2",
   "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
   "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
   "qiskit-algorithms>=0.4.0",

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -181,8 +181,9 @@ struct IQM_QDMI_Device_Job_impl_d {
   std::string program_;
   /// Whether a program has been set.
   bool program_set_ = false;
-  /// The number of shots to execute for a quantum circuit job.
-  size_t num_shots_ = 0;
+  /// @brief The number of shots to execute for a quantum circuit job.
+  /// @details Unset for calibration jobs, which execute no circuit.
+  std::optional<size_t> num_shots_;
   /// @brief Heralding mode for the job.
   /// @details Valid values include "none" and "zeros".
   ///          Can be set via the QDMI_DEVICE_JOB_PARAMETER_CUSTOM1 parameter.
@@ -1302,8 +1303,12 @@ int IQM_QDMI_device_job_query_property(IQM_QDMI_Device_Job job,
   }
   ADD_LIST_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_PROGRAM, char, job->program_, prop,
                     size, value, size_ret)
+  if (prop == QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM &&
+      !job->num_shots_.has_value()) {
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM, size_t,
-                            job->num_shots_, prop, size, value, size_ret)
+                            *job->num_shots_, prop, size, value, size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 }
 
@@ -1317,6 +1322,12 @@ std::string_view Program_contents(const std::string &stored_program) {
 }
 
 int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
+  if (!job->num_shots_.has_value()) {
+    // The IQM Server has no default; reject here instead of asking it to run
+    // zero shots.
+    LOG_ERROR("Submitting a circuit job without a number of shots");
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
   LOG_INFO("Submitting circuit job");
   auto json_program = nlohmann::json();
   json_program["circuits"] = nlohmann::json::array();
@@ -1328,7 +1339,7 @@ int IQM_QDMI_device_job_submit_circuit(IQM_QDMI_Device_Job job) {
     json_program["circuits"].emplace_back(std::string{program});
   }
   json_program["calibration_set_id"] = job->session_->calibration_set_id_;
-  json_program["shots"] = job->num_shots_;
+  json_program["shots"] = *job->num_shots_;
   json_program["heralding_mode"] = job->heralding_mode_;
   json_program["move_gate_validation"] = job->move_gate_validation_;
   json_program["move_gate_frame_tracking"] = job->move_gate_frame_tracking_;
@@ -1946,11 +1957,12 @@ int IQM_QDMI_device_job_get_results_shots(IQM_QDMI_Device_Job job,
         }
 
         // Validate that the number of shots matches what was requested
-        if (!job->retrieved_ && num_shots != job->num_shots_) {
+        if (!job->retrieved_ && job->num_shots_.has_value() &&
+            num_shots != *job->num_shots_) {
           LOG_ERROR(
               "Number of shots in measurement response (" +
               std::to_string(num_shots) + ") does not match requested shots (" +
-              std::to_string(job->num_shots_) + ") for job " + job->job_id_);
+              std::to_string(*job->num_shots_) + ") for job " + job->job_id_);
           job->status_ = QDMI_JOB_STATUS_FAILED;
           return QDMI_ERROR_FATAL;
         }

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -749,6 +749,10 @@ TEST_F(DeviceIntegrationMockTest, StatusFollowsTheQueueRatherThanSubmissions) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
             QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
   http_stub.queue_post(200, R"({"id": "job-123"})");
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
@@ -1434,6 +1438,10 @@ TEST_F(DeviceJobMockTest, JobWaitRemainsRetryableAfterTransportFailure) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
             QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
   http_stub.queue_get_connection_error();
@@ -1538,6 +1546,10 @@ TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
             QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
   constexpr auto move_validation = "allow_prx";
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_CUSTOM2,
@@ -1570,6 +1582,45 @@ TEST_F(DeviceJobMockTest, SubmissionUsesCanonicalRunRequestFields) {
   EXPECT_FALSE(request.contains("num_active_reset_cycles"));
 }
 
+TEST_F(DeviceJobMockTest, CircuitSubmissionRequiresAShotCount) {
+  // The IQM Server has no default shot count, so a circuit job that never set
+  // one is rejected before any request goes out.
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
+                strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_TRUE(http_stub.post_urls().empty());
+
+  // The rejection leaves the job submittable once the shot count arrives.
+  http_stub.queue_post(200, R"({"id": "job-shots-set"})");
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
+  EXPECT_EQ(http_stub.post_urls().size(), 1U);
+}
+
+TEST_F(DeviceJobMockTest, ShotCountIsAbsentUntilItIsSet) {
+  size_t num_shots = 0;
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM, sizeof(num_shots),
+                &num_shots, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+
+  constexpr size_t shots = 64;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
+  EXPECT_EQ(IQM_QDMI_device_job_query_property(
+                job, QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM, sizeof(num_shots),
+                &num_shots, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(num_shots, shots);
+}
+
 TEST_F(DeviceJobMockTest, ReplacingProgramUsesLatestValueForSubmission) {
   constexpr auto replacement_program =
       R"({"name":"replacement","instructions":[],"metadata":{}})";
@@ -1584,6 +1635,10 @@ TEST_F(DeviceJobMockTest, ReplacingProgramUsesLatestValueForSubmission) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
@@ -1815,6 +1870,10 @@ TEST_F(DeviceJobMockTest, SubmissionQueuePositionDoesNotSkipTheRefresh) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
             QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
   const auto gets_after_submission = http_stub.get_urls().size();
@@ -1837,6 +1896,10 @@ TEST_F(DeviceJobMockTest, QueryQueuePositionRefreshesJobStatus) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
@@ -1873,6 +1936,10 @@ TEST_F(DeviceJobMockTest, QueuePositionRequiresQueuedJobAndKnownPosition) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
@@ -2925,6 +2992,10 @@ TEST_F(DeviceJobMockTest, MalformedProgramSubmissionReturnsAnErrorCode) {
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(invalid_circuit) + 1, invalid_circuit),
             QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
+            QDMI_SUCCESS);
   EXPECT_EQ(IQM_QDMI_device_job_submit(job), QDMI_ERROR_FATAL);
 
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
@@ -2947,6 +3018,10 @@ TEST_F(DeviceJobMockTest, JobStatusRejectsResponsesWithoutStatus) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
 
@@ -2972,6 +3047,10 @@ TEST_F(DeviceJobMockTest, HistogramResultsRejectMalformedCountsResponses) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_submit(job), QDMI_SUCCESS);
   ASSERT_EQ(IQM_QDMI_device_job_wait(job, 0), QDMI_SUCCESS);
@@ -3046,6 +3125,10 @@ TEST_F(DeviceJobMockTest, JobEntryPointsContainCxxExceptions) {
   ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
                 job, QDMI_DEVICE_JOB_PARAMETER_PROGRAM,
                 strlen(TEST_CIRCUIT_IQM_JSON) + 1, TEST_CIRCUIT_IQM_JSON),
+            QDMI_SUCCESS);
+  constexpr size_t shots = 100;
+  ASSERT_EQ(IQM_QDMI_device_job_set_parameter(
+                job, QDMI_DEVICE_JOB_PARAMETER_SHOTSNUM, sizeof(shots), &shots),
             QDMI_SUCCESS);
   for (const auto &[exception, expected_status] : mappings) {
     throw_from_transport(exception);

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.9.1" },
+    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.9.2" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'qiskit'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.3.2" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.1" },
@@ -1023,7 +1023,7 @@ provides-extras = ["qiskit"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.9.2" },
     { name = "nox", specifier = ">=2026.4.10" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
@@ -1047,7 +1047,7 @@ docs = [
     { name = "sphinx-llm", specifier = ">=0.4.1" },
 ]
 qiskit = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.9.2" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
@@ -1055,7 +1055,7 @@ qiskit = [
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.9.2" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
@@ -1324,43 +1324,43 @@ wheels = [
 
 [[package]]
 name = "mqt-core"
-version = "3.9.1"
+version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/bb/4c5072b6b0110215dbc3d9dc54d53487ae705425552b0ceda7feb19af75a/mqt_core-3.9.1.tar.gz", hash = "sha256:6a77dfd7a09d8990b9771a4b0f8300e7660adf7622ac95b2f9851b4d607d2217", size = 811570, upload-time = "2026-08-24T23:04:46.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/90/aea2987b3f9e6495e7e4b7cd146e85d15ad467910382b09bfa9dd3e74c03/mqt_core-3.9.2.tar.gz", hash = "sha256:9165fcd73c173fe3742cdf192549f43e2afedc5e3881d7002775004b3cd92f76", size = 811847, upload-time = "2026-08-26T19:56:58.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8b/8c32c8b50299618625027f3e8a5f13912d4e6bf765e004e14a8bcb1801e1/mqt_core-3.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:67f239bb8566832be9cc250e9eff2a064a33d422a2d941aaed09e8b04c48570f", size = 5989334, upload-time = "2026-08-24T23:03:46.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c3/c79943abcfccf6f4d2ec019a27d5235c8f883109a367f7780e30dd484553/mqt_core-3.9.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5efae5b63e3fea30b9d437c02cc35031c292622f1ae8c4148fd69a191de4f9ff", size = 6439968, upload-time = "2026-08-24T23:03:48.464Z" },
-    { url = "https://files.pythonhosted.org/packages/09/4b/aca1ac8d61dcac34fca189bd16e7c6c52ea874a7aaa5db4d51461946e16d/mqt_core-3.9.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e36d1f2f7970ea6ebb6217994a7aa9faf2df11f0aba78c599a6b6af6f0857161", size = 8673577, upload-time = "2026-08-24T23:03:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b5/d0514923bded2822d19beffcb1ff0a32612c10c78b2f6389a8bf146378c2/mqt_core-3.9.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ab727ec2d637bfa66e3686de36c1b01d3c36eeca1fd4629b5062c25d95f9015", size = 9202836, upload-time = "2026-08-24T23:03:52.277Z" },
-    { url = "https://files.pythonhosted.org/packages/37/49/b16b9dd394334f96a5f6408c47c97e86e742422e436a1f5d079e08157580/mqt_core-3.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:91a3697509b20a77c8818032554ed9be608d2760c879835bece5e3c1d1af9b4d", size = 9175784, upload-time = "2026-08-24T23:03:54.313Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/e8/e04f972429c22edb87754c487d726465a17aaabf0e7d9215831f7e133809/mqt_core-3.9.1-cp310-cp310-win_arm64.whl", hash = "sha256:e22321af3c9895107791dcd8bd3c371a9e6eab8fc6523edae79f591df84b4b31", size = 9025819, upload-time = "2026-08-24T23:03:56.33Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d7/716ca35ed2dea5587198056ed8d36b37a7acdf5b43a3c05aecc5222daa5a/mqt_core-3.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2cfdf031a9a6070ea6d478ea03c553fe824b1c7d860b2dd3ac9f9ff57709e5f", size = 5989398, upload-time = "2026-08-24T23:03:58.199Z" },
-    { url = "https://files.pythonhosted.org/packages/11/9a/51186a8debb7b18abbe236e7cbad4b6e339d5c0f7255b12d14f528eec6da/mqt_core-3.9.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:fc48cf7b7629b4ed14ea5a6382a0d26acaad5f922fb62d207cb128fef0f27b4f", size = 6440025, upload-time = "2026-08-24T23:03:59.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/11/d2016aa95f85e960575dd569773f76c9fe8c78fb9a93d7fcff0d9cba88c1/mqt_core-3.9.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62fc8a86bec0aaac1c86d56194921995b64a9132e57f80ac455a2206124d1f56", size = 8673217, upload-time = "2026-08-24T23:04:01.384Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/3a/23ccf22e8099dc3a570873a962f75759b13d56741b774df0546caece65db/mqt_core-3.9.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3307d48dcb1dc6e491933303dbc2649fb0d25a54dcd31bc4dd9c38accc866018", size = 9202651, upload-time = "2026-08-24T23:04:03.243Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cd/1235014aa6afbc2a2d80c80d55414939e4219913d0820d8546f131394c34/mqt_core-3.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:e2cf666c8a6176311510778ccc57834b593916cc362c261da834ce85dbe35187", size = 9176015, upload-time = "2026-08-24T23:04:06.501Z" },
-    { url = "https://files.pythonhosted.org/packages/75/9f/0f11c28c02d3dac9a99bf3011ef427757d5c25da7b3881073205a2f52cf0/mqt_core-3.9.1-cp311-cp311-win_arm64.whl", hash = "sha256:cf28940b233b51a637a1b8c769d2e1565c196f772695bc05b8a5df2672505335", size = 9025621, upload-time = "2026-08-24T23:04:08.581Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ef/3a51d9663180e087567c69abf5657e55299fe8b013a45ed832fdea05dbf1/mqt_core-3.9.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:6cb9d21e99c27f6e00f303163b851ed1165ffbc078e8d16a97738fdd79718e4e", size = 5981892, upload-time = "2026-08-24T23:04:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7c/8531816da06b8a6eaaed325dd158e82d2b0a6276d623b37c1911356e2d70/mqt_core-3.9.1-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:d648118e380311101fea7cc8b616401dd67be62df1f09932d38570bdb52b9140", size = 6433797, upload-time = "2026-08-24T23:04:12.798Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c2/ccafedd9863cdfdc3b26b1952e575bf015b1916ad197432d2741bceb3113/mqt_core-3.9.1-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3a647281accbf405c5d95fdec1e7edd5cd047373b41b92aab8c0164252b2383", size = 8655936, upload-time = "2026-08-24T23:04:14.419Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b2/8074d5dea3da36080b56d98416c30f4c6264173c91f6139be08eefc535c8/mqt_core-3.9.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9624a6a54598602fe60a967aa56445d3a9a5e01817349a489183a0734e2423f", size = 9183022, upload-time = "2026-08-24T23:04:16.597Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/82/8c6482ee209fb62da359250a3ac9c0d7beffd497383b4f76e3a14a4176e7/mqt_core-3.9.1-cp312-abi3-win_amd64.whl", hash = "sha256:78b41b54682a9fb6fa9ec0fb45af9545709911a65c46b6c101130977750f7987", size = 9167071, upload-time = "2026-08-24T23:04:18.688Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8f/467b4f273e4a97df24268f5d11bc0ca6b6488b9415cd7d92d920ea4fc8ec/mqt_core-3.9.1-cp312-abi3-win_arm64.whl", hash = "sha256:7eb97b0b606736180769bd1ed459f70661f361da478adbc2f83ef281dbab550b", size = 9015267, upload-time = "2026-08-24T23:04:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/29/7846cf33b7cc124d6ea1cba38588ee26c0079c55c81dc6ee06a5938d126f/mqt_core-3.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fd105e117cc67820b12941a50ea457a813a23febb149fc918ad3307e7c36a67c", size = 5996211, upload-time = "2026-08-24T23:04:22.633Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ee/db674609fa6947511661edf310b95e80c98ca9d0f9f908bb77cc4c788604/mqt_core-3.9.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:ed65aeef950ebdeaafa5b8f10fc684aa4cbd0fc0f7d41909d8c708c6e314a7ff", size = 6448900, upload-time = "2026-08-24T23:04:24.304Z" },
-    { url = "https://files.pythonhosted.org/packages/60/05/0a0c8fb5f4dc7ae3c9c6693821e6fed8e69a7e873c459ffaf59b0d3f3f41/mqt_core-3.9.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f51e8c0e93cadf4645988398a43050d65f575f8c689690e1e284e4048bab710e", size = 8675517, upload-time = "2026-08-24T23:04:26.188Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f6/8a01a577b15119265e759a0fe15a532bb1152cf453a7367beafc15f326c1/mqt_core-3.9.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9f4ac776a1c3c72dc403ebb41c8574fe2044b6138713fcb1433990c8cb10f76", size = 9202503, upload-time = "2026-08-24T23:04:28.31Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d5/a6ac7b37aeceb48330d5fb8b11242a45813a3c1d9585d1d9f462972de42f/mqt_core-3.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:48fbaa86b3b6288fca4bc12cd4e9628afee89cdda816e92317a54f0e6e82915e", size = 9254604, upload-time = "2026-08-24T23:04:30.412Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/0e/aa58cef6679c02e5abbd5181e54f3011d68178f3a9335f035de9ece3725d/mqt_core-3.9.1-cp314-cp314t-win_arm64.whl", hash = "sha256:71d44b97600a2a9b153cc25662a4c7bd2e882515d423f9b1b21dbee2995cf66f", size = 9099836, upload-time = "2026-08-24T23:04:32.208Z" },
-    { url = "https://files.pythonhosted.org/packages/16/cd/9e6e4426f4d06b7b8ca5c7122a8b9f8072ea910a7ddea454cb518a202e15/mqt_core-3.9.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:7ebc47ff0d4f922c3af28ad36fe96fe0b901f8136034273612088e8b0c0d0285", size = 5996169, upload-time = "2026-08-24T23:04:34.316Z" },
-    { url = "https://files.pythonhosted.org/packages/80/5d/5950f18d39a60a903a2f8c75fe1a7f19a26600f93e2ff2f682337f392d9c/mqt_core-3.9.1-cp315-cp315t-macosx_11_0_x86_64.whl", hash = "sha256:96e5fced1c771bb16fc7ab40ac9eac0544921dc01f143a4edba826c3a21c0d7b", size = 6448890, upload-time = "2026-08-24T23:04:36.199Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/df/83e131f4fc9d312bc70d6d6286049320e77365a3b074bebe39fe31c1ca23/mqt_core-3.9.1-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483f09751db706fc645225f5624d9e0a9550d655039caa136f1349214f293b83", size = 8675516, upload-time = "2026-08-24T23:04:38.119Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/28/f3e69db050bcdb9cd4c6a038c20306106e7ceae6446f8074868abd4f99bf/mqt_core-3.9.1-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f079b6ca4c04cac7b8ed882f996fc55a3d3f2c041385131bd12c10a37bed2ffa", size = 9202481, upload-time = "2026-08-24T23:04:40.417Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/f80c2c651e5dd8e326aef2d11fc8f2fc2f09186d4f9e09ea2b4ee536ba2f/mqt_core-3.9.1-cp315-cp315t-win_amd64.whl", hash = "sha256:066f52ab7c1921f2d1a5b45329232099dbe5ab5bcd7acc38759c318244eb7153", size = 9254418, upload-time = "2026-08-24T23:04:42.465Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/28/ea5f047ea0af9040bb5b925112303fdca5e9be61ba1cf647822c1c8c0655/mqt_core-3.9.1-cp315-cp315t-win_arm64.whl", hash = "sha256:280d5a1724dd419acb912243f46b428c6d0e117f2c9561b749ee5edecf29af82", size = 9099846, upload-time = "2026-08-24T23:04:44.543Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1b/57857e82df97303099219de65d6687ee2ad62b17496b4796cf7b00584ca0/mqt_core-3.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:573fb6cc19c58df4092418bcc56195c508ac87c3b9cb8b271b3968b0b591bc86", size = 5990614, upload-time = "2026-08-26T19:55:55.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/59/5267642633f182599ff1fd17bc528eb23f84aee68436ce8503f9d2085b22/mqt_core-3.9.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:90e0162f10a60b8b8d1634237949233dde5c9f35fd59908932e1e7107704a44c", size = 6441514, upload-time = "2026-08-26T19:55:57.919Z" },
+    { url = "https://files.pythonhosted.org/packages/01/81/595d12bcfd742667bc91e1f0ecf700dd729fb02060f8bfa9d7e3ae2aa5b5/mqt_core-3.9.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db8c2621da7b4bff02ba6e349aca7895ff2af52c259581e2e1de0056e8cb25", size = 8675351, upload-time = "2026-08-26T19:55:59.886Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b7/b9404cb0c311ed94161f9712defe8bd88ca08c805a4ca0076dedd4e0c27a/mqt_core-3.9.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0e0de742b1e79a2d0af155833b8ce2b39de8738fef5355c2d54e3cc42fba65d", size = 9203930, upload-time = "2026-08-26T19:56:02.68Z" },
+    { url = "https://files.pythonhosted.org/packages/86/cf/cee09153034e137e34583889def38c065f23e85fb4eb11efcd1bc5109aa7/mqt_core-3.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:11ec148859b50770e9f1bb88b1ce7a58b1d24b6086757ddc51a346ae4fcf3c47", size = 9176627, upload-time = "2026-08-26T19:56:05.328Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8f/00002bcb50a49d07d010c0ec907d678c8c441431ed7ef0b5ca2ed3b99359/mqt_core-3.9.2-cp310-cp310-win_arm64.whl", hash = "sha256:5b4a24b2fa308463d9fe4d7caba92dcf47e9b8f9ca1a5c944188094823c82f05", size = 9026441, upload-time = "2026-08-26T19:56:07.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/6a307d854f34ea9c1c7b204d4693ac14db25a3a71ded59f966f9fe9c5638/mqt_core-3.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2c2d8977346a21fbe667c770bf1fbdadb54228b58e64d6f5fd21005e2201dd81", size = 5990654, upload-time = "2026-08-26T19:56:09.679Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c9/2e6e9da103e1c40cb3fc178932a1cc9c78d016bb88d2ac1b0f0445c5bc64/mqt_core-3.9.2-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:76919993da5efc6b589e0778b5441e3e651b4ddd3345bfb0c8c95c963dcd0744", size = 6441565, upload-time = "2026-08-26T19:56:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b9/d410f51aa5fa4b101bf18194ca9be04f2a497c69d0fae8fa07e2594f65eb/mqt_core-3.9.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99d5a3f78de946d2cb6de4c72872901a7a75e7fd8b85e1697ef7790eb5ede88", size = 8674960, upload-time = "2026-08-26T19:56:13.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ef/55d73c6aa6bf8a357c3c4a9dac283ad4597523033b769461a367fe111fdf/mqt_core-3.9.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a225fc2359fb2d5bebf9e6ef4a2d5fe613310a4529b92c64321b6ce1a8f9f98", size = 9203735, upload-time = "2026-08-26T19:56:15.16Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2b/cb794f7a44c14169b936893bfc75482f17de34ce2611b0d9e4477057d6f5/mqt_core-3.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:38c9ec6708dadc4c9c96b907b8056fe55bd4c7ea9a56d98bd8b0ba429e9967c2", size = 9176855, upload-time = "2026-08-26T19:56:17.451Z" },
+    { url = "https://files.pythonhosted.org/packages/00/4d/04ca0c5319342d3e5294f8e751485b18d09f18a0e98297acd5f1a697c4c4/mqt_core-3.9.2-cp311-cp311-win_arm64.whl", hash = "sha256:e02a0342339c11b5b0b642be49666c861f457e488f06e3da61ac455512b8441e", size = 9026259, upload-time = "2026-08-26T19:56:19.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/61/d23e4adc77d43a5f3af946cb9585caa4ae25d439c743e5328ad69c26d13d/mqt_core-3.9.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:f217d84252bdc4cf9d9216e06432ec1493c838f389e52f248802645a9ffcebfb", size = 5983121, upload-time = "2026-08-26T19:56:21.687Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ed/274e39ea905211b1808913045d53a74983098ef61eb1e96db6454b6cc412/mqt_core-3.9.2-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:6786e02226eb0269b63a7755b30b82843093645b7b4edeea3d058fa863f320d7", size = 6435172, upload-time = "2026-08-26T19:56:23.363Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a7/184ae073d6a44ded67aa3c054603884ea4c8ffd3a6ed39729a6e7f1c7980/mqt_core-3.9.2-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1483708a4cfb98b62998364940bcdd952b24de6786456747dcc72f4db689d0c4", size = 8657586, upload-time = "2026-08-26T19:56:25.291Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e1/2be4a668194e7bc41285a202742653ac4825878a5bf91ea7648d20283bf5/mqt_core-3.9.2-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dba6238b1409e73a17ad681a0e4018abc3f4b8ad1f7539c70fb00fa33b52700a", size = 9184324, upload-time = "2026-08-26T19:56:27.654Z" },
+    { url = "https://files.pythonhosted.org/packages/46/39/7a214dd6b0c17b92579cd76d78e609fbd624c6bd15d625c716c3614e7f1d/mqt_core-3.9.2-cp312-abi3-win_amd64.whl", hash = "sha256:0107df33fe2a3d7af9338703cc5a11b1821c0b385c390193431ad584ae3d6ef0", size = 9167916, upload-time = "2026-08-26T19:56:29.703Z" },
+    { url = "https://files.pythonhosted.org/packages/84/97/ed207d7a0800b46d13e4353044c365af986c06f05739a132ae0a4af52236/mqt_core-3.9.2-cp312-abi3-win_arm64.whl", hash = "sha256:0c1ad9fdf9cfe530934a05df023febc5bc24ce74f88c90be57f67059ae22546f", size = 9015897, upload-time = "2026-08-26T19:56:31.758Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/23af918b4cd795fd6648eda85e65930017d06510c5bc70dfc6cfeeefb1aa/mqt_core-3.9.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:50f9198ed00ce091e37ffccd62e0a97b85e85b37720499b1f2765682e6888a8c", size = 5997464, upload-time = "2026-08-26T19:56:34.045Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/75/cf13ff37e80c02079e9f89fb519a27f648602165510f07d49ba5d587db84/mqt_core-3.9.2-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:89bcbd1f867b2ea81f345bf809015aa92cc99c75f5cb8d8a610e1897ccdc385d", size = 6450364, upload-time = "2026-08-26T19:56:35.711Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3f/00c45549976c0e9474ab51ed7d5ea71e1210ea3a9d6fdf9894876b45ce08/mqt_core-3.9.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5548cfffb3115881804e26ddb93270a087dbbbac8905b18dc5954051553e17d2", size = 8677149, upload-time = "2026-08-26T19:56:37.619Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/67d8ad5aabf3e847822d6c3d7a112d1da0cfef62c13037eb855fd4612b4f/mqt_core-3.9.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca1e9855c7b0f3338958c465b42414ae95c7f1feb1d269666eabf0cf880a7aaa", size = 9203848, upload-time = "2026-08-26T19:56:39.741Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/f444af11e3845de4e1db3bbfe4c1ecf6136da40f572176873cc4c9a00db9/mqt_core-3.9.2-cp314-cp314t-win_amd64.whl", hash = "sha256:eadf31683555f910ce2f304cdd24a6ac7fe953bf70bce3a94ec8794f2b3360bf", size = 9255216, upload-time = "2026-08-26T19:56:41.987Z" },
+    { url = "https://files.pythonhosted.org/packages/71/07/3619cd5c14eb635810c95e95fa1edb6f96a423922d23397e4c1fdc2e7db2/mqt_core-3.9.2-cp314-cp314t-win_arm64.whl", hash = "sha256:93d986fe283b22c5396b9e91a45499dfb02a814ac0565dbeac3f892e9aefb51f", size = 9100846, upload-time = "2026-08-26T19:56:44.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/19/f455b307169c0bcd6eaf48b75320421b362d2a086f8550a1a450ad747a36/mqt_core-3.9.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:9f532618b865dc231c0df8fc7e479052507ac009cadc25c8d95af0f9816d03c8", size = 5997362, upload-time = "2026-08-26T19:56:46.202Z" },
+    { url = "https://files.pythonhosted.org/packages/af/24/05ffbbbd8fbb8233bdc95f8465dfc4c59ca106245ff5d18906d4f4f6555c/mqt_core-3.9.2-cp315-cp315t-macosx_11_0_x86_64.whl", hash = "sha256:4865ae0efb2fc068230dc3e7944254e03052f3ea6a4c086456683c65e608d575", size = 6450326, upload-time = "2026-08-26T19:56:48.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f9/ff5bb3d1e7a0d024f854b464bbf24ce4798c36b894b9ae05dae11ab0abee/mqt_core-3.9.2-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:960d360ddfc7f2e53ca5e5e670ae09a8b719d39696810ea6db8b9195aae0e76a", size = 8677111, upload-time = "2026-08-26T19:56:50.356Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/07/4130814a0162916702859c9b978a8229fe6e8b946d4c1af8577a83c43f69/mqt_core-3.9.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85a28feb1ce9868718a55c9da9a2f925db5f9a04a341dd2845a5086c29843765", size = 9203849, upload-time = "2026-08-26T19:56:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/20/62c4df70519ac7fb323f5c5ffd820eaa7239133fcfc63a9187bde4f7a097/mqt_core-3.9.2-cp315-cp315t-win_amd64.whl", hash = "sha256:2119fd2095e150fff0604aa97dd1d7d22c694b6fd8554a5f921f0a5f4e0e7f72", size = 9255025, upload-time = "2026-08-26T19:56:54.51Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b5/3c243c763ffca881e857535025d7db49d2ed11797affe57a91aeac92baeb/mqt_core-3.9.2-cp315-cp315t-win_arm64.whl", hash = "sha256:f16ac2eba19d9bb3d3d35a79aa783f5c09c06f82dce0b93ca2ec881af45d0822", size = 9100845, upload-time = "2026-08-26T19:56:56.577Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 *AI text below* 🤖

MQT Core 3.9.2 lets a client submit a QDMI job without ever setting `SHOTSNUM` (munich-quantum-toolkit/core#2258), which makes a state this device never had to handle reachable: it kept `size_t num_shots_ = 0` and wrote `json_program["shots"]` unconditionally, so an omitted count would have asked the IQM Server to run zero shots. The count is now a `std::optional`, a circuit job carrying none is rejected with `QDMI_ERROR_INVALIDARGUMENT` before any request goes out and stays submittable once the count arrives, and `QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM` answers `QDMI_ERROR_NOTSUPPORTED` while it is unset. Calibration jobs already arrived without a shot count and are otherwise unaffected, though `Job::getNumShots` now throws for them instead of returning a fabricated zero — say so if you would rather keep the zero. Eleven existing unit tests submitted circuit jobs without a shot count and now set one; two new ones cover the rejection and the property query, and there is no Python test because every job-submitting path here needs a live Resonance session. Once #200 lands, pulse jobs in `QDMI_PROGRAM_FORMAT_CUSTOM1` want the opposite treatment — the `RunDefinition` payload owns its repetition count, so that format should reject `SHOTSNUM` outright — but that belongs in its own PR. Verified with a Release Ninja build: 145 unit tests pass, `clang-tidy` is clean on both changed C++ files, `uvx nox -s lint` is green, and `pytest test/python` is 59 passed / 7 skipped (all live-credential).
