### PR TITLE
🐛 Keep token fixtures valid

### DIFF
--- a/test/unit/test_iqm_auth.cpp
+++ b/test/unit/test_iqm_auth.cpp
@@ -115,17 +115,16 @@ testing::AssertionResult Is_bearer_for(const std::optional<cpr::Bearer> &actual,
   return testing::AssertionSuccess();
 }
 
-constexpr std::string_view K_FUTURE_TOKEN =
+// The payload contains {"exp":9223372036854775807}, the largest signed
+// 64-bit timestamp, so the fixture cannot expire during the test suite's
+// lifetime.
+constexpr std::string_view K_VALID_TOKEN =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    "eyJleHAiOjE3ODg0MDY0MDAsIm5iZiI6MTYyMDY3NTIw"
-    "MCwiaWF0IjoxNjIwNjc1MjAwfQ.signature";
+    "eyJleHAiOjkyMjMzNzIwMzY4NTQ3NzU4MDd9.signature";
 } // namespace
 
 TEST(TokenManagerTest, TimeLeftSeconds) {
-  // A valid token with an expiration time in the future
-  const std::string valid_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-                                  "eyJleHAiOjE3ODg0MDY0MDAsIm5iZiI6MTYyMDY3NTIw"
-                                  "MCwiaWF0IjoxNjIwNjc1MjAwfQ.signature";
+  const auto valid_token = std::string(K_VALID_TOKEN);
   EXPECT_GT(iqm::TokenManager::time_left_seconds(valid_token), 0);
 
   // An expired token
@@ -233,35 +232,32 @@ TEST(TokenManagerTest, ConstructorWithExplicitTokenOverridesEnvironment) {
 TEST(TokenManagerTest, ConstructorWithExplicitTokensFile) {
   const ScopedEnvVar env_token("IQM_TOKEN", nullptr);
   const ScopedEnvVar env_tokens_file("IQM_TOKENS_FILE", nullptr);
-  const ScopedTokensFile tokens_file("test_tokens.json",
-                                     std::string(K_FUTURE_TOKEN));
+  const auto valid_token = std::string(K_VALID_TOKEN);
+  const ScopedTokensFile tokens_file("test_tokens.json", valid_token);
 
   iqm::TokenManager tm(std::nullopt, std::make_optional(tokens_file.path()));
-  EXPECT_TRUE(
-      Is_bearer_for(tm.get_bearer_token(), std::string(K_FUTURE_TOKEN)));
+  EXPECT_TRUE(Is_bearer_for(tm.get_bearer_token(), valid_token));
 }
 
 TEST(TokenManagerTest, ConstructorWithTokensFileFromEnvironment) {
   const ScopedEnvVar env_token("IQM_TOKEN", nullptr);
-  const ScopedTokensFile tokens_file("test_tokens_env.json",
-                                     std::string(K_FUTURE_TOKEN));
+  const auto valid_token = std::string(K_VALID_TOKEN);
+  const ScopedTokensFile tokens_file("test_tokens_env.json", valid_token);
   const ScopedEnvVar env_tokens_file("IQM_TOKENS_FILE",
                                      tokens_file.path().c_str());
 
   iqm::TokenManager tm(std::nullopt, std::nullopt);
-  EXPECT_TRUE(
-      Is_bearer_for(tm.get_bearer_token(), std::string(K_FUTURE_TOKEN)));
+  EXPECT_TRUE(Is_bearer_for(tm.get_bearer_token(), valid_token));
 }
 
 TEST(TokenManagerTest, ConstructorWithExplicitTokensFileOverridesEnvironment) {
   const ScopedEnvVar env_token("IQM_TOKEN", "different_token");
   const ScopedEnvVar env_tokens_file("IQM_TOKENS_FILE", "different_file");
-  const ScopedTokensFile tokens_file("test_tokens_override.json",
-                                     std::string(K_FUTURE_TOKEN));
+  const auto valid_token = std::string(K_VALID_TOKEN);
+  const ScopedTokensFile tokens_file("test_tokens_override.json", valid_token);
 
   iqm::TokenManager tm(std::nullopt, std::make_optional(tokens_file.path()));
-  EXPECT_TRUE(
-      Is_bearer_for(tm.get_bearer_token(), std::string(K_FUTURE_TOKEN)));
+  EXPECT_TRUE(Is_bearer_for(tm.get_bearer_token(), valid_token));
 }
 
 TEST(TokenManagerTest, ConstructorWithInvalidExplicitParameters) {
@@ -297,21 +293,11 @@ TEST(TokenManagerTest, TimeLeftSecondsInvalidJson) {
 }
 
 TEST(TokenManagerTokensFileTest, GetToken) {
-  // Create a temporary tokens file
-  const std::string filename = "test_tokens.json";
-  std::ofstream file(filename);
-  file
-      << R"({"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODg0MDY0MDAsIm5iZiI6MTYyMDY3NTIwMCwiaWF0IjoxNjIwNjc1MjAwfQ.signature"})";
-  file.close();
+  const auto valid_token = std::string(K_VALID_TOKEN);
+  const ScopedTokensFile tokens_file("test_tokens.json", valid_token);
 
-  iqm::TokenManager tm(std::nullopt, filename);
-  EXPECT_TRUE(Is_bearer_for(tm.get_bearer_token(),
-                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-                            "eyJleHAiOjE3ODg0MDY0MDAsIm5iZiI6MTYyMDY3NTIwMCwia"
-                            "WF0IjoxNjIwNjc1MjAwfQ.signature"));
-
-  // Clean up the temporary file
-  std::remove(filename.c_str());
+  iqm::TokenManager tm(std::nullopt, tokens_file.path());
+  EXPECT_TRUE(Is_bearer_for(tm.get_bearer_token(), valid_token));
 }
 
 TEST(TokenManagerTokensFileTest, GetTokenExpired) {


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Replace the expired JWT shared by the authentication tests with a fixture whose expiration is the maximum signed 64-bit timestamp. Reuse the scoped token-file fixture so all valid-token tests use the same value and clean up consistently.

This fixes the native test failures currently breaking CI on main.

## Validation

- uvx nox -s lint
- 22 focused TokenManagerTest and TokenManagerTokensFileTest cases passed in an isolated executable built from the normal CMake objects
- The full documented MinGW test executable currently cannot link because QDMI entry points are declared as imported symbols; this is being tracked separately

AI assistance: Codex diagnosed the expiring fixture, prepared the test-only change, and ran the checks above. A human reviewer remains responsible for accepting the change.