### PR TITLE
🔧 Round out the README badges and the packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@
 
 # QDMI on IQM
 
+[![PyPI](https://img.shields.io/pypi/v/iqm-qdmi?logo=pypi&style=flat-square)](https://pypi.org/project/iqm-qdmi/)
 [![Core Apache 2.0 License](https://img.shields.io/static/v1?logo=Apache&label=Core&message=Apache%202.0&color=informational&style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![SPANK Plugin GPLv3 License](https://img.shields.io/static/v1?logo=gnu&label=SPANK&message=GPLv3&color=informational&style=flat-square)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 [![C++20](https://img.shields.io/static/v1?logo=cplusplus&label=C%2B%2B&message=20&color=informational&style=flat-square)](https://isocpp.org/)
 [![CMake](https://img.shields.io/static/v1?logo=CMake&label=CMake&message=3.24%2B&color=informational&style=flat-square)](https://cmake.org/)
+[![CI](https://img.shields.io/github/actions/workflow/status/iqm-finland/QDMI-on-IQM/CI.yml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/iqm-finland/QDMI-on-IQM/actions/workflows/CI.yml)
+[![codecov](https://img.shields.io/codecov/c/github/iqm-finland/QDMI-on-IQM?style=flat-square&logo=codecov)](https://codecov.io/gh/iqm-finland/QDMI-on-IQM)
 
 **QDMI on IQM** is IQM's official, production-ready implementation of the
 [Quantum Device Management Interface (QDMI)](https://github.com/Munich-Quantum-Software-Stack/qdmi)—a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,3 +288,8 @@ cache-keys = [
 # To avoid limiting the usability of the core library, we purposely do not add these packages as dependencies.
 # As a consequence, we need to ignore the unresolved imports from these packages in the type analysis.
 allowed-unresolved-imports = ["mqt.bench.**", "qiskit_nature.**", "qiskit_algorithms.**", "pyscf.**"]
+
+[tool.ty.terminal]
+# Warnings are not surfaced by the exit code unless this is set, so `ty` findings
+# below error level would otherwise pass CI unnoticed.
+error-on-warning = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ install.components = ["iqm-qdmi-device_Runtime", "iqm-qdmi-device_Development"]
 sdist.include = ["python/iqm/qdmi/_version.py"]
 sdist.exclude = [
   "**/docs",
+  "**/test",
+  "spank/**",
   "sitecustomize.py",
   ".*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ qiskit = [
 
 [project.urls]
 Homepage = "https://github.com/iqm-finland/QDMI-on-IQM"
+Documentation = "https://iqm-finland.github.io/QDMI-on-IQM/"
 Issues = "https://github.com/iqm-finland/QDMI-on-IQM/issues"
 Discussions = "https://github.com/iqm-finland/QDMI-on-IQM/discussions"
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

The README advertised only static facts, so nothing there told a reader whether the published package was current, whether main was building, or what the coverage gate said, and the package metadata pointed everywhere except at the documentation site. The sdist also shipped the C++ and Python test trees and the SPANK plugin — 40 of its 79 entries — even though a source install configures with `BUILD_IQM_QDMI_TESTS=OFF` and `BUILD_IQM_SPANK` off, and `ty` exited zero on warning-level diagnostics, which `[tool.ty.terminal]` now turns into a failure. A wheel still builds from the trimmed sdist, `check-sdist` reads the exclude list and stays quiet, and the shields URL spells `CI.yml` exactly as the workflow file does, since shields matches it case-sensitively.