### PR TITLE
✨ Answer the standard needs-calibration device query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Answer `QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` with zero instead of
+  `QDMI_ERROR_NOTSUPPORTED`, since IQM schedules recalibration itself and never
+  asks a client to trigger one ([#229]) ([**@marcelwa**])
 - ✨ Slow down before the IQM Server API rate limit blocks the account, waiting
   out the quota window instead of taking a 30-second block.
   `IQM_RATE_LIMIT_THRESHOLD_PERCENT` moves the threshold or turns it off
@@ -240,6 +243,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#229]: https://github.com/iqm-finland/QDMI-on-IQM/pull/229
 [#214]: https://github.com/iqm-finland/QDMI-on-IQM/pull/214
 [#220]: https://github.com/iqm-finland/QDMI-on-IQM/pull/220
 [#218]: https://github.com/iqm-finland/QDMI-on-IQM/pull/218

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -305,6 +305,12 @@ The following properties about the device can be queried via the
   The list of available calibrated operations on the device.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_COUPLINGMAP`:
   The coupling map between qubits on the device.
+- {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION`:
+  Whether the device needs calibration. IQM schedules recalibration itself and
+  the IQM Server publishes no signal asking a client to trigger one, so this is
+  always zero. A quantum computer that is unfit to run reports itself as under
+  maintenance through
+  {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_STATUS`.
 - {cpp:enumerator}`~QDMI_DEVICE_PROPERTY_T::QDMI_DEVICE_PROPERTY_CUSTOM1`: The
   current calibration set ID used by the session.
 

--- a/src/iqm_device.cpp
+++ b/src/iqm_device.cpp
@@ -2358,6 +2358,10 @@ int IQM_QDMI_device_session_query_device_property(
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP,
                     (std::pair<IQM_QDMI_Site, IQM_QDMI_Site>{}),
                     session->connectivity_, prop, size, value, size_ret)
+  // Recalibration is scheduled by IQM, and the IQM Server exposes no signal
+  // asking a client to trigger one.
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION, size_t, 0,
+                            prop, size, value, size_ret)
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_DURATIONUNIT, "us", prop, size,
                       value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR, double,

--- a/test/unit/test_iqm_device.cpp
+++ b/test/unit/test_iqm_device.cpp
@@ -916,6 +916,21 @@ TEST_F(DeviceIntegrationMockTest, QubitCountMatchesSiteCountWithoutResonators) {
   EXPECT_EQ(sites_size / sizeof(IQM_QDMI_Site), 2U);
 }
 
+TEST_F(DeviceIntegrationMockTest, ReportsNoCalibrationRequirement) {
+  queue_successful_initialization();
+  ASSERT_EQ(IQM_QDMI_device_session_init(session), QDMI_SUCCESS);
+  const auto requests_before = http_stub.get_urls().size();
+
+  size_t needs_calibration = 1;
+  ASSERT_EQ(IQM_QDMI_device_session_query_device_property(
+                session, QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION,
+                sizeof(needs_calibration), &needs_calibration, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_EQ(needs_calibration, 0U);
+  // No IQM Server signal backs the answer, so no request is issued for it.
+  EXPECT_EQ(http_stub.get_urls().size(), requests_before);
+}
+
 TEST_F(DeviceTest, SessionAllocation) {
   // Session should be allocated in SetUp
   EXPECT_NE(session, nullptr);


### PR DESCRIPTION
🤖 *AI text below* 🤖

`QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` was unhandled, so a client asking whether the quantum computer needs calibration got `QDMI_ERROR_NOTSUPPORTED` instead of an answer. The QDMI contract makes it a `size_t` where zero means no calibration is needed, and the IQM Server publishes no field carrying that meaning — health reports `{healthy, updated_at}`, the queue endpoint reports length and availability, and the calibration-set endpoints only describe the current default set — so with recalibration scheduled by IQM and an unfit system already surfacing as `QDMI_DEVICE_STATUS_MAINTENANCE`, zero is the honest answer, matching QDMI's own reference device and its conformance test. Happy to derive it from a server signal instead if one exists that I could not find in the API.