### PR TITLE
:arrow_up: Adopt MQT Core version 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 💥 Use native Qiskit primitives with MQT Core 3.10, preserving genuine shot
+  order and using estimator precision `1/64` (4,096 shots per measurement
+  circuit) by default ([#246]) ([**@marcelwa**])
 - 💥 Drop support for x86 macOS and stop publishing the respective wheels
   ([#220]) ([**@denialhaag**])
 - ⬆️ Raise the macOS deployment target to 13.3 ([#220])
@@ -40,9 +43,9 @@ releases may include breaking changes.
 
 - 🐛 Decode base64url JWT payloads, so an access token whose payload encodes to
   a `-` or `_` is no longer reported as expired ([#232]) ([**@marcelwa**])
-- ⬆️ Require Qiskit 2.0 on Python 3.11–3.13 and Qiskit 2.1 on Python 3.14 and
-  newer so the supported minimum environments install and run ([#218], [#220])
-  ([**@burgholzer**])
+- ⬆️ Require Qiskit 2.1 on all supported Python versions so the minimum
+  environments install and run ([#218], [#220], [#246]) ([**@burgholzer**],
+  [**@marcelwa**])
 
 ## [1.4.0] - 2026-08-25
 
@@ -245,6 +248,7 @@ Compatible with QDMI `v1.3.0`.
 
 <!-- PR links -->
 
+[#246]: https://github.com/iqm-finland/QDMI-on-IQM/pull/246
 [#232]: https://github.com/iqm-finland/QDMI-on-IQM/pull/232
 [#229]: https://github.com/iqm-finland/QDMI-on-IQM/pull/229
 [#214]: https://github.com/iqm-finland/QDMI-on-IQM/pull/214

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -93,6 +93,12 @@ The QSCI example depends on PySCF for classical chemistry calculations, and
 [PySCF is not supported on Windows](https://pyscf.org/user/install.html).
 :::
 
+The QSCI example uses native Qiskit sampler and estimator primitives. Its
+positive `--shots` value sets the sampler shot count and the estimator precision
+to `1 / sqrt(shots)`. Qiskit rounds the estimator shot count up from
+`1 / precision**2` for each measurement circuit and groups compatible
+observables, so this value is not a total VQE shot budget.
+
 ## MQT Bench Programs
 
 To understand how the backend behaves on standard programs, we move on to
@@ -100,8 +106,8 @@ To understand how the backend behaves on standard programs, we move on to
 collects representative quantum algorithms across several abstraction levels. In
 this repository, the benchmark scripts show how to generate those programs,
 transpile them for the selected target, execute them through
-{py:class}`~mqt.core.plugins.qiskit.sampler.QDMISampler`, and inspect the
-resulting bitstring distributions.
+{py:class}`~qiskit.primitives.BackendSamplerV2`, and inspect the resulting
+bitstring distributions.
 
 The `examples/mqt_bench.py` entrypoint currently covers the following
 algorithms:

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -94,6 +94,10 @@ To run a parameter estimation job:
 iqm-estimator ansatz.qpy observable.pkl --maxiter 10
 ```
 
+The estimator CLI and `offloader.estimate` use Qiskit's default precision of
+`1/64`, corresponding to 4,096 shots per measurement circuit. See the
+[primitive options](qiskit.md#sampler-and-estimator-primitives).
+
 ## Programmatic Offloading with the `offloader` Module
 
 For workflows running on a Slurm login node (such as Jupyter notebooks on a

--- a/docs/qiskit.md
+++ b/docs/qiskit.md
@@ -64,16 +64,6 @@ endpoint. Every backend opens a fresh device session with its own configuration.
 {py:class}`~qiskit.primitives.BackendEstimatorV2` primitives bound to the
 backend instance.
 
-MQT Core 3.10 uses native Qiskit primitives. The sampler and
-`backend.run(memory=True)` require genuine QDMI shot results and preserve their
-order. Counts-only results remain usable by the estimator.
-
-The estimator uses positive precision instead of `default_shots`. Its default
-precision is `1/64`, corresponding to 4,096 shots per measurement circuit,
-compared with the previous default of 1,024. Set
-`backend.estimator(default_precision=1/32)` for 1,024 shots. Observable
-grouping, parameter broadcasting, metadata, and standard errors follow Qiskit.
-
 ```{code-cell} ipython3
 sampler_job = backend.sampler().run([(transpiled_qc,)], shots=128)
 counts = sampler_job.result()[0].data["meas"].get_counts()

--- a/docs/qiskit.md
+++ b/docs/qiskit.md
@@ -60,9 +60,19 @@ endpoint. Every backend opens a fresh device session with its own configuration.
 {py:class}`~iqm.qdmi.qiskit.IQMBackend` provides small helpers (see
 {py:meth}`~iqm.qdmi.qiskit.IQMBackend.sampler` and
 {py:meth}`~iqm.qdmi.qiskit.IQMBackend.estimator`) for constructing
-{py:class}`~qiskit.primitives.BaseSamplerV2` and
-{py:class}`~qiskit.primitives.BaseEstimatorV2` primitives bound to the backend
-instance.
+{py:class}`~qiskit.primitives.BackendSamplerV2` and
+{py:class}`~qiskit.primitives.BackendEstimatorV2` primitives bound to the
+backend instance.
+
+MQT Core 3.10 uses native Qiskit primitives. The sampler and
+`backend.run(memory=True)` require genuine QDMI shot results and preserve their
+order. Counts-only results remain usable by the estimator.
+
+The estimator uses positive precision instead of `default_shots`. Its default
+precision is `1/64`, corresponding to 4,096 shots per measurement circuit,
+compared with the previous default of 1,024. Set
+`backend.estimator(default_precision=1/32)` for 1,024 shots. Observable
+grouping, parameter broadcasting, metadata, and standard errors follow Qiskit.
 
 ```{code-cell} ipython3
 sampler_job = backend.sampler().run([(transpiled_qc,)], shots=128)

--- a/examples/mqt_bench.py
+++ b/examples/mqt_bench.py
@@ -41,7 +41,6 @@ from dataclasses import dataclass
 import numpy as np
 from mqt.bench import BenchmarkLevel, get_benchmark
 from mqt.core.plugins.qiskit.backend import QDMIBackend
-from mqt.core.plugins.qiskit.sampler import QDMISampler
 from qiskit.quantum_info import hellinger_fidelity
 
 from iqm.qdmi.qiskit import IQMBackend
@@ -214,7 +213,7 @@ def main() -> None:
     log.info("Circuit ready: %d qubits, %d gates, depth %d", circuit.num_qubits, circuit.size(), circuit.depth())
 
     log.info("Submitting job to '%s' (%d shots)...", backend.name, shots)
-    sampler = QDMISampler(backend, default_shots=shots)
+    sampler = backend.sampler(default_shots=shots)
     job = sampler.run([(circuit,)])
     counts: dict[str, int] = job.result()[0].data[config.result_register].get_counts()
     total_shots = sum(counts.values())

--- a/examples/qsci_h2.py
+++ b/examples/qsci_h2.py
@@ -43,8 +43,6 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import scipy.linalg as sla
 from mqt.core.plugins.qiskit.backend import QDMIBackend
-from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-from mqt.core.plugins.qiskit.sampler import QDMISampler
 from pyscf import ao2mo, gto, scf
 from qiskit.compiler import transpile
 from qiskit_algorithms.minimum_eigensolvers.vqe import VQE
@@ -84,6 +82,8 @@ def main() -> None:
     parser.add_argument("--maxiter", type=int, default=30)
     parser.add_argument("--cutoff", type=int, default=10)
     args = parser.parse_args()
+    if args.shots <= 0:
+        parser.error("--shots must be positive")
     log.info(
         "Starting QSCI/H2 example (backend=%s, shots=%d, maxiter=%d, cutoff=%d)",
         args.backend,
@@ -141,7 +141,7 @@ def main() -> None:
     )
 
     log.info("Running VQE (optimizer=L-BFGS-B, maxiter=%d, shots=%d)...", args.maxiter, args.shots)
-    estimator = QDMIEstimator(backend, default_shots=args.shots)
+    estimator = backend.estimator(default_precision=1 / np.sqrt(args.shots))
     vqe = VQE(estimator, ansatz, L_BFGS_B(maxiter=args.maxiter))
     result = vqe.compute_minimum_eigenvalue(operator=observable)
     optimal_parameters = result.optimal_parameters
@@ -158,7 +158,7 @@ def main() -> None:
     ansatz.measure_active()
 
     log.info("Submitting sampling job to '%s' (%d shots)...", backend.name, args.shots)
-    sampler = QDMISampler(backend, default_shots=args.shots)
+    sampler = backend.sampler(default_shots=args.shots)
     job = sampler.run([(ansatz,)])
     counts = job.result()[0].data["meas"].get_counts()
     log.info("Job completed. Collected %d shots across %d distinct bitstrings.", sum(counts.values()), len(counts))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,8 @@ classifiers = [
 
 [project.optional-dependencies]
 qiskit = [
-  "mqt-core~=3.9.1",
-  "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
-  "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
+  "mqt-core~=3.10.0",
+  "qiskit[qasm3-import]>=2.1",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",
   "numpy>=2.3.2; python_version >= '3.14'",
@@ -79,9 +78,8 @@ IQM_JSON = "iqm.qdmi.serializers:qiskit_to_iqm_json"
 
 [dependency-groups]
 qiskit = [
-  "mqt-core~=3.9.1",
-  "qiskit[qasm3-import]>=2.0; python_version < '3.14'",
-  "qiskit[qasm3-import]>=2.1; python_version >= '3.14'",
+  "mqt-core~=3.10.0",
+  "qiskit[qasm3-import]>=2.1",
   "qiskit-algorithms>=0.4.0",
   "numpy>=2.1; python_version >= '3.13'",
   "numpy>=2.3.2; python_version >= '3.14'",

--- a/python/iqm/qdmi/_backends.py
+++ b/python/iqm/qdmi/_backends.py
@@ -26,8 +26,7 @@ from mqt.core.plugins.qiskit.backend import QDMIBackend
 from iqm.qdmi.qiskit import IQMBackend
 
 if TYPE_CHECKING:
-    from mqt.core.plugins.qiskit.estimator import QDMIEstimator
-    from mqt.core.plugins.qiskit.sampler import QDMISampler
+    from qiskit.primitives import BackendEstimatorV2, BackendSamplerV2
 
 _SIMULATOR_DEVICE_ID = "mqt.ddsim.default"
 
@@ -44,7 +43,7 @@ def build_sampler(
     tokens_file: str | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
-) -> QDMISampler:
+) -> BackendSamplerV2:
     """Build the Sampler primitive to use for a sampling job.
 
     Returns:
@@ -65,7 +64,7 @@ def build_estimator(
     tokens_file: str | None = None,
     qc_id: str | None = None,
     qc_alias: str | None = None,
-) -> QDMIEstimator:
+) -> BackendEstimatorV2:
     """Build the Estimator primitive to use for a VQE estimation job.
 
     Returns:

--- a/test/python/test_qiskit_backend.py
+++ b/test/python/test_qiskit_backend.py
@@ -19,16 +19,23 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
+import numpy as np
 import pytest
-from qiskit.circuit import QuantumCircuit
+from mqt.core.plugins.qiskit.backend import QDMIBackend
+from mqt.core.qdmi import Device, Job, ProgramFormat
+from mqt.core.qdmi.driver import open_device
+from qiskit.circuit import ClassicalRegister, Parameter, QuantumCircuit, QuantumRegister
 from qiskit.compiler import transpile
 from qiskit.quantum_info import SparsePauliOp
 
 from iqm.qdmi import qiskit as iqm_qiskit
+from iqm.qdmi._backends import build_estimator  # ruff:ignore[import-private-name]
 from iqm.qdmi.qiskit import IQMBackend
 
 ENVIRONMENT_TOKENS_FILE = Path("/opt/iqm/environment-tokens.json")
@@ -282,11 +289,85 @@ def test_iqm_backend_estimator(circuit: QuantumCircuit, backend: IQMBackend) -> 
     """The bound estimator should execute a simple observable on the live IQM backend."""
     observable = SparsePauliOp("Z" * backend.num_qubits)
     transpiled_circuit = transpile(circuit, backend=backend)
-    job = backend.estimator(default_shots=32).run([(transpiled_circuit, observable)])
+    job = backend.estimator(default_precision=1 / 8).run([(transpiled_circuit, observable)])
     result = job.result()[0]
     expectation_value = float(result.data["evs"][()])
     standard_deviation = float(result.data["stds"][()])
 
     assert -1.0 <= expectation_value <= 1.0
     assert standard_deviation >= 0.0
-    assert result.metadata["shots"] == 32
+    assert result.metadata["shots"] == 64
+
+
+@pytest.fixture
+def iqm_results(monkeypatch: pytest.MonkeyPatch) -> tuple[IQMBackend, Mock, Mock]:
+    """Return an IQM adapter with simulator topology and stubbed remote results."""
+    device = open_device("mqt.ddsim.default")
+    monkeypatch.setattr(iqm_qiskit, "register_device_if_absent", Mock())
+    monkeypatch.setattr(iqm_qiskit, "open_device", Mock(return_value=device))
+    monkeypatch.setattr(Device, "supported_program_formats", Mock(return_value=[ProgramFormat.IQM_JSON]))
+    job = Mock(spec=Job)
+    job.id = "offline-job"
+    job.check.return_value = Job.Status.DONE
+    submit = Mock(return_value=job)
+    monkeypatch.setattr(Device, "submit_job", submit)
+    return IQMBackend(), job, submit
+
+
+def test_iqm_primitives_preserve_ordered_shots(iqm_results: tuple[IQMBackend, Mock, Mock]) -> None:
+    """Native memory and sampler results preserve shot order across registers."""
+    backend, job, submit = iqm_results
+    circuit = QuantumCircuit(QuantumRegister(3), ClassicalRegister(1, "left"), ClassicalRegister(2, "right"))
+    circuit.measure(range(3), range(3))
+    job.get_shots.return_value = ["101", "000", "110", "101"]
+
+    result = backend.run(circuit, shots=4, memory=True).result()
+    assert result.get_memory() == ["10 1", "00 0", "11 0", "10 1"]
+    assert result.get_counts() == {"10 1": 2, "00 0": 1, "11 0": 1}
+
+    data = backend.sampler(default_shots=4).run([circuit]).result()[0].data
+    assert data["left"].get_bitstrings() == ["1", "0", "0", "1"]
+    assert data["right"].get_bitstrings() == ["10", "00", "11", "10"]
+    job.get_counts.assert_not_called()
+    assert submit.call_count == 2
+    assert submit.call_args.kwargs["program_format"] == ProgramFormat.IQM_JSON
+    program = json.loads(submit.call_args.kwargs["program"])
+    assert [op["args"]["key"] for op in program["instructions"]] == ["left_1_0_0", "right_2_1_0", "right_2_1_1"]
+
+
+def test_iqm_counts_only_support_estimator(iqm_results: tuple[IQMBackend, Mock, Mock]) -> None:
+    """Counts-only jobs support estimation but fail when a sampler collects shots."""
+    backend, job, submit = iqm_results
+    job.get_shots.side_effect = RuntimeError("SHOTS unavailable")
+    circuit = QuantumCircuit(1)
+    circuit.measure_all()
+    with pytest.raises(RuntimeError, match="SHOTS unavailable"):
+        backend.sampler(default_shots=4).run([circuit]).result()
+
+    job.get_shots.reset_mock()
+    job.get_counts.return_value = {"0": 4096}
+    result = backend.estimator().run([(QuantumCircuit(1), SparsePauliOp("Z"))]).result()[0]
+    assert result.data["evs"] == pytest.approx(1)
+    assert result.data["stds"] == pytest.approx(0)
+    assert result.metadata["shots"] == 4096
+    assert submit.call_args.kwargs["num_shots"] == 4096
+    job.get_shots.assert_not_called()
+
+
+def test_estimator_groups_observables_and_broadcasts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The shared estimator groups compatible terms across parameter bindings."""
+    estimator = build_estimator(simulator=True)
+    assert isinstance(estimator.backend, QDMIBackend)
+    submit = Mock(wraps=estimator.backend.device.submit_job)
+    monkeypatch.setattr(Device, "submit_job", submit)
+    theta = Parameter("theta")
+    circuit = QuantumCircuit(2)
+    circuit.ry(theta, 0)
+    observable = SparsePauliOp.from_list([("IZ", 1.0), ("ZI", 2.0)])  # spellchecker:disable-line
+
+    result = estimator.run([(circuit, observable, {theta: [[0], [np.pi]]})], precision=1 / 8).result()[0]
+
+    np.testing.assert_allclose(result.data["evs"], [3, 1])
+    np.testing.assert_allclose(result.data["stds"], [0, 0])
+    assert result.metadata["shots"] == 64
+    assert submit.call_count == 2  # One grouped measurement circuit per parameter binding.

--- a/test/python/test_qiskit_backend.py
+++ b/test/python/test_qiskit_backend.py
@@ -19,23 +19,16 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock
 
-import numpy as np
 import pytest
-from mqt.core.plugins.qiskit.backend import QDMIBackend
-from mqt.core.qdmi import Device, Job, ProgramFormat
-from mqt.core.qdmi.driver import open_device
-from qiskit.circuit import ClassicalRegister, Parameter, QuantumCircuit, QuantumRegister
+from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.quantum_info import SparsePauliOp
 
 from iqm.qdmi import qiskit as iqm_qiskit
-from iqm.qdmi._backends import build_estimator  # ruff:ignore[import-private-name]
 from iqm.qdmi.qiskit import IQMBackend
 
 ENVIRONMENT_TOKENS_FILE = Path("/opt/iqm/environment-tokens.json")
@@ -297,77 +290,3 @@ def test_iqm_backend_estimator(circuit: QuantumCircuit, backend: IQMBackend) -> 
     assert -1.0 <= expectation_value <= 1.0
     assert standard_deviation >= 0.0
     assert result.metadata["shots"] == 64
-
-
-@pytest.fixture
-def iqm_results(monkeypatch: pytest.MonkeyPatch) -> tuple[IQMBackend, Mock, Mock]:
-    """Return an IQM adapter with simulator topology and stubbed remote results."""
-    device = open_device("mqt.ddsim.default")
-    monkeypatch.setattr(iqm_qiskit, "register_device_if_absent", Mock())
-    monkeypatch.setattr(iqm_qiskit, "open_device", Mock(return_value=device))
-    monkeypatch.setattr(Device, "supported_program_formats", Mock(return_value=[ProgramFormat.IQM_JSON]))
-    job = Mock(spec=Job)
-    job.id = "offline-job"
-    job.check.return_value = Job.Status.DONE
-    submit = Mock(return_value=job)
-    monkeypatch.setattr(Device, "submit_job", submit)
-    return IQMBackend(), job, submit
-
-
-def test_iqm_primitives_preserve_ordered_shots(iqm_results: tuple[IQMBackend, Mock, Mock]) -> None:
-    """Native memory and sampler results preserve shot order across registers."""
-    backend, job, submit = iqm_results
-    circuit = QuantumCircuit(QuantumRegister(3), ClassicalRegister(1, "left"), ClassicalRegister(2, "right"))
-    circuit.measure(range(3), range(3))
-    job.get_shots.return_value = ["101", "000", "110", "101"]
-
-    result = backend.run(circuit, shots=4, memory=True).result()
-    assert result.get_memory() == ["10 1", "00 0", "11 0", "10 1"]
-    assert result.get_counts() == {"10 1": 2, "00 0": 1, "11 0": 1}
-
-    data = backend.sampler(default_shots=4).run([circuit]).result()[0].data
-    assert data["left"].get_bitstrings() == ["1", "0", "0", "1"]
-    assert data["right"].get_bitstrings() == ["10", "00", "11", "10"]
-    job.get_counts.assert_not_called()
-    assert submit.call_count == 2
-    assert submit.call_args.kwargs["program_format"] == ProgramFormat.IQM_JSON
-    program = json.loads(submit.call_args.kwargs["program"])
-    assert [op["args"]["key"] for op in program["instructions"]] == ["left_1_0_0", "right_2_1_0", "right_2_1_1"]
-
-
-def test_iqm_counts_only_support_estimator(iqm_results: tuple[IQMBackend, Mock, Mock]) -> None:
-    """Counts-only jobs support estimation but fail when a sampler collects shots."""
-    backend, job, submit = iqm_results
-    job.get_shots.side_effect = RuntimeError("SHOTS unavailable")
-    circuit = QuantumCircuit(1)
-    circuit.measure_all()
-    with pytest.raises(RuntimeError, match="SHOTS unavailable"):
-        backend.sampler(default_shots=4).run([circuit]).result()
-
-    job.get_shots.reset_mock()
-    job.get_counts.return_value = {"0": 4096}
-    result = backend.estimator().run([(QuantumCircuit(1), SparsePauliOp("Z"))]).result()[0]
-    assert result.data["evs"] == pytest.approx(1)
-    assert result.data["stds"] == pytest.approx(0)
-    assert result.metadata["shots"] == 4096
-    assert submit.call_args.kwargs["num_shots"] == 4096
-    job.get_shots.assert_not_called()
-
-
-def test_estimator_groups_observables_and_broadcasts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The shared estimator groups compatible terms across parameter bindings."""
-    estimator = build_estimator(simulator=True)
-    assert isinstance(estimator.backend, QDMIBackend)
-    submit = Mock(wraps=estimator.backend.device.submit_job)
-    monkeypatch.setattr(Device, "submit_job", submit)
-    theta = Parameter("theta")
-    circuit = QuantumCircuit(2)
-    circuit.ry(theta, 0)
-    observable = SparsePauliOp.from_list([("IZ", 1.0), ("ZI", 2.0)])  # spellchecker:disable-line
-
-    result = estimator.run([(circuit, observable, {theta: [[0], [np.pi]]})], precision=1 / 8).result()[0]
-
-    np.testing.assert_allclose(result.data["evs"], [3, 1])
-    np.testing.assert_allclose(result.data["stds"], [0, 0])
-    assert result.metadata["shots"] == 64
-    assert submit.call_count == 2  # One grouped measurement circuit per parameter binding.

--- a/uv.lock
+++ b/uv.lock
@@ -874,18 +874,17 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.9.1" },
+    { name = "mqt-core", marker = "extra == 'qiskit'", specifier = "~=3.10.0" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'qiskit'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.3.2" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14' and extra == 'qiskit'", specifier = ">=2.1" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14' and extra == 'qiskit'", specifier = ">=2.0" },
+    { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=2.1" },
     { name = "qiskit-algorithms", marker = "extra == 'qiskit'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["qiskit"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.10.0" },
     { name = "nox", specifier = ">=2026.4.10" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
@@ -894,8 +893,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
+    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 docs = [
@@ -909,15 +907,14 @@ docs = [
     { name = "sphinx-llm", specifier = ">=0.4.1" },
 ]
 qiskit = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.10.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
+    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 test = [
-    { name = "mqt-core", specifier = "~=3.9.1" },
+    { name = "mqt-core", specifier = "~=3.10.0" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pytest", specifier = ">=9.0.1" },
@@ -925,8 +922,7 @@ test = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version < '3.14'", specifier = ">=2.0" },
-    { name = "qiskit", extras = ["qasm3-import"], marker = "python_full_version >= '3.14'", specifier = ">=2.1" },
+    { name = "qiskit", extras = ["qasm3-import"], specifier = ">=2.1" },
     { name = "qiskit-algorithms", specifier = ">=0.4.0" },
 ]
 
@@ -1151,34 +1147,23 @@ wheels = [
 
 [[package]]
 name = "mqt-core"
-version = "3.9.2"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/90/aea2987b3f9e6495e7e4b7cd146e85d15ad467910382b09bfa9dd3e74c03/mqt_core-3.9.2.tar.gz", hash = "sha256:9165fcd73c173fe3742cdf192549f43e2afedc5e3881d7002775004b3cd92f76", size = 811847, upload-time = "2026-08-26T19:56:58.438Z" }
+dependencies = [
+    { name = "nanobind-backend" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/8f/01a1a2b2a3add3be844710981df49d1f37aaa749cb09d925f27e1717342a/mqt_core-3.10.0.tar.gz", hash = "sha256:4d9fea47eae908f3bb1b8bd40eaddef1c665b5ace05d47dca5b4e306ff568404", size = 631746, upload-time = "2026-09-05T16:30:53.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/06/6a307d854f34ea9c1c7b204d4693ac14db25a3a71ded59f966f9fe9c5638/mqt_core-3.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2c2d8977346a21fbe667c770bf1fbdadb54228b58e64d6f5fd21005e2201dd81", size = 5990654, upload-time = "2026-08-26T19:56:09.679Z" },
-    { url = "https://files.pythonhosted.org/packages/68/c9/2e6e9da103e1c40cb3fc178932a1cc9c78d016bb88d2ac1b0f0445c5bc64/mqt_core-3.9.2-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:76919993da5efc6b589e0778b5441e3e651b4ddd3345bfb0c8c95c963dcd0744", size = 6441565, upload-time = "2026-08-26T19:56:11.352Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b9/d410f51aa5fa4b101bf18194ca9be04f2a497c69d0fae8fa07e2594f65eb/mqt_core-3.9.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99d5a3f78de946d2cb6de4c72872901a7a75e7fd8b85e1697ef7790eb5ede88", size = 8674960, upload-time = "2026-08-26T19:56:13.122Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/ef/55d73c6aa6bf8a357c3c4a9dac283ad4597523033b769461a367fe111fdf/mqt_core-3.9.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a225fc2359fb2d5bebf9e6ef4a2d5fe613310a4529b92c64321b6ce1a8f9f98", size = 9203735, upload-time = "2026-08-26T19:56:15.16Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2b/cb794f7a44c14169b936893bfc75482f17de34ce2611b0d9e4477057d6f5/mqt_core-3.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:38c9ec6708dadc4c9c96b907b8056fe55bd4c7ea9a56d98bd8b0ba429e9967c2", size = 9176855, upload-time = "2026-08-26T19:56:17.451Z" },
-    { url = "https://files.pythonhosted.org/packages/00/4d/04ca0c5319342d3e5294f8e751485b18d09f18a0e98297acd5f1a697c4c4/mqt_core-3.9.2-cp311-cp311-win_arm64.whl", hash = "sha256:e02a0342339c11b5b0b642be49666c861f457e488f06e3da61ac455512b8441e", size = 9026259, upload-time = "2026-08-26T19:56:19.6Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/61/d23e4adc77d43a5f3af946cb9585caa4ae25d439c743e5328ad69c26d13d/mqt_core-3.9.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:f217d84252bdc4cf9d9216e06432ec1493c838f389e52f248802645a9ffcebfb", size = 5983121, upload-time = "2026-08-26T19:56:21.687Z" },
-    { url = "https://files.pythonhosted.org/packages/52/ed/274e39ea905211b1808913045d53a74983098ef61eb1e96db6454b6cc412/mqt_core-3.9.2-cp312-abi3-macosx_11_0_x86_64.whl", hash = "sha256:6786e02226eb0269b63a7755b30b82843093645b7b4edeea3d058fa863f320d7", size = 6435172, upload-time = "2026-08-26T19:56:23.363Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/a7/184ae073d6a44ded67aa3c054603884ea4c8ffd3a6ed39729a6e7f1c7980/mqt_core-3.9.2-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1483708a4cfb98b62998364940bcdd952b24de6786456747dcc72f4db689d0c4", size = 8657586, upload-time = "2026-08-26T19:56:25.291Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/e1/2be4a668194e7bc41285a202742653ac4825878a5bf91ea7648d20283bf5/mqt_core-3.9.2-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dba6238b1409e73a17ad681a0e4018abc3f4b8ad1f7539c70fb00fa33b52700a", size = 9184324, upload-time = "2026-08-26T19:56:27.654Z" },
-    { url = "https://files.pythonhosted.org/packages/46/39/7a214dd6b0c17b92579cd76d78e609fbd624c6bd15d625c716c3614e7f1d/mqt_core-3.9.2-cp312-abi3-win_amd64.whl", hash = "sha256:0107df33fe2a3d7af9338703cc5a11b1821c0b385c390193431ad584ae3d6ef0", size = 9167916, upload-time = "2026-08-26T19:56:29.703Z" },
-    { url = "https://files.pythonhosted.org/packages/84/97/ed207d7a0800b46d13e4353044c365af986c06f05739a132ae0a4af52236/mqt_core-3.9.2-cp312-abi3-win_arm64.whl", hash = "sha256:0c1ad9fdf9cfe530934a05df023febc5bc24ce74f88c90be57f67059ae22546f", size = 9015897, upload-time = "2026-08-26T19:56:31.758Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ba/23af918b4cd795fd6648eda85e65930017d06510c5bc70dfc6cfeeefb1aa/mqt_core-3.9.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:50f9198ed00ce091e37ffccd62e0a97b85e85b37720499b1f2765682e6888a8c", size = 5997464, upload-time = "2026-08-26T19:56:34.045Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/75/cf13ff37e80c02079e9f89fb519a27f648602165510f07d49ba5d587db84/mqt_core-3.9.2-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:89bcbd1f867b2ea81f345bf809015aa92cc99c75f5cb8d8a610e1897ccdc385d", size = 6450364, upload-time = "2026-08-26T19:56:35.711Z" },
-    { url = "https://files.pythonhosted.org/packages/98/3f/00c45549976c0e9474ab51ed7d5ea71e1210ea3a9d6fdf9894876b45ce08/mqt_core-3.9.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5548cfffb3115881804e26ddb93270a087dbbbac8905b18dc5954051553e17d2", size = 8677149, upload-time = "2026-08-26T19:56:37.619Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/67d8ad5aabf3e847822d6c3d7a112d1da0cfef62c13037eb855fd4612b4f/mqt_core-3.9.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca1e9855c7b0f3338958c465b42414ae95c7f1feb1d269666eabf0cf880a7aaa", size = 9203848, upload-time = "2026-08-26T19:56:39.741Z" },
-    { url = "https://files.pythonhosted.org/packages/17/dd/f444af11e3845de4e1db3bbfe4c1ecf6136da40f572176873cc4c9a00db9/mqt_core-3.9.2-cp314-cp314t-win_amd64.whl", hash = "sha256:eadf31683555f910ce2f304cdd24a6ac7fe953bf70bce3a94ec8794f2b3360bf", size = 9255216, upload-time = "2026-08-26T19:56:41.987Z" },
-    { url = "https://files.pythonhosted.org/packages/71/07/3619cd5c14eb635810c95e95fa1edb6f96a423922d23397e4c1fdc2e7db2/mqt_core-3.9.2-cp314-cp314t-win_arm64.whl", hash = "sha256:93d986fe283b22c5396b9e91a45499dfb02a814ac0565dbeac3f892e9aefb51f", size = 9100846, upload-time = "2026-08-26T19:56:44.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/19/f455b307169c0bcd6eaf48b75320421b362d2a086f8550a1a450ad747a36/mqt_core-3.9.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:9f532618b865dc231c0df8fc7e479052507ac009cadc25c8d95af0f9816d03c8", size = 5997362, upload-time = "2026-08-26T19:56:46.202Z" },
-    { url = "https://files.pythonhosted.org/packages/af/24/05ffbbbd8fbb8233bdc95f8465dfc4c59ca106245ff5d18906d4f4f6555c/mqt_core-3.9.2-cp315-cp315t-macosx_11_0_x86_64.whl", hash = "sha256:4865ae0efb2fc068230dc3e7944254e03052f3ea6a4c086456683c65e608d575", size = 6450326, upload-time = "2026-08-26T19:56:48.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f9/ff5bb3d1e7a0d024f854b464bbf24ce4798c36b894b9ae05dae11ab0abee/mqt_core-3.9.2-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:960d360ddfc7f2e53ca5e5e670ae09a8b719d39696810ea6db8b9195aae0e76a", size = 8677111, upload-time = "2026-08-26T19:56:50.356Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/07/4130814a0162916702859c9b978a8229fe6e8b946d4c1af8577a83c43f69/mqt_core-3.9.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85a28feb1ce9868718a55c9da9a2f925db5f9a04a341dd2845a5086c29843765", size = 9203849, upload-time = "2026-08-26T19:56:52.391Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/20/62c4df70519ac7fb323f5c5ffd820eaa7239133fcfc63a9187bde4f7a097/mqt_core-3.9.2-cp315-cp315t-win_amd64.whl", hash = "sha256:2119fd2095e150fff0604aa97dd1d7d22c694b6fd8554a5f921f0a5f4e0e7f72", size = 9255025, upload-time = "2026-08-26T19:56:54.51Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b5/3c243c763ffca881e857535025d7db49d2ed11797affe57a91aeac92baeb/mqt_core-3.9.2-cp315-cp315t-win_arm64.whl", hash = "sha256:f16ac2eba19d9bb3d3d35a79aa783f5c09c06f82dce0b93ca2ec881af45d0822", size = 9100845, upload-time = "2026-08-26T19:56:56.577Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c6/78bc3f78f8cd9e08287239ea1625ac40975aff8d2f8ec3f0a9c3c65ca04a/mqt_core-3.10.0-cp311-abi3-macosx_13_0_arm64.whl", hash = "sha256:c82aef9803568278334f1fe18862ce69d5b35ce25ff83a24b7708b5e976d122e", size = 3063277, upload-time = "2026-09-05T16:30:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/d64613db07b5968a09adb8068bb20f5981c2c6d732405d47636c56e75d8f/mqt_core-3.10.0-cp311-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf1e128426ec3fb842a6c76997342774f388ee0d199acca4d93f11431843f7e3", size = 4558515, upload-time = "2026-09-05T16:30:33.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/c2333ec9d8cc6f68cd54912f17f242ea879584a3af30a979a160103e3c3b/mqt_core-3.10.0-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2bdc8e86391538ff9cdd09247558b8ae065bd5e277c32bbdcbd9135987b65277", size = 4911780, upload-time = "2026-09-05T16:30:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/10/3413b2d409f46f65f14014cb8b3726cabf2f03f9747475853aa33d53d7ba/mqt_core-3.10.0-cp311-abi3-win_amd64.whl", hash = "sha256:6cea2638ca58f87a0619a57a8fde4ac2c49c886cb43c023e880a29489d0dd8f4", size = 5631156, upload-time = "2026-09-05T16:30:37.484Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d7/edbde848f150051c36f65f5389943de9006d02a82c41ff0b5889fad048e4/mqt_core-3.10.0-cp311-abi3-win_arm64.whl", hash = "sha256:61fa27d9406f4acf84d71e2378a90fdde8c8f18750559e72cd833895a61b84dc", size = 5595406, upload-time = "2026-09-05T16:30:39.419Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2f/a4740fa16ed3d986b3b3496b8de0be49eea5d0f0171b952df1a301666da9/mqt_core-3.10.0-cp315-abi3t-macosx_13_0_arm64.whl", hash = "sha256:39dd3dbe5c1d879c0ca9fb122522e2d696cd120a2b545fa39b584158fbc4f930", size = 3064522, upload-time = "2026-09-05T16:30:41.82Z" },
+    { url = "https://files.pythonhosted.org/packages/74/40/bdd6efdcd6ff4cda35910be7e55311d3cecb313d7542a72624615a1301ae/mqt_core-3.10.0-cp315-abi3t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf19320873ab1989bf408eb8bb2e6b5573fc635eb080eabaa80edf083a63f195", size = 4559107, upload-time = "2026-09-05T16:30:43.711Z" },
+    { url = "https://files.pythonhosted.org/packages/00/57/15db7c4dbce83a84be121333f67b61b4ee48604464105b16ed6ed75a0a4e/mqt_core-3.10.0-cp315-abi3t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5a102ff32ad4a9c6d91c036fb8f49f84e94503910b4e8c08a83ecc45f47614a", size = 4912429, upload-time = "2026-09-05T16:30:46.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2f/d2fd1731f40c964cb3092b7bb783ba494e06b48912220882d1c7c026c546/mqt_core-3.10.0-cp315-abi3t-win_amd64.whl", hash = "sha256:2c005cce4f9874950238fc18f4421dbf399e9228694858007713c4305bea6695", size = 5683108, upload-time = "2026-09-05T16:30:48.45Z" },
+    { url = "https://files.pythonhosted.org/packages/03/97/0e6fc3fdbe7efde93cdc0f27666b230b7008c22aa3ffb6bf6641e33643cc/mqt_core-3.10.0-cp315-abi3t-win_arm64.whl", hash = "sha256:78be13369703959fdf508f7f933771ac3b2d9d4ee3150ca117c9ee0a3f536d76", size = 5645165, upload-time = "2026-09-05T16:30:50.751Z" },
 ]
 
 [[package]]
@@ -1219,6 +1204,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
+]
+
+[[package]]
+name = "nanobind-backend"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/49/a4c01de9c358b5749560a5415b899a8b57399381e5c8ae64962381302a59/nanobind_backend-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:b20b3e4bbb672987f9d65e52f1829299589c1ccf0502360879846a922e9cb1ed", size = 80577, upload-time = "2026-08-22T04:22:45.852Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/65/c3ff5ef09109a163a3cbe8a69250ae7c4b0b4d8df79b1cb447d03747529f/nanobind_backend-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:89c582f83d491ba01aa1a5ad39ed6c59bdead67ec3b8c88b288b7e4b6bac18df", size = 76586, upload-time = "2026-08-22T04:22:46.756Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/14/40f0a465df491562debf55044bcfc728dca7cb8e3ef76f532aa8f75e775b/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdf41e97cfb9f149c89b323b7850bd9dc6316d1d79adf99081511b9a1d0858b1", size = 98356, upload-time = "2026-08-22T04:22:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9a/0db4d9982ac708b6c532ca6ea2a523d5c85a25f7fc288558c4d6fad725b0/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33bdec0da2f78669d5c95bd546ff2bb7744dafa43a16bb72b2eecdf83d8c3b3a", size = 106460, upload-time = "2026-08-22T04:22:48.716Z" },
+    { url = "https://files.pythonhosted.org/packages/49/77/45d11f991aa78e8dfaac490c6330e38912d414b60a6b624024e8eaa4cadb/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d77ecad0d4b8526865f6bec7cd77603c686ef65b57cc7ec81795b3a468dba0f1", size = 100025, upload-time = "2026-08-22T04:22:49.763Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/22/8a2576123da22743a1ca6b683e2e1a046990dd75ab3f70c21c0c8690d936/nanobind_backend-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:691be892dcd6b4b1317d628b49bf3e688470f4f927ac316dca233ee19fab7ecd", size = 264783, upload-time = "2026-08-22T04:22:50.856Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/fbaa64393f5ed253de5879e8d30477d05f53a3c2b106b9db4f33db7da310/nanobind_backend-1.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:dc199056cbd534c5317899539a36245aa14bce6b8afd48c217e578b2463e0594", size = 435095, upload-time = "2026-08-22T04:22:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/57/f02cc977a0ba1ddf2a41ebad61bcf2fbfd905aef7753082d9f39389a13e1/nanobind_backend-1.0.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:9fd9145b1aa8e9b78029308a73e1ade94369d7250c826783655210d1800f1493", size = 80504, upload-time = "2026-08-22T04:22:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3a/40e9ef3133573dddf32f7dcaf1bc7d4f459ecb632b2274c7a619fbfa40ea/nanobind_backend-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dca8999e4e87a4e39e162c55b70f39fe1882913c4d7de1adab81cf82bb8cb9ad", size = 75568, upload-time = "2026-08-22T04:22:54.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3b/806d3346ae8175746853b204efd59a4ad8bbddf91d48d03f4eac48d15245/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a42503f65cd595f97a31f24d21c6ddbd017ffcb808626d0134e475e0db25f3d", size = 97730, upload-time = "2026-08-22T04:22:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2c/7fb13ecb1e8c0c268e26c6bc44be4a7f51996b2a3c006749ce6fc4fd7da2/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa9864050cc5fd1ff59d1f9b79740efa278515eed27af848efae07125c029b8", size = 106063, upload-time = "2026-08-22T04:22:55.973Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bf/2f6dbcedcca065c20b73346f037d69d78fdb545c9abbf7ad8b27da7890c5/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:00dadccfa92d0f9eac0b1877fdc3fd99d2ebb1a651fbe44daff365a173bd2faa", size = 99415, upload-time = "2026-08-22T04:22:57.03Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/da/f6af805e0737652d4b6aa2e51e3ec1485d906e77ee9389b126adbb9f9644/nanobind_backend-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b1502e3f160358feff92f60a634e198c76754f50a60fdacd9a8b5dccbe5d9d0", size = 264454, upload-time = "2026-08-22T04:22:58.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/851847d5246c0c47dbebe473ecfbb0ed44a41fae9ef7e2ec73cd7c8975a3/nanobind_backend-1.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:a1f6e6320aee495e5cad933d671e9d60ee42f4bf460930ef7afed191243aa733", size = 434441, upload-time = "2026-08-22T04:22:59.442Z" },
+    { url = "https://files.pythonhosted.org/packages/06/eb/1c4f3e1fcc41093e321b1c4eb7ca79f628a36057496398bb9fba4d97e417/nanobind_backend-1.0.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:a6dd7a66fb7416d62be577d41d64478a187d9f36d089759555698bb08addc2c3", size = 80547, upload-time = "2026-08-22T04:23:00.75Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c2/d59e5b6af43e45088c18895035e053c4585bce7d1bde9679368ef5b960e0/nanobind_backend-1.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:28a4c397d6d36dfb712acbab817c02ad2f8658a85fb1dbbae7385689d28d20e9", size = 75630, upload-time = "2026-08-22T04:23:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a1/97ffb303def8e5a4e48694b01d58477899392468295e8af5c60fdae5f035/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ddf018fc62a2bd51e9d7cc6477af7ae13ccc0db69b775d67d837ba7e0bc41b4", size = 97824, upload-time = "2026-08-22T04:23:02.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/0a2143308fd413ae10da3fb8732e9d2fc87de4605a1126d304ffe9f63414/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c78ed4b88ef6c59a835eebe7f5e91ab6869f17f915a61c7d4eec24a1e2b85", size = 106253, upload-time = "2026-08-22T04:23:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/7bb71f0a2566cb398d6877e3540307c3d0e684797001eb1128c2c3732a52/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:36a116471c3ca0b6cd3af1e1fa2e38c52086a2d2daf00b86f90a99da5efdde53", size = 99504, upload-time = "2026-08-22T04:23:04.644Z" },
+    { url = "https://files.pythonhosted.org/packages/90/49/8038eedfd35433968e638081ca4eb6881869e517f766beff0f095387dc9a/nanobind_backend-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:915c6ff4ce92584cdde18a24cc5d730f04a70c2f26bc0bc4db903ca54043eb86", size = 264501, upload-time = "2026-08-22T04:23:05.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/6c515cac31f723d2ce2c3155de4343a3ccf612025171cde25d48290c3680/nanobind_backend-1.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:6b7c31403e6f39fd704359ce4a0687d894a9ffa67813da6a54c6d0eb6fde93aa", size = 434433, upload-time = "2026-08-22T04:23:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/33/82/474e530e562a2c98db0dbd35cc2bc08500895be7cab6b13c5c990c09a650/nanobind_backend-1.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:04a35c7395daeb9a33f6801ca3d1e11e0384702ae22b8e3e251ef9f6a4a54c10", size = 80613, upload-time = "2026-08-22T04:23:07.851Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/36/7f79710b96ba643c91db149f7ba1b454124cf2cf97e379ef6c3529d97dd0/nanobind_backend-1.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:574d104bf6322711e5db55ed49409289df9582e8c1fd2a2f2d643d2136428e13", size = 76216, upload-time = "2026-08-22T04:23:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/08/08/fecefa8c4e5774222b2ed1b715822bca5c9bfb5623fef9be7cc9133df18c/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:926ba1e7e12bbf3f701f7a200e8801c5f9bd05ba2244962692fcafbd32b8a0d2", size = 98152, upload-time = "2026-08-22T04:23:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/65/8073c078a91e2fed8c54154f6a0b1d39e362c0ab5ffa7cb93c73f87c9954/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a42a2d594f22e689f15cbdbdf4bf1468ef7a8287da41842515c1cc836a1f2dec", size = 106486, upload-time = "2026-08-22T04:23:10.771Z" },
+    { url = "https://files.pythonhosted.org/packages/37/fe/69f69fbcd6d4e6cee3e27e65a2b10e354da8adfd0d88a87c4c33a845864f/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:ce93f26da63eaa24729d214fa6669525293d75e56f394f2980839cd65a75d2e5", size = 99382, upload-time = "2026-08-22T04:23:11.881Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3e/e33c10a7b0a728e83d492673612146ed7cd47c5d28c242969b4296cb6265/nanobind_backend-1.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0eabf671c91fdcd6a61d2177aa434731680442aa2317de54acfabeac4a4cc06", size = 273371, upload-time = "2026-08-22T04:23:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f2/7a44d3b12d4a876c123445fe6f4971eff1260c6f7660ee00e261cdbe2770/nanobind_backend-1.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:1e5f8217887d1d83ccbe1e61c37d1502ab951fef466a06df2abb1161e246ef79", size = 450418, upload-time = "2026-08-22T04:23:13.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/3104f9a204271cd57192bdf50577980c030ad3e53dd6ae6fe1aef9bbb5d8/nanobind_backend-1.0.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:4816cf6f998b0c2435aa643df7a5c59492202778c96e575e55da802e51c75461", size = 80862, upload-time = "2026-08-22T04:23:15.118Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/441ddd77a34b013350289c2fc99279d76403d45ab6cfdd6ea60be3e09a75/nanobind_backend-1.0.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7a7c76fc958eb7bf4b5454d9c036f1e92f8b406343c7b7b7f4e53302718ffee6", size = 76556, upload-time = "2026-08-22T04:23:16.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/29/101f4ebf5d0455ddab57785d8a341c1bd25d248e0c444ef9cb6ce85df9bb/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9a15c8155c465066fdf43a2589223cd41f4a688f52046f59edcded0790a8ad3", size = 98453, upload-time = "2026-08-22T04:23:17.215Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e1/5630f4e2297fb03749551592e9850ba45d498952a135d3065b49bc68e603/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9574cc624b9fff2e8f5946211422476977e43f6b796b83e143b289ecb70df4cf", size = 106886, upload-time = "2026-08-22T04:23:18.314Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/698c970f8df703be42720b96678ce0de08536938c95b3ab551e64a33f9ca/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:fac95e67ba91c639c52298388d22595c1d912a09a671d4793c8d16711a0dd1be", size = 99637, upload-time = "2026-08-22T04:23:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/29/6dd73fdcd3deed710d0dc3b2a4a86ad491450dbc2cd58018a9091a4164f1/nanobind_backend-1.0.0-cp315-cp315-win_amd64.whl", hash = "sha256:4ae0214ad6708b8001d82f1dd6c302aaba9627d81aa0573efc896a3b90f95bce", size = 273532, upload-time = "2026-08-22T04:23:20.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/14/cd5789bb09cb3a82b9e85b5164f2b4d7cff2ca6b861d4f89a7df9ae8d207/nanobind_backend-1.0.0-cp315-cp315-win_arm64.whl", hash = "sha256:a7a97a1326fa2d70e013b7af769305796047a01dc4567f5f90d769c6a2e2344d", size = 450650, upload-time = "2026-08-22T04:23:21.317Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/60/7754c00b60994a790574ec6190aeafeb8878e7c72c2c1877b84ebc911451/nanobind_backend-1.0.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:d8581ccc5f000a76b4304f9c8c4ee9e60499a9d9502e6e0e885c1606d6b29f60", size = 84440, upload-time = "2026-08-22T04:23:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e8/526799c68933550776b2002a0240ff770474d11a527962541b212f9d23fc/nanobind_backend-1.0.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:17a9ddc6cc096d713151fbbaabe41d960d1d596c0e046abcd2b17c6d6565c443", size = 80036, upload-time = "2026-08-22T04:23:23.459Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/29/a953f8be0c7b69509793d179f8f709b2c5d301bf65089bb3d87afa859f25/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a83f1c86aa2c7da33ce4a8df4304d34d6364335b2c455a490983059471e21c4d", size = 100522, upload-time = "2026-08-22T04:23:24.394Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/cce583c8177b061a3ee82c23da857f64975c1f28bdd614ecf7beda52f38a/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ea3fe04341040b09444cc946f5cd39145290b2de3b90ca9868b1b59cc75c23e", size = 108352, upload-time = "2026-08-22T04:23:25.411Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/7e56cf0b6faae40d23ec7b5c4d90ad74480038bc99dd9f8b05c58dc70726/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:983aaeaf65e61ddff125a3eea463675d322d9981510f6f6e462e6bcfc915dca6", size = 103571, upload-time = "2026-08-22T04:23:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/cf/941d624be0dd41f4bb139fe74d489d83845909dadc9f19fe7d4da5d5c3d1/nanobind_backend-1.0.0-cp315-cp315t-win_amd64.whl", hash = "sha256:2a42cd509c1889cbccdcf8a23dc3733c4b7e2388973ac4292db094576e3e27d0", size = 279141, upload-time = "2026-08-22T04:23:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/badc51c6b13ccb0f7a6ef88e8be014193cfe727f0849eaafa28489a848a2/nanobind_backend-1.0.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8975422479b145ce46d4d79b4fc03dbfab40254470468a99ea417090bb1ce460", size = 453221, upload-time = "2026-08-22T04:23:28.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 *AI text below* 🤖

Supersedes #245, which bumps MQT Core but leaves imports and estimator options that 3.10 removed. This migrates the examples and shared factories to native Qiskit primitives, with offline tests for ordered shots, counts-only estimation, and grouped observables. The default estimator now uses precision 1/64 (4,096 shots per measurement circuit); the QSCI example retains its explicit shot option.
