### PR TITLE
🔒️ Stop the SPANK plugin from exporting its bundled dependencies into slurmstepd

### DIFF
--- a/spank/CMakeLists.txt
+++ b/spank/CMakeLists.txt
@@ -26,6 +26,18 @@ target_link_libraries(
                                     qdmi::qdmi_project_warnings)
 set_target_properties(${BUILD_IQM_SPANK_TARGET} PROPERTIES PREFIX "")
 
+# Export only the SPANK ABI. Slurm dlopens the plugin into slurmstepd next to
+# other site plugins, so the statically linked cpr, libcurl, and OpenSSL symbols
+# must not be visible there for anything else to bind against.
+set(IQM_QDMI_SPANK_VERSION_SCRIPT
+    "${CMAKE_CURRENT_SOURCE_DIR}/iqm-spank-plugin.map")
+target_link_options(${BUILD_IQM_SPANK_TARGET} PRIVATE
+                    "LINKER:--version-script=${IQM_QDMI_SPANK_VERSION_SCRIPT}")
+set_property(
+  TARGET ${BUILD_IQM_SPANK_TARGET}
+  APPEND
+  PROPERTY LINK_DEPENDS "${IQM_QDMI_SPANK_VERSION_SCRIPT}")
+
 # Detect the Slurm plugin directory for the SPANK plugin.
 set(IQM_QDMI_SPANK_INSTALL_DIR_DEFAULT "/usr/lib/slurm")
 find_program(IQM_QDMI_SCONTROL_EXECUTABLE scontrol)

--- a/spank/iqm-spank-plugin.map
+++ b/spank/iqm-spank-plugin.map
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 IQM Finland Oy
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+{
+  global:
+    plugin_name;
+    plugin_type;
+    plugin_version;
+    spank_plugin_version;
+    slurm_spank_init;
+    slurm_spank_init_post_opt;
+    slurm_spank_user_init;
+    slurm_spank_task_init;
+    slurm_spank_task_init_privileged;
+    slurm_spank_exit;
+  local:
+    *;
+};

--- a/spank/test/run_docker_tests.sh
+++ b/spank/test/run_docker_tests.sh
@@ -42,6 +42,18 @@ if ldd "${plugin_path}" | grep -Fq libiqm-qdmi-device; then
   exit 1
 fi
 
+echo "=== Verifying the SPANK plugin exports only the SPANK ABI ==="
+expected_symbols=$(printf '%s\n' \
+  plugin_name plugin_type plugin_version spank_plugin_version \
+  slurm_spank_init slurm_spank_init_post_opt slurm_spank_user_init \
+  slurm_spank_task_init slurm_spank_task_init_privileged slurm_spank_exit | sort)
+actual_symbols=$(nm --dynamic --defined-only "${plugin_path}" | awk '{print $3}' | sort)
+if [[ "${actual_symbols}" != "${expected_symbols}" ]]; then
+  echo "IQM SPANK plugin exports symbols beyond the SPANK ABI:" >&2
+  echo "${actual_symbols}" >&2
+  exit 1
+fi
+
 echo "=== Verifying basic Slurm srun connectivity ==="
 srun --partition=debug --immediate=5 /bin/true
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

The SPANK plugin links `iqm::qdmi_device_internals`, which attaches cpr, libcurl, zlib, and OpenSSL as PUBLIC on an OBJECT library, so those symbols end up in the dlopened module with default visibility and are candidates for interposition inside `slurmstepd` alongside other site plugins — 576 exported symbols where the SPANK ABI needs 10. This adds a linker version script that exports exactly the four metadata symbols and six hooks the plugin defines and hides the rest, plus an assertion in the Docker test run so a dropped version script fails instead of silently widening the surface again. Nothing observable changes for users; `--version-script` is GNU ld/lld only, which is fine because the plugin requires `slurm/spank.h` and is built solely on Linux in CI.