### PR TITLE
✅ Let CTest select the offline test suite

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -259,6 +259,10 @@ ctest -C Release --test-dir build --output-on-failure
 ctest -C Release --test-dir build/test/unit --output-on-failure
 ```
 
+The integration tests also carry the `integration` CTest label, so
+`ctest -C Release --test-dir build -LE integration --output-on-failure` selects
+the same offline subset from the top-level build directory.
+
 **Running integration tests (requires IQM access):**
 
 Before running the integration tests, make sure you have set the necessary

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -31,8 +31,10 @@ if(WIN32)
       $<TARGET_FILE_DIR:integration_tests>)
 endif()
 
+# These tests need a live IQM backend, so they carry a CTest label that lets a
+# caller select them with `ctest -L integration` or skip them with `-LE`.
 gtest_discover_tests(
   integration_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-             DISCOVERY_TIMEOUT 60)
+  PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}" LABELS
+             integration DISCOVERY_TIMEOUT 60)


### PR DESCRIPTION
🤖 *AI text below* 🤖

The integration tests reach a live IQM backend, but they registered with CTest without a label, so selecting the offline suite meant knowing the build layout and pointing ctest at `build/test/unit`. They now carry an `integration` label, which makes `ctest -LE integration` run everything that works without credentials and `ctest -L integration` run the live suite, from the top-level build directory. Default behaviour is unchanged and every CI workflow keeps running the whole suite; note that the label has to precede `DISCOVERY_TIMEOUT` in the argument list, since that keyword ends the `PROPERTIES` list and anything after it is dropped silently.